### PR TITLE
WB-30: Harden iOS CI against CoreSimulator flakes (retry + bootstatus)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,11 @@ jobs:
 
       - name: Boot iOS simulator
         run: |
+          # `bootstatus` without `-b` waits for the in-flight boot started
+          # above; with `-b` it races to issue a second boot and fails with
+          # SimError 405 once the device has reached "Booted" state.
           xcrun simctl boot ${{ steps.sim.outputs.udid }} || true
-          xcrun simctl bootstatus ${{ steps.sim.outputs.udid }} -b
+          xcrun simctl bootstatus ${{ steps.sim.outputs.udid }}
           echo "Simulator booted"
 
       - name: Run iOS build tests

--- a/build-tests/unit/IosSimulatorLauncher_spec.js
+++ b/build-tests/unit/IosSimulatorLauncher_spec.js
@@ -96,6 +96,76 @@ describe("IosSimulatorLauncher", function() {
       expect(calls.some(a => a[1] === "install")).to.be.false;
     });
 
+    it("retries simctl launch once if it times out, and succeeds on the retry", async function() {
+      // CoreSimulator services (installd / FrontBoard / launchd) sometimes
+      // aren't ready to accept spawn requests even after the device reports
+      // "Booted". simctl launch silently waits, hits our timeout, and dies.
+      // A single retry usually catches up once the services are warm.
+      let launchAttempts = 0;
+      const fakeExecFile = sinon.stub().callsFake((_cmd, args, _opts, callback) => {
+        const key = args.join(" ");
+        if (key === `simctl boot ${UDID}`) {
+          callback(null, "", "");
+        } else if (key === `simctl launch ${UDID} net.thewaterbug.waterbug`) {
+          launchAttempts++;
+          if (launchAttempts === 1) {
+            const err = new Error("Command failed: xcrun simctl launch ...");
+            err.killed = true; // execFile sets this when the timeout kills the process
+            callback(err, "", "");
+          } else {
+            callback(null, "net.thewaterbug.waterbug: 1234\n", "");
+          }
+        } else {
+          callback(null, "", "");
+        }
+      });
+      const launcher = new IosSimulatorLauncher({ execFile: fakeExecFile, udid: UDID });
+      await launcher.launch("net.thewaterbug.waterbug");
+      expect(launchAttempts).to.equal(2);
+      expect(launcher._pid).to.equal(1234);
+    });
+
+    it("rethrows when simctl launch times out twice", async function() {
+      const err = new Error("Command failed: xcrun simctl launch ...");
+      err.killed = true;
+      const fakeExecFile = makeExecFile({
+        [`simctl boot ${UDID}`]: "",
+        [`simctl launch ${UDID} net.thewaterbug.waterbug`]: err,
+      });
+      const launcher = new IosSimulatorLauncher({ execFile: fakeExecFile, udid: UDID });
+      let caught;
+      try {
+        await launcher.launch("net.thewaterbug.waterbug");
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught, "expected launch to reject after retry exhausted").to.exist;
+      expect(caught.killed).to.be.true;
+      const launchCalls = fakeExecFile.getCalls().filter(c => c.args[1][1] === "launch");
+      expect(launchCalls).to.have.lengthOf(2);
+    });
+
+    it("does not retry simctl launch on non-timeout errors", async function() {
+      // A real launch failure (e.g. app not installed, bad bundle id) should
+      // surface immediately — retrying just delays the diagnostic.
+      const err = new Error("Application not found");
+      // err.killed is left undefined — this is a real failure, not a timeout
+      const fakeExecFile = makeExecFile({
+        [`simctl boot ${UDID}`]: "",
+        [`simctl launch ${UDID} net.thewaterbug.waterbug`]: err,
+      });
+      const launcher = new IosSimulatorLauncher({ execFile: fakeExecFile, udid: UDID });
+      let caught;
+      try {
+        await launcher.launch("net.thewaterbug.waterbug");
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).to.exist;
+      const launchCalls = fakeExecFile.getCalls().filter(c => c.args[1][1] === "launch");
+      expect(launchCalls).to.have.lengthOf(1);
+    });
+
     it("uses a generous timeout for install/launch so cold CI runners don't get killed mid-launch", async function() {
       const APP_PATH = "./builds/unit-test/Waterbug.app";
       const fakeExecFile = makeExecFile({

--- a/build-utils/IosSimulatorLauncher.js
+++ b/build-utils/IosSimulatorLauncher.js
@@ -43,7 +43,18 @@ class IosSimulatorLauncher {
     if (appPath) {
       await this._exec(["simctl", "install", this._udid, appPath], { timeout: 180000 });
     }
-    const stdout = await this._exec(["simctl", "launch", this._udid, appId], { timeout: 180000 });
+    const launchArgs = ["simctl", "launch", this._udid, appId];
+    let stdout;
+    try {
+      stdout = await this._exec(launchArgs, { timeout: 180000 });
+    } catch (err) {
+      // Retry once if the timeout killed simctl. CoreSimulator services
+      // sometimes aren't accepting spawn requests yet even after the device
+      // reports "Booted"; a second attempt usually succeeds once they warm up.
+      // Real launch errors (bad bundle id, missing app) surface immediately.
+      if (!err.killed) throw err;
+      stdout = await this._exec(launchArgs, { timeout: 180000 });
+    }
     const match = stdout.match(/:\s*(\d+)/);
     this._pid = match ? parseInt(match[1], 10) : null;
   }


### PR DESCRIPTION
[WB-30 on Trello](https://trello.com/c/wRQUJkug/30-harden-ios-ci-against-coresimulator-flakes-retry-readiness-probe)

## Summary

Two complementary fixes for the intermittent iOS unit-test failures we keep paying for in CI.

1. **Drop `bootstatus -b` from the unit-tests boot step** in [.github/workflows/ci.yml](.github/workflows/ci.yml). The acceptance job had this same race in PR #188 — `-b` issues a second boot while the first is still in flight, then fails with SimError 405 once the device reaches "Booted". Without `-b`, bootstatus just waits for the existing boot to finish.
2. **Retry `simctl launch` once on timeout** in [build-utils/IosSimulatorLauncher.js](build-utils/IosSimulatorLauncher.js). CoreSimulator services (installd / FrontBoard / launchd) sometimes aren't accepting spawn requests even after the device reports "Booted" — simctl launch silently waits, hits the 180s timeout, and the job fails with no stderr. A single retry usually catches up once the services are warm. Real launch failures (bad bundle id, missing app) still surface immediately because `err.killed` is only set when our own timeout killed the process.

Skipping fix (3) from the card (post-boot readiness probe via `launchctl print system`) — it's the deterministic fix but a bigger change. Trying the smaller two first.

## TDD coverage

Three new specs in [build-tests/unit/IosSimulatorLauncher_spec.js](build-tests/unit/IosSimulatorLauncher_spec.js):
- retries `simctl launch` once if it times out, succeeds on retry
- rethrows when `simctl launch` times out twice (retry exhausted)
- does **not** retry on non-timeout errors

## Test plan
- [ ] CI on this branch: iOS unit tests pass.
- [ ] Re-run iOS unit tests on this branch a few times to confirm flake is reduced.
- [ ] Watch the next few merges to main for any recurrence of the `simctl launch ... timeout` symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)