### PR TITLE
test: validate WB-32 CI skip path on doc-only change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WALTA
 
-This repository contains the source code for both the iOS and the Android versions of the Waterbug App.
+This repository contains the source code for both the iOS and Android versions of the Waterbug App.
 
 ## Licensing
 


### PR DESCRIPTION
## Purpose

This PR exists to validate the path-filter skip behaviour added in #196. It changes only [README.md](README.md) (which is **not** in the CI allowlist), so the expected behaviour is:

- The new `Detect relevant changes` job runs and outputs `relevant=false`.
- All 5 expensive jobs (Node unit, iOS unit, Android unit, iOS acceptance, Android acceptance) report **skipped**.
- The PR is **mergeable** despite the skipped jobs (skipped checks count as success for required-checks branch protection).

## What to verify

- [ ] CI completes within ~30 seconds total (no expensive jobs ran).
- [ ] All five required checks are reported (as `skipped`) so the ruleset doesn't see them as missing.
- [ ] The `Detect relevant changes` job log shows `relevant=false`.
- [ ] PR shows as mergeable.

If all four are true, WB-32 works as intended. **Do not merge** this PR — it is a test artefact. Close it once verified.

The substantive change is a one-character README copy-edit (dropping a redundant "the") so closing without merging loses nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)