### PR TITLE
fix(android): remove x86 ABI from release, inject for CI emulators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,9 @@ jobs:
       - name: Run install.sh
         run: sh install.sh
 
+      - name: Add x86 ABI for emulator builds
+        run: sed -i 's|<abi>arm64-v8a,armeabi-v7a</abi>|<abi>arm64-v8a,armeabi-v7a,x86</abi>|' walta-app/tiapp.xml
+
       - name: Read Titanium SDK version
         id: ti-version
         run: |
@@ -509,6 +512,9 @@ jobs:
 
       - name: Run install.sh
         run: sh install.sh
+
+      - name: Add x86 ABI for emulator builds
+        run: sed -i 's|<abi>arm64-v8a,armeabi-v7a</abi>|<abi>arm64-v8a,armeabi-v7a,x86</abi>|' walta-app/tiapp.xml
 
       - name: Read Titanium SDK version
         id: ti-version

--- a/walta-app/tiapp.xml.template
+++ b/walta-app/tiapp.xml.template
@@ -62,7 +62,7 @@
   </ios>
   <android
     xmlns:android="http://schemas.android.com/apk/res/android">
-    <abi>arm64-v8a,armeabi-v7a,x86,x86_64</abi>
+    <abi>arm64-v8a,armeabi-v7a</abi>
     <manifest android:versionCode="2000040014" android:versionName="2.0.4.14">
     <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="34"/>
     <application android:debuggable="false" android:icon="@drawable/appicon" android:label="Waterbug" android:name="WaterbugApplication" android:theme="@style/Theme.WaterbugApp" android:resizeableActivity="true" android:screenOrientation="sensorLandscape">


### PR DESCRIPTION
## Summary

- Play Store rejects bundles where x86 (32-bit) is included without x86_64 (64-bit)
- The bugfender module doesn't ship x86_64 native libs, causing Titanium to silently drop 64-bit x86 support
- No real Android devices use x86 — it's only needed for CI emulators
- Remove x86 from `tiapp.xml.template`, inject it into `tiapp.xml` in the two Android CI jobs

## Test plan

- [ ] Android emulator unit tests pass (x86 ABI injected by CI)
- [ ] Android emulator acceptance tests pass
- [ ] Release workflow uploads to Play Store without 64-bit compliance error

🤖 Generated with [Claude Code](https://claude.com/claude-code)