### PR TITLE
WB-37: --grep and --manual CLI args for on-device unit tests

### DIFF
--- a/.claude/skills/fast-device-test/SKILL.md
+++ b/.claude/skills/fast-device-test/SKILL.md
@@ -29,6 +29,17 @@ npx grunt --platform=android --simulator --liveview --reuse-server unit-test
 | `--simulator` | Use the Android emulator (`Medium_Phone_API_36.1`) rather than a physical device |
 | `--liveview` | Serve JS over a local Vite dev server on port 8323 instead of baking it into the APK |
 | `--reuse-server` | If a LiveView server is already running on :8323, reuse it instead of a fresh rebuild |
+| `--grep=<pattern>` | (optional) Mocha grep filter — only runs tests whose fully-qualified name matches, e.g. `--grep=SyncFeedback` |
+| `--manual` | (optional) Enables manual mode — mocha.timeout(0), window stays open after the test so you can interact with the screen. On Android tap the "Continue" menu when you're done |
+
+**Typical focused-manual-test invocation:**
+
+```bash
+npx grunt --platform=android --simulator --liveview --reuse-server \
+  --grep=SyncFeedback --manual unit-test
+```
+
+Note: grunt options must use the `--flag=value` form (not `--flag value`) or the value gets parsed as a task name.
 
 **Timing (rough, M-series Mac, emulator already booted):**
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -669,8 +669,20 @@ const KobitonAPI = require("./features/support/kobiton");
         grunt.log.writeln('No app path — launching existing installed app');
       }
 
+      // Optional runtime test config forwarded to the on-device spec runner.
+      // Android: intent extras via `am start --es/--ez`.
+      // iOS: NSUserDefaults-style argv via `simctl launch`.
+      const launchArgs = {};
+      const grep = grunt.option('grep');
+      if (grep) launchArgs.test_grep = grep;
+      if (grunt.option('manual')) launchArgs.test_manual = true;
+      const hasLaunchArgs = Object.keys(launchArgs).length > 0;
+      if (hasLaunchArgs) {
+        grunt.log.writeln(`Forwarding launch args to test runner: ${JSON.stringify(launchArgs)}`);
+      }
+
       getLauncher(platform, isSimulator)
-        .then(launcher => launcher.launch(APP_ID, appPath))
+        .then(launcher => launcher.launch(APP_ID, appPath, hasLaunchArgs ? launchArgs : undefined))
         .then(done)
         .catch(err => { grunt.fail.fatal(err); done(); });
     });
@@ -834,7 +846,11 @@ const KobitonAPI = require("./features/support/kobiton");
 
           grunt.task.run(`launch:${platform}:unit-test-liveview`);
           grunt.task.run(`output-logs:${platform}:${preview?"preview":""}`);
-          grunt.task.run(`terminate:${platform}`);
+          // Skip teardown in --manual mode so the screen-under-test stays
+          // visible on the device after the spec finishes.
+          if (!grunt.option('manual')) {
+            grunt.task.run(`terminate:${platform}`);
+          }
           mockServer.shutdown();
           done();
         }).catch(err => { grunt.fail.fatal(err); done(); });
@@ -847,7 +863,11 @@ const KobitonAPI = require("./features/support/kobiton");
 
         grunt.task.run(`launch:${platform}:unit-test`);
         grunt.task.run(`output-logs:${platform}:${preview?"preview":""}`);
-        grunt.task.run(`terminate:${platform}`);
+        // Skip teardown in --manual mode so the screen-under-test stays
+        // visible on the device after the spec finishes.
+        if (!grunt.option('manual')) {
+          grunt.task.run(`terminate:${platform}`);
+        }
         mockServer.shutdown();
       }
     } );

--- a/TESTING.md
+++ b/TESTING.md
@@ -103,6 +103,22 @@ When `--reuse-server` is passed:
 
 **When NOT to use it:** When switching platforms (e.g. Android to iOS), when `tiapp.xml` changes, or when native assets change. In those cases, omit `--reuse-server` to get a fresh build.
 
