### PR TITLE
fix(ci): upload only AAB to Google Play

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: net.thewaterbug.waterbug
-          releaseFiles: builds/release/Waterbug.*
+          releaseFiles: builds/release/Waterbug.aab
           track: internal
           status: completed
 


### PR DESCRIPTION
## Summary

- The release workflow glob `Waterbug.*` matched both AAB and APK, causing the Play Store upload to fail after the AAB was accepted
- Google Play requires AAB format — change to `Waterbug.aab` only

## Test plan

- [x] First Android release run built successfully and uploaded the AAB before failing on the duplicate APK
- [ ] Re-run release workflow after merge to verify clean upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)