### PR TITLE
WB-44: SampleHistory: move Sync Now into the anchor bar toolbar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,14 @@ adb logcat -s "TiAPI:*"   # Android
 - `features/` — Cucumber BDD acceptance tests
 - `end-to-end-testing/` — Appium integration tests
 
+### Documentation maintenance
+
+The `docs/` folder holds pattern references that this CLAUDE.md links to. **When you rediscover something** — a non-obvious pattern, a gotcha that bit you, a convention that wasn't clear from reading existing code — add it to the relevant doc (or create a new one and link it from here). Aim short and specific: a one-liner with a code example beats a paragraph. The test for "is this worth writing down?" is *would the next session save time if it could find this?*
+
+Existing pattern docs:
+- [docs/toolbar-buttons.md](docs/toolbar-buttons.md) — anchor bar / NavButton pattern
+- [docs/device-specs.md](docs/device-specs.md) — device spec idioms, child-controller refs, test pollution
+
 ### Patterns & Conventions
 
 **Controller communication:** Controllers communicate via `Topics` (a pub/sub event bus over Ti's global event system — see `lib/ui/Topics.js`). Use `Topics.fireTopicEvent(Topics.SOME_EVENT, payload)` to publish and `Topics.subscribe(Topics.SOME_EVENT, handler)` to listen. Direct function calls are used within a controller; Topics are used across controllers.
@@ -153,6 +161,8 @@ adb logcat -s "TiAPI:*"   # Android
 **Photo paths:** Photos taken by users are stored in `Ti.Filesystem.applicationDataDirectory` using relative paths (no leading `/`). Taxonomy reference images are in `Ti.Filesystem.resourcesDirectory` (absolute paths starting `/`). `PhotoUtils.absolutePath()` handles both conventions.
 
 **Ti.App.Properties keys:** Persistent storage uses `Ti.App.Properties.setObject/getObject`. Key names in use: `userAccessTokenLive` (user auth token object), `appAccessTokenLive` (app-level OAuth token object), `userAccessUsername` (logged-in email).
+
+**Toolbar buttons:** Screen-level action buttons (Back, Next, Done, Sync, etc.) belong on the anchor bar, not in the screen body. Pattern: `getAnchorBar().addTool(Alloy.createController("NavButton").getView())`. See [docs/toolbar-buttons.md](docs/toolbar-buttons.md) for the full pattern, accessibilityLabel semantics, and the Appium selector convention.
 
 ### Configuration & Environment
 
@@ -177,6 +187,12 @@ There are four levels of tests:
 2. **Device unit tests** (`walta-app/app/spec/`) — run on device via Titanium; required when code uses `Ti.*` APIs that cannot be mocked
 3. **End-to-end tests** (`end-to-end-testing/`) — Appium-driven
 4. **Acceptance/BDD tests** (`features/`) — Cucumber + WebdriverIO (Appium), uses `@only` tag to filter
+
+**Acceptance test environment:** The local dev environment is already provisioned — emulator/simulator, Appium drivers, and the mock CERDI server are configured and ready. Run acceptance tests directly (`npx grunt --platform=android acceptance-test`); don't gate on or caveat about setup.
+
+**Acceptance coverage does not replace device specs.** Every screen-level feature must have a device spec in `walta-app/app/spec/` even if an acceptance test covers the same path. Rationale: acceptance tests are slow integration tests — a single run takes minutes — so they're unsuitable for the tight TDD loop. Device specs run quickly with `--liveview --reuse-server` (see `fast-device-test`), give per-screen test checklists for future work, and pinpoint failures at the controller level rather than at the end of an end-to-end flow. When adding/modifying a screen feature, default to a device spec; add an acceptance scenario only for cross-screen flows.
+
+**Device spec idioms:** [docs/device-specs.md](docs/device-specs.md) covers the things that aren't obvious from reading existing specs — `TestUtils` helpers, how to reach inner views of child controllers (`ctl.childCtl.NavButton.fireEvent("click")`), test pollution between specs (Topics subscribers, `Alloy.Globals.CerdiApi`, `SyncStore` singleton), and `--manual` mode considerations. Read this before adding a new device spec.
 
 **Mocking `Ti.*` in Node.js tests:** The Node.js environment has no Titanium runtime. Mock `Ti.Network.createHTTPClient` by injecting a fake via the module's `ProxyCreateHTTPClient` export — see `test/CerdiApi_spec.js` for the canonical pattern. `mocha-bootstrap.js` is only loaded for on-device tests; do not include it in Node tests.
 

--- a/docs/device-specs.md
+++ b/docs/device-specs.md
@@ -1,0 +1,80 @@
+# Device Spec Idioms
+
+Device specs (`walta-app/app/spec/*_spec.js`) run on a real or simulated device via the Titanium runtime. Use them when you need real `Ti.*` APIs, real Alloy controller construction, or a quick controller-level smoke test that's faster than acceptance.
+
+## Stack
+
+- Test runner: **mocha** via `spec/lib/ti-mocha`
+- Assertions: **chai 4.x** via `spec/lib/chai` — pinned at 4.x because chai 6 is ESM-only and breaks the device runner ([memory note](../README.md))
+- Mocking: **simple-mock** via `spec/lib/simple-mock`
+
+## Running
+
+```bash
+# Fastest loop (LiveView reuses the dev server across runs)
+npx grunt --platform=android --simulator --liveview --reuse-server unit-test
+
+# Filter to one describe block by adding .only in the spec file:
+describe.only("My test", function() { ... });
+```
+
+See also the `fast-device-test` skill.
+
+## TestUtils helpers
+
+From `walta-app/app/spec/util/TestUtils.js` — the ones worth knowing:
+
+| Helper | When to use |
+|--------|-------------|
+| `clearDatabase()` | `beforeEach` — wipes the samples + taxa tables and resets `Alloy.Models` / `Alloy.Collections` |
+| `controllerOpenTest(ctl)` | Open a controller and await its `postlayout` event — returns a Promise |
+| `closeWindow(win, done)` | `afterEach` — closes a window and resolves on the `close` event. Honors `--manual` mode (won't auto-close so a human can drive the UI) |
+| `actionFiresTopicTest(actionObj, evtName, topic)` | Fire `evtName` on `actionObj`, assert `topic` is published, return the topic payload |
+| `wrapViewInWindow(view)` | Wrap a bare view in a window so it can be opened |
+| `makeTestPhoto(name)` | Copy `site-mock.jpg` into `applicationDataDirectory` and return its path |
+
+## Asserting against child controllers
+
+When a parent controller embeds a child via `Alloy.createController("Foo")` and assigns it to `$.thing`, the child's `$`-namespaced views are reachable from the parent test:
+
+```js
+ctl.syncButton                  // the child controller object
+ctl.syncButton.NavButton        // the child's root view (Alloy convention: $.<ControllerName>)
+ctl.syncButton.label            // an inner view by id (e.g. <Label id="label"/>)
+ctl.syncButton.button.enabled   // properties of inner views
+ctl.syncButton.NavButton.fireEvent("click")  // simulate a tap
+```
+
+`getView()` on the child returns the root view — same as `child.<ControllerName>`. Use whichever reads better in context; both appear in existing specs.
+
+## Common gotchas
+
+### Test pollution
+
+Module-level state leaks across specs because Titanium loads modules once per test session:
+
+- **Topics subscribers** — a controller that subscribes in its top-level (e.g. `Topics.subscribe(Topics.LOGGEDIN, ...)`) can leave the listener registered after the test that created it tears down. Later specs that fire the same topic will trigger that listener.
+- **`Alloy.Globals.CerdiApi`** — different specs assign different mocks (some use `MockCerdiApi`, some build a real `createCerdiApi(...)`). Whatever ran last wins. If your spec calls into a code path that uses `Alloy.Globals.CerdiApi`, mock the methods you need explicitly — don't rely on what's already there.
+- **`SyncStore` singleton** — `lib/logic/SampleSync.js` holds a module-level `var syncStore = new SyncStore()`. State persists across tests. The SyncFeedback spec has a known issue where prior runs leave `status === "complete"`.
+- **Module-level `isSyncing` flag** in `SampleSync` — if a previous test left a sync mid-flight, subsequent `startSynchronise` calls early-return.
+
+When in doubt, mock the leaf functions your code path will actually hit (`retrieveUserToken`, `forceUpload`, etc.) rather than trying to clean up upstream state.
+
+### `--manual` mode
+
+`closeWindow` deliberately does not auto-close the window when `--manual` is set, so a human can poke at the UI. Spec teardown that runs synchronous cleanup *before* the close handler fires can dead-lock the screen. Pattern:
+
+```js
+afterEach(async () => {
+  await closeWindow(ctl.getView());  // wait for actual close
+  ctl.cleanUp?.();                   // then dispose
+});
+```
+
+### `mocha-bootstrap.js` is device-only
+
+Don't `require` it from Node.js specs — Node specs use Mocha directly and don't load Titanium globals.
+
+## Mocking `Ti.*` in Node specs
+
+Node specs (`test/*_spec.js`) have no Titanium runtime. Mock `Ti.Network.createHTTPClient` by injecting a fake via the module's `ProxyCreateHTTPClient` export — see `test/CerdiApi_spec.js` for the canonical pattern.

--- a/docs/toolbar-buttons.md
+++ b/docs/toolbar-buttons.md
@@ -1,0 +1,40 @@
+# Toolbar (Anchor Bar) Buttons
+
+Screens that extend `TopLevelWindow` get an **anchor bar** at the top — a header strip with a title and slots for left/right tools. This is the standard place for nav and screen-level action buttons (Back, Next, Done, Sync). Don't put action buttons in the screen body if they belong on the toolbar.
+
+## Adding a button
+
+The base `TopLevelWindow` controller exposes `getAnchorBar()`. From a screen controller:
+
+```js
+var acb = $.getAnchorBar();
+$.syncButton = Alloy.createController("NavButton");
+$.syncButton.setLabel("Sync");
+$.syncButton.on("click", syncNowClicked);
+acb.addTool( $.syncButton.getView() );
+```
+
+Then in the window's `cleanUp` listener, call `$.syncButton.cleanUp();` so the inner click listener is removed.
+
+`addTool(view)` appends to the right tool slot by default. Pass `addTool(view, true)` to put it on the left.
+
+## Built-in button controllers
+
+- **`NavButton`** — generic right-side button. `setLabel(text)`, `enable()`, `disable()`, `setIconLeft(img)`, `setIconRight(img)`. Fires `"click"` on its `$` controller.
+- **`GoBackButton`** — back button that fires a Topic when clicked. Constructed with `{ topic, slide, readonly }`.
+- **`GoForwardButton`** — forward equivalent.
+
+Examples in [walta-app/app/controllers/Summary.js:16-27](../walta-app/app/controllers/Summary.js#L16-L27), [walta-app/app/controllers/Habitat.js](../walta-app/app/controllers/Habitat.js), [walta-app/app/controllers/SiteDetails.js](../walta-app/app/controllers/SiteDetails.js).
+
+## Label vs accessibilityLabel
+
+`NavButton.setLabel(s)` does two things:
+
+- Sets visible text to `s.toUpperCase()` ("Sync" → "SYNC")
+- Sets `accessibilityLabel` to `s` unchanged ("Sync")
+
+Acceptance/spec tests select by accessibility identifier, so they match the original-case string. Don't write `this.click("SYNC")` — write `this.click("Sync")`.
+
+## Selector convention (Appium)
+
+The acceptance-test base screen wraps selectors as `~<label>.` — Titanium appends a period to its accessibility identifiers, which discriminates explicitly-set `accessibilityLabel` values from iOS auto-derived labels (e.g. a `<Label text="Sync"/>` body label without `accessibilityLabel` won't match `~Sync.`). See [features/support/base-screen.js:53-56](../features/support/base-screen.js#L53-L56).

--- a/features/support/archive-screen.js
+++ b/features/support/archive-screen.js
@@ -40,7 +40,7 @@ class ArchiveScreen extends BaseScreen {
     }
 
     async clickSyncNow() {
-        await this.click("Synchronise samples now");
+        await this.click("Sync");
         await this.world.syncFeedback.waitFor();
     }
 }

--- a/walta-app/app/controllers/SampleHistory.js
+++ b/walta-app/app/controllers/SampleHistory.js
@@ -5,12 +5,19 @@ var SampleSync = require('logic/SampleSync');
 exports.baseController  = "TopLevelWindow";
 $.TopLevelWindow.title = "Survey History";
 
+var acb = $.getAnchorBar();
+$.syncButton = Alloy.createController("NavButton");
+$.syncButton.setLabel("Sync");
+$.syncButton.on("click", syncNowClicked);
+acb.addTool( $.syncButton.getView() );
+
 Topics.subscribe( Topics.UPLOAD_PROGRESS, updateSampleList );
 $.TopLevelWindow.addEventListener('close', function cleanUp() {
     if ( $.sampleMenu ) {
         $.sampleMenu.cleanUp();
     }
     closeSyncFeedback();
+    $.syncButton.cleanUp();
     $.destroy();
     $.off();
 	$.TopLevelWindow.removeEventListener('close', cleanUp );

--- a/walta-app/app/spec/SampleHistory_spec.js
+++ b/walta-app/app/spec/SampleHistory_spec.js
@@ -5,25 +5,26 @@ var { expect } = require("spec/lib/chai");
 var { makeSampleData } = require("spec/fixtures/SampleData_fixture");
 var { clearDatabase, closeWindow, controllerOpenTest, actionFiresTopicTest } = require("spec/util/TestUtils");
 var moment = require("lib/moment");
+var SampleSync = require('logic/SampleSync');
 
 describe("SampleHistory controller", function() {
 	var ctl;
 	beforeEach( function() {
-    clearDatabase(); 
+    clearDatabase();
     makeSampleData({ serverSampleId: 666, dateCompleted: moment("2021-06-21T20:23").format() }).save();
     makeSampleData({ serverSampleId: 667, dateCompleted: moment("2021-06-21T22:23").format() }).save();
     makeSampleData({ serverSampleId: 668, dateCompleted: moment("2021-06-21T23:23").format() }).save();
     simple.mock(Alloy.Globals.CerdiApi,"retrieveUserId")
       .returnWith(38);
 		ctl = Alloy.createController("SampleHistory");
-    
+
 	});
 	afterEach( function(done) {
     closeWindow( ctl.getView(), done );
     simple.restore();
 	});
 	it('should display the SampleHistory view', async function() {
-    
+
 		await controllerOpenTest( ctl );
   });
   it('selecting row should open menu', async function() {
@@ -37,12 +38,25 @@ describe("SampleHistory controller", function() {
     let result = await actionFiresTopicTest( ctl.sampleMenu.view.getView(), "click", Topics.SITEDETAILS );
     expect( result.readonly ).to.be.true;
 
-  }); 
+  });
   it('selecting edit should raise edit event', async function() {
     await controllerOpenTest( ctl );
     ctl.sampleTable.fireEvent("click", { index: 0 } );
     let result = await actionFiresTopicTest( ctl.sampleMenu.edit.getView(), "click", Topics.SITEDETAILS );
     expect( result.readonly ).to.be.false;
+  });
+  it('places a Sync button on the anchor bar toolbar', async function() {
+    await controllerOpenTest( ctl );
+    expect( ctl.syncButton ).to.exist;
+    expect( ctl.syncButton.label.text ).to.equal("SYNC");
+    expect( ctl.syncButton.label.accessibilityLabel ).to.equal("Sync");
+  });
+  it('clicking the Sync button opens the SyncFeedback popup', async function() {
+    Alloy.Globals.CerdiApi.retrieveUserToken = function() { return null; };
+    simple.mock(SampleSync, "forceUpload");
+    await controllerOpenTest( ctl );
+    ctl.syncButton.NavButton.fireEvent("click");
+    expect( ctl.syncFeedback ).to.exist;
   });
 
 });

--- a/walta-app/app/styles/SampleHistory.tss
+++ b/walta-app/app/styles/SampleHistory.tss
@@ -41,24 +41,3 @@
     textAlign: Ti.UI.TEXT_ALIGNMENT_LEFT,
     width: "35%"
 }
-".actionRow": {
-    height: "48dp",
-    width: Ti.UI.FILL,
-    layout: "horizontal",
-    horizontalWrap: false
-}
-".syncNowButton": {
-    right: "12dp",
-    top: "6dp",
-    height: "36dp",
-    width: Ti.UI.SIZE,
-    color: "#ffffff",
-    backgroundColor: "#26849c",
-    borderColor: "#26849c",
-    borderWidth: "1dp",
-    borderRadius: "4dp",
-    font: {
-        fontFamily: "sans-serif",
-        fontSize: "14dp"
-    }
-}

--- a/walta-app/app/views/SampleHistory.xml
+++ b/walta-app/app/views/SampleHistory.xml
@@ -1,9 +1,6 @@
 <Alloy>
 	<Collection src="sample" instance="true" id="samples" />
 	<View id="content" layout="vertical">
-		<View class="actionRow">
-			<Button id="syncNowButton" class="syncNowButton" onClick="syncNowClicked" accessibilityLabel="Synchronise samples now">Sync Now</Button>
-		</View>
 		<View  class="headerRow">
 			<Label class="idColumn column" text="Id"/>
 			<Label class="dateCompletedColumn column" text="Date Submitted"/>

--- a/walta.code-workspace
+++ b/walta.code-workspace
@@ -2,9 +2,6 @@
 	"folders": [
 		{
 			"path": "."
-		},
-		{
-			"path": "../liveview"
 		}
 	],
 	"settings": {


### PR DESCRIPTION
## Summary

- Renames the "Sync Now" button to "Sync" and moves it from the in-content `actionRow` into the SampleHistory anchor bar toolbar via `NavButton` + `getAnchorBar().addTool`, matching the Summary/Habitat/SiteDetails pattern.
- Updates the acceptance-test selector ([features/support/archive-screen.js](features/support/archive-screen.js)) and adds two device specs covering toolbar placement and click-opens-popup.
- Adds [docs/toolbar-buttons.md](docs/toolbar-buttons.md) and [docs/device-specs.md](docs/device-specs.md) capturing patterns rediscovered during this task; [CLAUDE.md](CLAUDE.md) now links them and asks future sessions to extend the docs when they hit something undocumented.

Trello: https://trello.com/c/as1nBbXh

## Test plan

- [x] Node unit tests: `npx grunt unit-test-node` — 86/86 passing
- [x] Android device unit tests: 305 passing (was 303 on main; +2 new SampleHistory tests). The pre-existing `SyncFeedback › renders the initial view without errors` failure is unchanged — it exists on main too. CI does not currently gate on this failure.
- [ ] Android emulator acceptance tests (`submit_sample.feature`) — to be verified by CI
- [ ] iOS simulator unit tests — to be verified by CI
- [ ] iOS simulator acceptance tests — to be verified by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)