+### Runtime Test Config (`--grep` and `--manual`)
+
+`grunt unit-test` accepts two more options that are forwarded to the on-device spec runner at launch (no rebuild needed):
+
+```bash
+npx grunt --platform=android --simulator --liveview --reuse-server \
+  --grep=SyncFeedback --manual unit-test
+```
+
+- `--grep=<pattern>` — Mocha grep filter on the fully-qualified test name. `--grep=SyncFeedback` runs only tests under `describe("SyncFeedback controller", …)`; `--grep="should render"` runs every `it("should render …")` across the suite.
+- `--manual` — enables manual mode: no test timeout and the window stays open after the test finishes. On Android, tap the "Continue" menu item to dismiss. Useful for poking at a single screen after its setup has run.
+
+**How this works**: the grunt `launch` task maps these options into launcher arguments — Android intent extras (`--es test_grep … --ez test_manual true`) or iOS `simctl launch` argv (`-test_grep … -test_manual true`). `walta-app/app/spec/index.js` reads them on startup via `Ti.Android.currentActivity.intent.getStringExtra(…)` or `Ti.App.arguments` and configures Mocha accordingly.
+
+Combine freely with `--liveview --reuse-server` for sub-30-second iteration on a focused test.
+
 ### LiveView with Other Tasks
 
 ```bash

--- a/build-tests/unit/AndroidEmulatorLauncher_spec.js
+++ b/build-tests/unit/AndroidEmulatorLauncher_spec.js
@@ -108,6 +108,15 @@ describe("AndroidEmulatorLauncher", function() {
       expect(fakeLauncher.launch.calledWith("com.example.app", "/path/to/app.apk")).to.be.true;
     });
 
+    it("forwards launchArgs to the inner launcher when provided", async function() {
+      await launcher.launch("com.example.app", null, { test_grep: "About", test_manual: true });
+      expect(fakeLauncher.launch.calledWith(
+        "com.example.app",
+        null,
+        { test_grep: "About", test_manual: true }
+      )).to.be.true;
+    });
+
     it("calls connect() before delegating launch() so the emulator serial is set", async function() {
       const freshLauncher = new AndroidEmulatorLauncher({
         execFile: makeExecFile({ "devices": EMULATOR_DEVICES }),

--- a/build-tests/unit/AndroidLauncher_spec.js
+++ b/build-tests/unit/AndroidLauncher_spec.js
@@ -136,6 +136,70 @@ describe("AndroidLauncher", function() {
       ]);
     });
 
+    it("appends string launchArgs as --es intent extras on am start", async function() {
+      const fakeExecFile = makeExecFile({
+        "devices": DEVICES_OUTPUT,
+        ...STAY_AWAKE_RESPONSES,
+        "-s emulator-5554 logcat -c": "",
+        "-s emulator-5554 shell am start -S -n net.thewaterbug.waterbug/.WaterbugActivity --es test_grep SyncFeedback": ""
+      });
+      const launcher = new AndroidLauncher({ activity: ".WaterbugActivity", execFile: fakeExecFile });
+      await launcher.launch("net.thewaterbug.waterbug", null, { test_grep: "SyncFeedback" });
+      expect(fakeExecFile.lastCall.args[1]).to.deep.equal([
+        "-s", "emulator-5554",
+        "shell", "am", "start", "-S", "-n", "net.thewaterbug.waterbug/.WaterbugActivity",
+        "--es", "test_grep", "SyncFeedback"
+      ]);
+    });
+
+    it("appends boolean launchArgs as --ez intent extras on am start", async function() {
+      const fakeExecFile = makeExecFile({
+        "devices": DEVICES_OUTPUT,
+        ...STAY_AWAKE_RESPONSES,
+        "-s emulator-5554 logcat -c": "",
+        "-s emulator-5554 shell am start -S -n net.thewaterbug.waterbug/.WaterbugActivity --ez test_manual true": ""
+      });
+      const launcher = new AndroidLauncher({ activity: ".WaterbugActivity", execFile: fakeExecFile });
+      await launcher.launch("net.thewaterbug.waterbug", null, { test_manual: true });
+      expect(fakeExecFile.lastCall.args[1]).to.deep.equal([
+        "-s", "emulator-5554",
+        "shell", "am", "start", "-S", "-n", "net.thewaterbug.waterbug/.WaterbugActivity",
+        "--ez", "test_manual", "true"
+      ]);
+    });
+
+    it("combines string and boolean launchArgs on the same am start call", async function() {
+      const fakeExecFile = makeExecFile({
+        "devices": DEVICES_OUTPUT,
+        ...STAY_AWAKE_RESPONSES,
+        "-s emulator-5554 logcat -c": "",
+        "-s emulator-5554 shell am start -S -n net.thewaterbug.waterbug/.WaterbugActivity --es test_grep SyncFeedback --ez test_manual true": ""
+      });
+      const launcher = new AndroidLauncher({ activity: ".WaterbugActivity", execFile: fakeExecFile });
+      await launcher.launch("net.thewaterbug.waterbug", null, { test_grep: "SyncFeedback", test_manual: true });
+      expect(fakeExecFile.lastCall.args[1]).to.deep.equal([
+        "-s", "emulator-5554",
+        "shell", "am", "start", "-S", "-n", "net.thewaterbug.waterbug/.WaterbugActivity",
+        "--es", "test_grep", "SyncFeedback",
+        "--ez", "test_manual", "true"
+      ]);
+    });
+
+    it("omits launchArg flags entirely when no launchArgs are passed", async function() {
+      const fakeExecFile = makeExecFile({
+        "devices": DEVICES_OUTPUT,
+        ...STAY_AWAKE_RESPONSES,
+        "-s emulator-5554 logcat -c": "",
+        "-s emulator-5554 shell am start -n net.thewaterbug.waterbug/.WaterbugActivity": ""
+      });
+      const launcher = new AndroidLauncher({ activity: ".WaterbugActivity", execFile: fakeExecFile });
+      await launcher.launch("net.thewaterbug.waterbug");
+      expect(fakeExecFile.lastCall.args[1]).to.deep.equal([
+        "-s", "emulator-5554",
+        "shell", "am", "start", "-n", "net.thewaterbug.waterbug/.WaterbugActivity"
+      ]);
+    });
+
     it("proceeds with install even if uninstall fails (app not previously installed)", async function() {
       const fakeExecFile = makeExecFile({
         "devices": DEVICES_OUTPUT,

--- a/build-tests/unit/IosLauncher_spec.js
+++ b/build-tests/unit/IosLauncher_spec.js
@@ -103,6 +103,24 @@ describe("IosLauncher", function() {
         "devicectl", "device", "install", "app", "--device", UDID, APP_PATH
       ]);
     });
+
+    it("forwards launchArgs as NSUserDefaults-style argv and adds --terminate-existing", async function() {
+      const fakeExecFile = makeExecFile({
+        "-l": `${UDID}\n`,
+        "devicectl device process launch": "",
+      });
+      const fakeReadFile = makeReadFile(LAUNCH_OUTPUT);
+      const launcher = new IosLauncher({ execFile: fakeExecFile, readFile: fakeReadFile });
+      await launcher.launch(APP_ID, null, { test_grep: "About", test_manual: true });
+      const launchCall = fakeExecFile.getCalls().find(c => c.args[1]?.[2] === "process" && c.args[1]?.[3] === "launch");
+      const args = launchCall.args[1];
+      expect(args).to.include("--terminate-existing");
+      expect(args).to.include("-test_grep");
+      expect(args[args.indexOf("-test_grep") + 1]).to.equal("About");
+      expect(args).to.include("-test_manual");
+      expect(args[args.indexOf("-test_manual") + 1]).to.equal("true");
+      expect(args[args.length - 5]).to.equal(APP_ID);
+    });
   });
 
   describe("terminate()", function() {

--- a/build-tests/unit/IosSimulatorLauncher_spec.js
+++ b/build-tests/unit/IosSimulatorLauncher_spec.js
@@ -96,6 +96,49 @@ describe("IosSimulatorLauncher", function() {
       expect(calls.some(a => a[1] === "install")).to.be.false;
     });
 
+    it("appends string launchArgs as NSUserDefaults-style argv pairs after the bundle id", async function() {
+      const fakeExecFile = makeExecFile({
+        [`simctl boot ${UDID}`]: "",
+        [`simctl launch --terminate-running-process ${UDID} net.thewaterbug.waterbug -test_grep SyncFeedback`]: "net.thewaterbug.waterbug: 1\n",
+      });
+      const launcher = new IosSimulatorLauncher({ execFile: fakeExecFile, udid: UDID });
+      await launcher.launch("net.thewaterbug.waterbug", null, { test_grep: "SyncFeedback" });
+      const launchCall = fakeExecFile.getCalls().find(c => c.args[1][1] === "launch");
+      expect(launchCall.args[1]).to.deep.equal([
+        "simctl", "launch", "--terminate-running-process", UDID, "net.thewaterbug.waterbug",
+        "-test_grep", "SyncFeedback"
+      ]);
+    });
+
+    it("appends boolean launchArgs as '-key true'/'-key false' pairs", async function() {
+      const fakeExecFile = makeExecFile({
+        [`simctl boot ${UDID}`]: "",
+        [`simctl launch --terminate-running-process ${UDID} net.thewaterbug.waterbug -test_manual true`]: "net.thewaterbug.waterbug: 1\n",
+      });
+      const launcher = new IosSimulatorLauncher({ execFile: fakeExecFile, udid: UDID });
+      await launcher.launch("net.thewaterbug.waterbug", null, { test_manual: true });
+      const launchCall = fakeExecFile.getCalls().find(c => c.args[1][1] === "launch");
+      expect(launchCall.args[1]).to.deep.equal([
+        "simctl", "launch", "--terminate-running-process", UDID, "net.thewaterbug.waterbug",
+        "-test_manual", "true"
+      ]);
+    });
+
+    it("combines multiple launchArgs on the same simctl launch call", async function() {
+      const fakeExecFile = makeExecFile({
+        [`simctl boot ${UDID}`]: "",
+        [`simctl launch --terminate-running-process ${UDID} net.thewaterbug.waterbug -test_grep SyncFeedback -test_manual true`]: "net.thewaterbug.waterbug: 1\n",
+      });
+      const launcher = new IosSimulatorLauncher({ execFile: fakeExecFile, udid: UDID });
+      await launcher.launch("net.thewaterbug.waterbug", null, { test_grep: "SyncFeedback", test_manual: true });
+      const launchCall = fakeExecFile.getCalls().find(c => c.args[1][1] === "launch");
+      expect(launchCall.args[1]).to.deep.equal([
+        "simctl", "launch", "--terminate-running-process", UDID, "net.thewaterbug.waterbug",
+        "-test_grep", "SyncFeedback",
+        "-test_manual", "true"
+      ]);
+    });
+
     it("retries simctl launch if it times out, and succeeds on the retry", async function() {
       // CoreSimulator services (installd / FrontBoard / launchd) sometimes
       // aren't ready to accept spawn requests even after the device reports

--- a/build-utils/AndroidEmulatorLauncher.js
+++ b/build-utils/AndroidEmulatorLauncher.js
@@ -92,7 +92,7 @@ class AndroidEmulatorLauncher {
     });
   }
 
-  async launch(appId, apkPath) { await this.connect(); return this._inner.launch(appId, apkPath); }
+  async launch(appId, apkPath, launchArgs) { await this.connect(); return this._inner.launch(appId, apkPath, launchArgs); }
   async terminate(appId) { await this.connect(); return this._inner.terminate(appId); }
   streamLogs(onLine) { return this._inner.streamLogs(onLine); }
   getDriver() { return null; }

--- a/build-utils/AndroidLauncher.js
+++ b/build-utils/AndroidLauncher.js
@@ -14,6 +14,20 @@ function exec(execFile, adb, args) {
   });
 }
 
+function buildIntentExtras(launchArgs) {
+  if (!launchArgs) return [];
+  const flags = [];
+  for (const key of Object.keys(launchArgs)) {
+    const value = launchArgs[key];
+    if (typeof value === "boolean") {
+      flags.push("--ez", key, value ? "true" : "false");
+    } else if (value !== undefined && value !== null) {
+      flags.push("--es", key, String(value));
+    }
+  }
+  return flags;
+}
+
 class AndroidLauncher {
   constructor({ adb = defaultAdb(), execFile = defaultExecFile, spawn = defaultSpawn, activity = null, logTag = "TiAPI", logNoisePattern = /^Waterbug \d|^ti\.playservices:/ } = {}) {
     this._adb = adb;
@@ -43,7 +57,7 @@ class AndroidLauncher {
     return this;
   }
 
-  async launch(appId, apkPath) {
+  async launch(appId, apkPath, launchArgs) {
     await this.connect();
     // Keep screen on while USB-connected to prevent lock-mode test failures
     await this._exec(["shell", "svc", "power", "stayon", "usb"]).catch(() => {});
@@ -53,10 +67,15 @@ class AndroidLauncher {
       await this._exec(["install", "-r", apkPath]);
     }
     await this._exec(["logcat", "-c"]);
+    const extras = buildIntentExtras(launchArgs);
+    // `-S` force-stops the app before starting so JS re-runs and any new
+    // intent extras are picked up at spec-runner init — otherwise `am start`
+    // on a live process only delivers onNewIntent and index.js isn't re-evaluated.
+    const startFlags = extras.length > 0 ? ["-S"] : [];
     if (this._activity) {
-      await this._exec(["shell", "am", "start", "-n", `${appId}/${this._activity}`]);
+      await this._exec(["shell", "am", "start", ...startFlags, "-n", `${appId}/${this._activity}`, ...extras]);
     } else {
-      await this._exec(["shell", "am", "start", "-a", "android.intent.action.MAIN", "-c", "android.intent.category.LAUNCHER", "-p", appId]);
+      await this._exec(["shell", "am", "start", ...startFlags, "-a", "android.intent.action.MAIN", "-c", "android.intent.category.LAUNCHER", "-p", appId, ...extras]);
     }
   }
 

--- a/build-utils/IosLauncher.js
+++ b/build-utils/IosLauncher.js
@@ -10,6 +10,20 @@ function computeLogPort(appId) {
   return parseInt(sha1, 16) % 50000 + 10000;
 }
 
+function buildLaunchArgv(launchArgs) {
+  if (!launchArgs) return [];
+  const argv = [];
+  for (const key of Object.keys(launchArgs)) {
+    const value = launchArgs[key];
+    if (typeof value === "boolean") {
+      argv.push(`-${key}`, value ? "true" : "false");
+    } else if (value !== undefined && value !== null) {
+      argv.push(`-${key}`, String(value));
+    }
+  }
+  return argv;
+}
+
 class IosLauncher {
   constructor({ execFile = defaultExecFile, readFile = defaultReadFile, spawn = defaultSpawn, iosDevice = defaultIosDevice, udid = null, appId = null } = {}) {
     this._execFile = execFile;
@@ -40,19 +54,26 @@ class IosLauncher {
     return this;
   }
 
-  async launch(appId, appPath) {
+  async launch(appId, appPath, launchArgs) {
     await this.connect();
     if (appPath) {
       await this._exec(["devicectl", "device", "install", "app", "--device", this._udid, appPath]);
     }
     const tmpDir = await mkdtemp(join(tmpdir(), "devicectl-"));
     const jsonOut = join(tmpDir, "launch.json");
+    const argv = buildLaunchArgv(launchArgs);
+    // `--terminate-existing` forces a fresh JS runtime when launch args are
+    // present so the spec runner re-evaluates with the new NSUserDefaults
+    // values; otherwise devicectl delivers the args to the existing process.
+    const terminateFlags = argv.length > 0 ? ["--terminate-existing"] : [];
     try {
       await this._exec([
         "devicectl", "device", "process", "launch",
         "--json-output", jsonOut,
+        ...terminateFlags,
         "--device", this._udid,
-        appId
+        appId,
+        ...argv
       ]);
       const json = JSON.parse(await this._readFile(jsonOut, "utf-8"));
       this._pid = json.result.process.processIdentifier;

--- a/build-utils/IosSimulatorLauncher.js
+++ b/build-utils/IosSimulatorLauncher.js
@@ -1,5 +1,19 @@
 import { execFile as defaultExecFile, spawn as defaultSpawn } from "child_process";
 
+function buildLaunchArgv(launchArgs) {
+  if (!launchArgs) return [];
+  const argv = [];
+  for (const key of Object.keys(launchArgs)) {
+    const value = launchArgs[key];
+    if (typeof value === "boolean") {
+      argv.push(`-${key}`, value ? "true" : "false");
+    } else if (value !== undefined && value !== null) {
+      argv.push(`-${key}`, String(value));
+    }
+  }
+  return argv;
+}
+
 class IosSimulatorLauncher {
   constructor({ execFile = defaultExecFile, spawn = defaultSpawn, udid = null, logProcessName = "Waterbug(TitaniumKit)" } = {}) {
     this._execFile = execFile;
@@ -35,7 +49,7 @@ class IosSimulatorLauncher {
     return this;
   }
 
-  async launch(appId, appPath) {
+  async launch(appId, appPath, launchArgs) {
     await this.connect();
     // Generous timeouts: on a cold CI runner the first install/launch can take
     // 60-90s while CoreSimulator's lazy services (installd, FrontBoard, etc.)
@@ -43,13 +57,19 @@ class IosSimulatorLauncher {
     if (appPath) {
       await this._exec(["simctl", "install", this._udid, appPath], { timeout: 180000 });
     }
-    const launchArgs = ["simctl", "launch", this._udid, appId];
+    const argv = buildLaunchArgv(launchArgs);
+    // Match the Android `-S` behaviour — when launch args are present we
+    // want a fresh JS runtime so the spec runner re-evaluates with the new
+    // arguments rather than handing them to the running process's onNewIntent
+    // equivalent.
+    const terminateFlags = argv.length > 0 ? ["--terminate-running-process"] : [];
+    const simctlArgs = ["simctl", "launch", ...terminateFlags, this._udid, appId, ...argv];
     const MAX_ATTEMPTS = 3;
     let stdout;
     let lastErr = null;
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
       try {
-        stdout = await this._exec(launchArgs, { timeout: 180000 });
+        stdout = await this._exec(simctlArgs, { timeout: 180000 });
         lastErr = null;
         break;
       } catch (err) {

--- a/walta-app/app/spec/index.js
+++ b/walta-app/app/spec/index.js
@@ -3,7 +3,9 @@ var { setManualTests, isManualTests } = require('spec/util/TestUtils');
 
 // Runtime test config passed via launcher args:
 //   Android: intent extras (--es test_grep "…" --ez test_manual true)
-//   iOS:     NSUserDefaults-style argv (-test_grep … -test_manual true)
+//   iOS:     NSUserDefaults-style argv (-test_grep … -test_manual true),
+//            which iOS auto-merges into NSUserDefaults — read via
+//            Ti.App.Properties (backed by NSUserDefaults on iOS).
 // See build-utils/{AndroidLauncher,IosSimulatorLauncher}.js for the
 // producer side; Gruntfile.js `launch` task maps --grep / --manual
 // into the launchArgs payload.
@@ -18,11 +20,13 @@ function readTestConfig() {
         manual: intent.getBooleanExtra("test_manual", false),
       };
     }
-    var args = Ti.App.arguments || {};
-    return {
-      grep: args.test_grep || null,
-      manual: args.test_manual === 'true' || args.test_manual === true,
-    };
+    // iOS: argv `-test_grep About -test_manual true` is merged into
+    // NSUserDefaults on launch; Ti.App.Properties is our bridge to it.
+    // Values come back as strings regardless of the original type.
+    var grep = Ti.App.Properties.getString("test_grep") || null;
+    var manualRaw = Ti.App.Properties.getString("test_manual");
+    var manual = manualRaw === "true" || manualRaw === "1";
+    return { grep: grep, manual: manual };
   } catch (e) {
     Ti.API.warn("Could not read launch args for test config: " + e);
     return {};

--- a/walta-app/app/spec/index.js
+++ b/walta-app/app/spec/index.js
@@ -1,6 +1,36 @@
 var Mocha = require("spec/lib/ti-mocha");
 var { setManualTests, isManualTests } = require('spec/util/TestUtils');
 
+// Runtime test config passed via launcher args:
+//   Android: intent extras (--es test_grep "…" --ez test_manual true)
+//   iOS:     NSUserDefaults-style argv (-test_grep … -test_manual true)
+// See build-utils/{AndroidLauncher,IosSimulatorLauncher}.js for the
+// producer side; Gruntfile.js `launch` task maps --grep / --manual
+// into the launchArgs payload.
+function readTestConfig() {
+  try {
+    if (Ti.Platform.osname === 'android') {
+      var activity = Ti.Android.currentActivity;
+      var intent = activity && activity.intent;
+      if (!intent) return {};
+      return {
+        grep: intent.getStringExtra("test_grep") || null,
+        manual: intent.getBooleanExtra("test_manual", false),
+      };
+    }
+    var args = Ti.App.arguments || {};
+    return {
+      grep: args.test_grep || null,
+      manual: args.test_manual === 'true' || args.test_manual === true,
+    };
+  } catch (e) {
+    Ti.API.warn("Could not read launch args for test config: " + e);
+    return {};
+  }
+}
+
+var TEST_CONFIG = readTestConfig();
+
 var SPEC_FILES = [
   "About",
   "Help",
@@ -47,6 +77,10 @@ function runTests() {
     ui: 'bdd',
     reporter: 'ti-spec'
   });
+  if ( TEST_CONFIG.grep ) {
+    Ti.API.info(`Running only tests matching /${TEST_CONFIG.grep}/`);
+    mocha.grep(TEST_CONFIG.grep);
+  }
   if ( isManualTests() ) {
     mocha.timeout(0);
   } else {
@@ -66,7 +100,8 @@ function runTests() {
 var infinteLoopMode = false;
 
 // freeze each test to allow manual inspection - on Android use the menu option "Continue" to continue test.
-setManualTests( false );
+// Can be flipped at runtime via `--manual` on `grunt unit-test` (no rebuild needed).
+setManualTests( TEST_CONFIG.manual === true );
 
 // Prevent the screen from locking during test runs — if the device auto-locks
 // iOS classifies the app as background and the watchdog kills it within 10s.


### PR DESCRIPTION
## Summary

Adds two new options to `grunt unit-test` so you can focus a single test and keep its screen open on the device without rebuilding. Pairs with WB-36's LiveView fast loop.

```bash
npx grunt --platform=android --simulator --liveview --reuse-server \
  --grep=SyncFeedback --manual unit-test
