### PR TITLE
WB-50: cache node_modules/.cache/appium between CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,6 +527,19 @@ jobs:
         if: steps.wda-cache.outputs.cache-hit != 'true'
         run: bash build-utils/prebuild-wda.sh
 
+      # Appium creates `node_modules/.cache/appium` on first start to hold
+      # driver-hash files; caching it across runs avoids re-doing that
+      # work and shaves driver-load time off every acceptance run.
+      # Keyed on package-lock.json so dependency upgrades bust the cache.
+      # See WB-50.
+      - name: Cache Appium driver hashes
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache/appium
+          key: appium-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            appium-cache-${{ runner.os }}-
+
       - name: Acceptance preflight (Appium launcher integration test)
         env:
           SIM_UDID: ${{ steps.sim.outputs.udid }}
@@ -685,6 +698,19 @@ jobs:
             ~/.android/adb*
             /usr/local/lib/android/sdk/system-images/android-30
           key: avd-30-google_apis-x86
+
+      # Appium creates `node_modules/.cache/appium` on first start to hold
+      # driver-hash files; caching it across runs avoids re-doing that
+      # work and shaves driver-load time off every acceptance run.
+      # Keyed on package-lock.json so dependency upgrades bust the cache.
+      # See WB-50.
+      - name: Cache Appium driver hashes
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache/appium
+          key: appium-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            appium-cache-${{ runner.os }}-
 
       - name: Boot Android emulator and run acceptance tests
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
## Summary

Caches `node_modules/.cache/appium` between CI runs so subsequent runs skip the driver-hash directory setup that Appium does on first start. Steady-state speedup; complements (does not replace) the server-startup-timeout fix in #207.

Trello: https://trello.com/c/5STpV8Ak

## Caveats

This does **not** fix the [WB-49](https://trello.com/c/fg6XvpJ4) preflight timeout failure — the slow phase on macOS-15 runners happens *before* Appium reaches the cache-creating step (the 8min pre-emit gap is `npx`/Appium startup overhead, not driver-hash work). #207 is the actual fix; this is purely a follow-up speedup.

## Cache key

`appium-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}` with restore-key fallback to `appium-cache-${{ runner.os }}-`. Per-OS so Linux and macOS hash dirs don't collide, busted on any package-lock change.

## Test plan

- [ ] First CI run after merge: cache miss (creates the cache)
- [ ] Second CI run: cache hit; driver-load timings should drop on the iOS preflight log
- [ ] Cache invalidates correctly when an appium-related dependency in package-lock.json changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)