### PR TITLE
docs: describe the GitHub Actions release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: >
           Version (e.g. 2.0.5.1). Leave empty to auto-increment the build
-          number from the current version in tiapp.xml.template.
+          number from the latest v* git tag.
         required: false
         type: string
       platforms:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,17 @@ This produces `builds/release/Waterbug.{apk,aab,ipa}`.
 
 ## Making a release
 
-1. Bump the version numbers in `tiapp.xml.template` for both Android and iOS.
-2. Build the release packages as described above.
-3. Upload the resulting packages to the Google Play Store and Apple App Store.
+Releases are built and published by the **Release** GitHub Action. From the [Actions tab](https://github.com/TheWaterBugCompany/WALTA/actions/workflows/release.yml), click **Run workflow** and choose:
+
+- **Version** — e.g. `2.0.5.1`. Leave empty to auto-increment the build number from the latest `v*` git tag.
+- **Platforms** — `both` (default), `android`, or `ios`.
+
+The workflow will:
+
+1. Build signed release packages for the selected platform(s).
+2. Upload the Android `.aab` to the Google Play **internal** track.
+3. Upload the iOS `.ipa` to **TestFlight**.
+4. Tag the commit with `v<version>` on success.
+
+Promotion from the internal track / TestFlight to production is done manually in the Play Console and App Store Connect.
 


### PR DESCRIPTION
## Summary
- Rewrite the **Making a release** section in [README.md](README.md) to describe the actual flow: trigger the **Release** workflow from the Actions tab, choose a platform, builds get pushed to Google Play internal + TestFlight, and the commit gets tagged on success.
- Fix the version input description in [.github/workflows/release.yml](.github/workflows/release.yml): it claimed the auto-increment reads `tiapp.xml.template`, but the workflow actually reads the latest `v*` git tag.

## Test plan
- [ ] Sanity-check the rendered README on the PR's Files-changed view.
- [ ] On the next release run, confirm the `version` input description text on the workflow-dispatch form matches the new wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)