```

Trello: [WB-37](https://trello.com/c/Qrnl33QU) • Stacked on **#200** (WB-36).

## What the options do

| Flag | Effect |
|---|---|
| `--grep=<pattern>` | Forwarded to `mocha.grep(…)`. Filters by fully-qualified describe/it name. |
| `--manual` | Enables `setManualTests(true)` + `mocha.timeout(0)`. Also skips `terminate:<platform>` so the screen stays up. |

## How it works (producer → consumer)

1. **Gruntfile `launch` task** reads `grunt.option('grep')` / `grunt.option('manual')` and builds a `launchArgs` object.
2. **Launchers** forward the args through to the platform-native launch command:
   - Android (`AndroidLauncher` + `AndroidEmulatorLauncher` passthrough): `am start -S --es test_grep … --ez test_manual true`. The `-S` flag force-stops the app first so the Titanium JS runtime re-initialises — without it, a running app only gets `onNewIntent` and `spec/index.js` doesn't re-run.
   - iOS (`IosSimulatorLauncher` + `IosLauncher`): NSUserDefaults-style argv after the bundle id (`-test_grep … -test_manual true`) plus `--terminate-running-process` / `--terminate-existing` for the same reason.
3. **`walta-app/app/spec/index.js`** reads intent extras (Android) or `Ti.App.arguments` (iOS) on startup and applies them to Mocha before running.

Existing `grunt unit-test` behaviour is unchanged when the options aren't passed — launchers short-circuit cleanly on an empty `launchArgs`.

## Verification

Ran end-to-end on the Android emulator:

```
Forwarding launch args to test runner: {"test_grep":"About","test_manual":true}
...
Running only tests matching /About/
  About controller
    + should display the About view
  1 passing (1265ms)
  UNIT_TESTS_PASSED
```

Only the About controller spec ran, grunt skipped `terminate:android`, and the About view stayed visible on the emulator.

## Test plan

- [x] `npx grunt build-test-android` — 30 passing (+1 AndroidEmulatorLauncher passthrough, +4 AndroidLauncher intent-extra cases).
- [x] `npx grunt build-test-ios` — 40 passing (+3 IosSimulatorLauncher argv cases, +1 IosLauncher `--terminate-existing`).
- [x] Android emulator end-to-end: `--grep=About --manual` filters + leaves window open.
- [ ] iOS simulator end-to-end — I don't have one booted locally; added the spec coverage but a physical verify is outstanding.

## Stacked PR note

This PR's base is `task/wb-36-pin-vite-to-4x` (PR #200). Once WB-36 merges, I'll re-target to `main` for a clean diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)