### PR TITLE
fix(android): bump targetSdkVersion 34 → 35

### DIFF
--- a/walta-app/tiapp.xml.template
+++ b/walta-app/tiapp.xml.template
@@ -64,7 +64,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
     <abi>arm64-v8a,armeabi-v7a</abi>
     <manifest android:versionCode="2000040014" android:versionName="2.0.4.14">
-    <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="34"/>
+    <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="35"/>
     <application android:debuggable="false" android:icon="@drawable/appicon" android:label="Waterbug" android:name="WaterbugApplication" android:theme="@style/Theme.WaterbugApp" android:resizeableActivity="true" android:screenOrientation="sensorLandscape">
       <meta-data android:name="com.google.android.geo.API_KEY" android:value="GOOGLE_MAPS_API_KEY_PLACEHOLDER" />
       <activity android:name=".WaterbugActivity" android:label="@string/app_name" android:theme="@style/Theme.WaterbugApp" android:configChanges="keyboardHidden|orientation|fontScale|screenSize|smallestScreenSize|screenLayout|density" android:screenOrientation="sensorLandscape">


### PR DESCRIPTION
## Summary

- Google Play now requires targetSdkVersion 35 (Android 15) for new uploads
- Bump from 34 → 35

## Test plan

- [ ] CI passes (Android emulator tests on API 30 still work with target 35)
- [ ] Release workflow uploads to Play Store successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)