### PR TITLE
fix(ci): derive release version from git tags, not template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
       version_code: ${{ steps.version.outputs.version_code }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need full history for tags
 
       - name: Compute version and versionCode
         id: version
@@ -43,8 +45,14 @@ jobs:
           if [ -n "${{ inputs.version }}" ]; then
             VERSION="${{ inputs.version }}"
           else
-            # Read current version and auto-increment build number
-            CURRENT=$(grep -o '<version>[^<]*' walta-app/tiapp.xml.template | cut -d'>' -f2)
+            # Auto-increment build number from the latest release tag
+            LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
+            if [ -n "$LATEST_TAG" ]; then
+              CURRENT="${LATEST_TAG#v}"
+            else
+              # No tags yet — fall back to 2.0.4.0 as the base version
+              CURRENT="2.0.4.0"
+            fi
             IFS='.' read -r major minor patch build <<< "$CURRENT"
             build=$((build + 1))
             VERSION="${major}.${minor}.${patch}.${build}"
@@ -342,22 +350,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Bump version in template and commit
-        run: |
-          VERSION="${{ needs.prepare.outputs.version }}"
-          VERSION_CODE="${{ needs.prepare.outputs.version_code }}"
-
-          sed -i "s|<version>[^<]*</version>|<version>${VERSION}</version>|" walta-app/tiapp.xml.template
-          sed -i "s|android:versionCode=\"[^\"]*\"|android:versionCode=\"${VERSION_CODE}\"|" walta-app/tiapp.xml.template
-          sed -i "s|android:versionName=\"[^\"]*\"|android:versionName=\"${VERSION}\"|" walta-app/tiapp.xml.template
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add walta-app/tiapp.xml.template
-          git commit -m "chore: bump version to ${VERSION}" || echo "No version change to commit"
-
       - name: Create and push tag
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
-          git tag "v${VERSION}"
-          git push origin HEAD "v${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "Release ${VERSION}"
+          git push origin "v${VERSION}"

--- a/walta-app/tiapp.xml.template
+++ b/walta-app/tiapp.xml.template
@@ -63,7 +63,7 @@
   <android
     xmlns:android="http://schemas.android.com/apk/res/android">
     <abi>arm64-v8a,armeabi-v7a</abi>
-    <manifest android:versionCode="0" android:versionName="0.0.0.0">
+    <manifest android:versionCode="1" android:versionName="0.0.0.0">
     <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="35"/>
     <application android:debuggable="false" android:icon="@drawable/appicon" android:label="Waterbug" android:name="WaterbugApplication" android:theme="@style/Theme.WaterbugApp" android:resizeableActivity="true" android:screenOrientation="sensorLandscape">
       <meta-data android:name="com.google.android.geo.API_KEY" android:value="GOOGLE_MAPS_API_KEY_PLACEHOLDER" />

--- a/walta-app/tiapp.xml.template
+++ b/walta-app/tiapp.xml.template
@@ -3,7 +3,7 @@
   xmlns:ti="http://ti.appcelerator.org">
   <id>net.thewaterbug.waterbug</id>
   <name>Waterbug</name>
-  <version>2.0.4.14</version>
+  <version>0.0.0.0</version>
   <publisher>The Code Sharman</publisher>
   <url>http://www.thewaterbug.net/</url>
   <description>The Waterbug App</description>
@@ -63,7 +63,7 @@
   <android
     xmlns:android="http://schemas.android.com/apk/res/android">
     <abi>arm64-v8a,armeabi-v7a</abi>
-    <manifest android:versionCode="2000040014" android:versionName="2.0.4.14">
+    <manifest android:versionCode="0" android:versionName="0.0.0.0">
     <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="35"/>
     <application android:debuggable="false" android:icon="@drawable/appicon" android:label="Waterbug" android:name="WaterbugApplication" android:theme="@style/Theme.WaterbugApp" android:resizeableActivity="true" android:screenOrientation="sensorLandscape">
       <meta-data android:name="com.google.android.geo.API_KEY" android:value="GOOGLE_MAPS_API_KEY_PLACEHOLDER" />


### PR DESCRIPTION
## Summary

- Release version is now derived from the latest `v*` git tag instead of `tiapp.xml.template`
- Removes the version bump commit to main (which was blocked by branch protection)
- Tag-release job now only pushes an annotated tag
- Template version set to `0.0.0.0` as a placeholder — real versions come from the release workflow

## How it works

1. `prepare` job reads the latest `v*` tag (e.g. `v2.0.4.19`) and increments → `2.0.4.20`
2. Build jobs patch `tiapp.xml` at build time with the computed version
3. After successful upload, `tag-release` creates `v2.0.4.20` tag
4. Next release reads that tag and increments again

## Test plan

- [ ] CI passes
- [ ] Release workflow auto-increments from `v2.0.4.19` to `v2.0.4.20`
- [ ] Tag is created after successful upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)