### PR TITLE
chore: ignore liveview and chai >=5 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
+    ignore:
+      # liveview is pinned to our fork on a custom branch — we manage it manually
+      - dependency-name: "liveview"
+      # chai 6 is ESM-only and breaks the in-app mocha unit test harness
+      - dependency-name: "chai"
+        versions: [">=5"]
     groups:
       dev-dependencies:
         dependency-type: "development"


### PR DESCRIPTION
## Summary
- Add `ignore` rules to `.github/dependabot.yml` so dependabot stops advancing the `liveview` submodule (we track our own fork on a custom branch) and stops bumping `chai` past 4.x.

## Why
- PR #190 tried to advance `liveview` — but we pin to `TheCodeSharman/liveview#fix/android-emulator-unit-test-support` and manage that fork by hand.
- PR #189 hung both Android and iOS unit-test CI jobs with `output-logs idle for 300s`. The in-app mocha harness can't load chai 6 (ESM-only), so the app launches but the test runner never initialises. Acceptance tests (which run in Node) are unaffected.

## Test plan
- [ ] Verify the next dependabot run does not open a PR for `liveview` or for `chai >= 5`.
- [ ] Close PR #190.
- [ ] Rebase PR #189 to drop chai from the bump; confirm unit tests go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)