### PR TITLE
fix(android): add x86_64 ABI for Play Store 64-bit compliance

### DIFF
--- a/walta-app/tiapp.xml.template
+++ b/walta-app/tiapp.xml.template
@@ -62,7 +62,7 @@
   </ios>
   <android
     xmlns:android="http://schemas.android.com/apk/res/android">
-    <abi>arm64-v8a,armeabi-v7a,x86</abi>
+    <abi>arm64-v8a,armeabi-v7a,x86,x86_64</abi>
     <manifest android:versionCode="2000040014" android:versionName="2.0.4.14">
     <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="34"/>
     <application android:debuggable="false" android:icon="@drawable/appicon" android:label="Waterbug" android:name="WaterbugApplication" android:theme="@style/Theme.WaterbugApp" android:resizeableActivity="true" android:screenOrientation="sensorLandscape">


### PR DESCRIPTION
## Summary

- Google Play rejects releases where bundles serve 64-bit devices but only have 32-bit native code for a given ABI
- The `x86` ABI was included (for emulator CI) without its 64-bit counterpart `x86_64`
- Adds `x86_64` to the ABI list in tiapp.xml.template

## Test plan

- [ ] CI passes (Android emulator tests still work)
- [ ] Release workflow uploads to Play Store without 64-bit compliance error

🤖 Generated with [Claude Code](https://claude.com/claude-code)