### PR TITLE
WB-32: Skip CI build/test jobs when paths don't affect the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,57 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ── 0. Detect changes ─────────────────────────────────────────────────────
+  # Build/test jobs only run if files relevant to the build or its tests have
+  # changed. Doc/graphics/ruleset-only PRs skip the expensive jobs entirely.
+  # Skipped jobs report a "skipped" status which counts as success for
+  # required-checks branch protection.
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              # App source & taxonomy
+              - 'walta-app/**'
+              - 'walta-taxonomy/walta/**'
+              # Build configuration
+              - 'Gruntfile.js'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'install.sh'
+              - '.babelrc'
+              - '.npmrc'
+              - 'webpack.config.js'
+              - 'patches/**'
+              - 'plugins/**'
+              # Build utilities
+              - 'build-utils/**'
+              # Test infrastructure
+              - 'build-tests/**'
+              - 'test/**'
+              - 'test-resources/**'
+              - 'features/**'
+              - 'end-to-end-testing/**'
+              - 'mocha-bootstrap.js'
+              - 'wdio.conf.js'
+              # CI workflow itself — any change re-runs everything
+              - '.github/workflows/ci.yml'
+
   # ── 1. Node.js unit tests ─────────────────────────────────────────────────
   node-tests:
     name: Node.js unit tests
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,6 +104,8 @@ jobs:
   # ── 2. iOS simulator unit tests ───────────────────────────────────────────
   ios-simulator-tests:
     name: iOS simulator unit tests
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -193,6 +243,8 @@ jobs:
   # The AVD name "Medium_Phone_API_36.1" matches AndroidEmulatorLauncher.js.
   android-emulator-tests:
     name: Android emulator unit tests
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -320,6 +372,8 @@ jobs:
   # ── 4. iOS simulator acceptance tests ─────────────────────────────────────
   ios-simulator-acceptance-tests:
     name: iOS simulator acceptance tests
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: macos-latest
     timeout-minutes: 30
     env:
@@ -483,6 +537,8 @@ jobs:
   # ── 5. Android emulator acceptance tests ──────────────────────────────────
   android-emulator-acceptance-tests:
     name: Android emulator acceptance tests
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
[WB-32 on Trello](https://trello.com/c/kQ8cOmRf/32-skip-ci-build-test-jobs-when-paths-dont-affect-the-build)

## Summary

Add a `changes` preflight job to [.github/workflows/ci.yml](.github/workflows/ci.yml) using [`dorny/paths-filter@v3`](https://github.com/dorny/paths-filter). The five expensive jobs (Node unit, iOS unit, Android unit, iOS acceptance, Android acceptance) now gate on `needs: changes` + `if: needs.changes.outputs.relevant == 'true'`.

Doc-only, graphics-only, ruleset-only and dependabot-config-only PRs will skip all five expensive jobs — saving roughly **38 min of macOS + Linux runner time per such PR**, and removing the "branch up to date → re-run all CI" pain when main moves with an irrelevant commit.

Skipped jobs report a `skipped` status, which GitHub treats as success for required-checks branch protection — so the PR still becomes mergeable.

## Allowlist

Single shared allowlist (no platform split — iOS and Android share enough that splitting isn't worth the complexity):

- **App source & taxonomy:** `walta-app/**`, `walta-taxonomy/walta/**`
- **Build config:** `Gruntfile.js`, `package.json`, `package-lock.json`, `install.sh`, `.babelrc`, `.npmrc`, `webpack.config.js`, `patches/**`, `plugins/**`
- **Build utilities:** `build-utils/**`
- **Test infrastructure:** `build-tests/**`, `test/**`, `test-resources/**`, `features/**`, `end-to-end-testing/**`, `mocha-bootstrap.js`, `wdio.conf.js`
- **CI itself:** `.github/workflows/ci.yml` — any change here re-runs everything as a safety net

## Failure mode

Inverted from a blocklist: instead of "forgot to exclude a safe folder → wasted CI", it becomes "forgot to include a relevant folder → silent regression". The allowlist favours over-inclusion (anything under `walta-app/` or any root config triggers a full run), and the workflow file is in the allowlist so any future ci.yml edit forces a full re-run.

## Test plan

- [ ] **Happy path** — this PR modifies `ci.yml` (in the allowlist), so all 5 expensive jobs should still run on this PR. Confirms the structure doesn't break the run path.
- [ ] **Skip path** — after merging, push a doc-only commit (e.g. a README typo) and confirm:
  - The `changes` job runs and outputs `relevant=false`
  - All 5 expensive jobs report `skipped`
  - The PR is mergeable per the ruleset (skipped counts as success)
- [ ] Confirm the next dependabot config / dependabot dev-deps / pure-graphics PR genuinely skips the heavy jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)