### PR TITLE
WB-25: runtime unit-test flag — bundle both entry points and dispatch at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,9 +52,6 @@ walta-app/modules/iphone/ti.map
 walta-app/modules/android/ti.map
 walta-app/modules/android/ti.playservices
 
-# Generated symlink (created by install.sh, overwritten by unittest plugin at build time)
-walta-app/app/controllers/index.js
-
 # Generated test libs (webpack + install.sh)
 walta-app/app/spec/lib/chai.js
 walta-app/app/spec/lib/chai.js.map

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -676,6 +676,13 @@ const KobitonAPI = require("./features/support/kobiton");
       const grep = grunt.option('grep');
       if (grep) launchArgs.test_grep = grep;
       if (grunt.option('manual')) launchArgs.test_manual = true;
+      // WB-25: the index.js dispatcher reads `unit_test` to choose between
+      // the real app and the on-device test runner. Set it whenever we're
+      // launching the unit-test build path so the dispatcher routes to
+      // UnitTest.js.
+      if (buildType === 'unit-test' || buildType === 'unit-test-liveview') {
+        launchArgs.unit_test = true;
+      }
       const hasLaunchArgs = Object.keys(launchArgs).length > 0;
       if (hasLaunchArgs) {
         grunt.log.writeln(`Forwarding launch args to test runner: ${JSON.stringify(launchArgs)}`);

--- a/build-tests/unit/unittest_spec.js
+++ b/build-tests/unit/unittest_spec.js
@@ -63,15 +63,18 @@ describe("unittest hook", function () {
             });
         });
 
-        it("should symlink index.js to index-app.js when --unit-test is not set", function (done) {
-            cli.argv["unit-test"] = false;
+        it("does not manage app/controllers/index.js — it is a real dispatcher file (WB-25)", function (done) {
+            cli.argv["unit-test"] = true;
             preCompile({}, function () {
-                expect(fs.symlinkSync.calledWith('index-app.js', `${projectDir}/app/controllers/index.js`)).to.be.true;
+                const indexPath = `${projectDir}/app/controllers/index.js`;
+                expect(fs.symlinkSync.calledWith('UnitTest.js', indexPath)).to.be.false;
+                expect(fs.symlinkSync.calledWith('index-app.js', indexPath)).to.be.false;
+                expect(fs.unlinkSync.calledWith(indexPath)).to.be.false;
                 done();
             });
         });
 
-        it("should remove any existing symlink before creating a new one", function (done) {
+        it("should remove any existing spec symlink before creating a new one", function (done) {
             cli.argv["unit-test"] = true;
             preCompile({}, function () {
                 expect(fs.unlinkSync.calledWith(`${projectDir}/app/lib/spec`)).to.be.true;
@@ -80,7 +83,7 @@ describe("unittest hook", function () {
             });
         });
 
-        it("should remove existing symlink on normal builds to keep specs out", function (done) {
+        it("should remove existing spec symlink on normal builds to keep specs out", function (done) {
             cli.argv["unit-test"] = false;
             preCompile({}, function () {
                 expect(fs.unlinkSync.calledWith(`${projectDir}/app/lib/spec`)).to.be.true;

--- a/install.sh
+++ b/install.sh
@@ -11,12 +11,6 @@ sed "s/GOOGLE_MAPS_API_KEY_PLACEHOLDER/$GOOGLE_MAPS_API_KEY/" \
   walta-app/tiapp.xml.template > walta-app/tiapp.xml
 echo "tiapp.xml generated from template."
 
-# Create default index.js symlink if missing (build plugin overwrites for unit-test builds)
-if [ ! -e walta-app/app/controllers/index.js ]; then
-  ln -s index-app.js walta-app/app/controllers/index.js
-  echo "Symlinked controllers/index.js -> index-app.js"
-fi
-
 # Seed app-config.test.json from template if missing. Gitignored —
 # the user fills in cerdiApiSecret from 1Password (see
 # INSTALLATION.md). Used by debug + acceptance/unit-test builds

--- a/plugins/unittest/1.0/hooks/unittest.js
+++ b/plugins/unittest/1.0/hooks/unittest.js
@@ -46,11 +46,11 @@ exports.init = function (_logger, _config, cli) {
 			fs.symlinkSync('../spec', specSymlink);
 		}
 
-		const indexSymlink = join(cli.argv['project-dir'], 'app', 'controllers', 'index.js');
-		try { fs.unlinkSync(indexSymlink); } catch(e) {}
-		const indexTarget = isUnitTest ? 'UnitTest.js' : 'index-app.js';
-		debug(`Symlinking app/controllers/index.js -> ${indexTarget}`);
-		fs.symlinkSync(indexTarget, indexSymlink);
+		// Note (WB-25): app/controllers/index.js used to be symlinked here
+		// to either UnitTest.js or index-app.js based on --unit-test. It's
+		// now a real dispatcher file that picks at runtime, so the symlink
+		// management has been removed. Both entry points are bundled in
+		// dev/CI builds and the launch arg `unit_test` selects between them.
 
 		// Swap the Camera wrapper for simulator builds. Using a file copy
 		// rather than a symlink because Alloy's Resource copy step chokes on

--- a/test/RuntimeMode_spec.js
+++ b/test/RuntimeMode_spec.js
@@ -1,0 +1,92 @@
+var { expect } = require("chai");
+var RuntimeMode = require("../walta-app/app/lib/util/RuntimeMode");
+
+// `app/lib/util/RuntimeMode.js` reads its launch-arg signal off the
+// global `Ti` runtime, but to keep the helper unit-testable in node we
+// pass `Ti` in as an argument. The dispatcher in `app/controllers/index.js`
+// is the only place that hands it the real `Ti`.
+
+function fakeAndroidTi(extras) {
+    return {
+        Platform: { osname: "android" },
+        Android: {
+            currentActivity: {
+                intent: {
+                    getBooleanExtra: function (key, fallback) {
+                        return key in extras ? extras[key] : fallback;
+                    },
+                },
+            },
+        },
+    };
+}
+
+function fakeIosTi(properties) {
+    return {
+        Platform: { osname: "iphone" },
+        App: {
+            Properties: {
+                getString: function (key) {
+                    return key in properties ? properties[key] : null;
+                },
+            },
+        },
+    };
+}
+
+describe("RuntimeMode.isUnitTestRun", function () {
+    describe("Android", function () {
+        it("returns true when the unit_test intent extra is true", function () {
+            const ti = fakeAndroidTi({ unit_test: true });
+            expect(RuntimeMode.isUnitTestRun(ti)).to.be.true;
+        });
+
+        it("returns false when the unit_test intent extra is false", function () {
+            const ti = fakeAndroidTi({ unit_test: false });
+            expect(RuntimeMode.isUnitTestRun(ti)).to.be.false;
+        });
+
+        it("returns false when the intent has no unit_test extra", function () {
+            const ti = fakeAndroidTi({});
+            expect(RuntimeMode.isUnitTestRun(ti)).to.be.false;
+        });
+
+        it("returns false when there is no current activity", function () {
+            const ti = { Platform: { osname: "android" }, Android: { currentActivity: null } };
+            expect(RuntimeMode.isUnitTestRun(ti)).to.be.false;
+        });
+    });
+
+    describe("iOS", function () {
+        it("returns true when Ti.App.Properties returns 'true' for unit_test", function () {
+            const ti = fakeIosTi({ unit_test: "true" });
+            expect(RuntimeMode.isUnitTestRun(ti)).to.be.true;
+        });
+
+        it("returns true when Ti.App.Properties returns '1' for unit_test", function () {
+            // iOS argv merging into NSUserDefaults coerces booleans to "1" sometimes.
+            const ti = fakeIosTi({ unit_test: "1" });
+            expect(RuntimeMode.isUnitTestRun(ti)).to.be.true;
+        });
+
+        it("returns false when Ti.App.Properties returns null", function () {
+            const ti = fakeIosTi({});
+            expect(RuntimeMode.isUnitTestRun(ti)).to.be.false;
+        });
+
+        it("returns false when Ti.App.Properties returns 'false'", function () {
+            const ti = fakeIosTi({ unit_test: "false" });
+            expect(RuntimeMode.isUnitTestRun(ti)).to.be.false;
+        });
+    });
+
+    describe("error handling", function () {
+        it("returns false (defensive) when Ti throws unexpectedly", function () {
+            const ti = {
+                Platform: { osname: "android" },
+                Android: { get currentActivity() { throw new Error("boom"); } },
+            };
+            expect(RuntimeMode.isUnitTestRun(ti)).to.be.false;
+        });
+    });
+});

--- a/walta-app/.gitignore
+++ b/walta-app/.gitignore
@@ -12,5 +12,4 @@ tmp
 .settings
 Thumbs.db
 app/lib/spec
-app/controllers/index.js
 tiapp.xml

--- a/walta-app/app/controllers/index.js
+++ b/walta-app/app/controllers/index.js
@@ -1,0 +1,17 @@
+// Entry-point dispatcher. The real app and the on-device test runner
+// are both bundled into every dev/CI build; this file picks one at
+// startup based on a runtime launch arg. See WB-25.
+//
+// - Production launch (no flag): `index-app` — the user-facing app.
+// - Test launch (`-unit_test true` on iOS / `--ez unit_test true` on
+//   Android): `UnitTest` — the on-device mocha runner.
+//
+// `Ti` is read here and handed to RuntimeMode so the helper itself
+// stays node-testable.
+var RuntimeMode = require("util/RuntimeMode");
+
+if (RuntimeMode.isUnitTestRun(Ti)) {
+    Alloy.createController("UnitTest");
+} else {
+    Alloy.createController("index-app");
+}

--- a/walta-app/app/lib/util/RuntimeMode.js
+++ b/walta-app/app/lib/util/RuntimeMode.js
@@ -1,0 +1,24 @@
+// Reads runtime launch arguments to decide which entry point the
+// dispatcher in `app/controllers/index.js` should hand off to. See
+// WB-25.
+//
+// `ti` is injected so the helper is unit-testable in node — the
+// dispatcher passes the global `Ti` at call time. Launch-arg
+// conventions mirror those used by `app/spec/index.js` for
+// `test_grep` / `test_manual` (Android intent extras, iOS argv
+// merged into NSUserDefaults via Ti.App.Properties).
+
+function isUnitTestRun(ti) {
+    try {
+        if (ti.Platform.osname === "android") {
+            var intent = ti.Android.currentActivity && ti.Android.currentActivity.intent;
+            return !!(intent && intent.getBooleanExtra("unit_test", false));
+        }
+        var raw = ti.App.Properties.getString("unit_test");
+        return raw === "true" || raw === "1";
+    } catch (e) {
+        return false;
+    }
+}
+
+exports.isUnitTestRun = isUnitTestRun;


### PR DESCRIPTION
## Summary

Replaces the build-time `app/controllers/index.js` symlink dance with a runtime dispatcher. Both `index-app.js` (real app) and `UnitTest.js` (mocha runner) are now bundled into every dev/CI build, and the new `index.js` reads the `unit_test` launch arg to pick which one runs.

Trello: https://trello.com/c/SqETB10A

## Motivations

1. **Local iteration win** (the bigger one): switching between "run the app" and "run device specs" no longer needs a Titanium rebuild. Relaunch the same `.app` with or without `unit_test=true`. Combined with `--liveview --reuse-server` this extends LiveView's fast-iteration to mode switches, not just JS edits.
2. **CI prerequisite for [WB-51](https://trello.com/c/ca3fYG8b)**: with both entry points sharing a binary, the iOS unit-test and acceptance jobs can eventually share a single `Waterbug.app` artifact (~5 min/run iOS savings). WB-51 picks that up.

## What's in this PR

| File | Change |
|------|--------|
| `walta-app/app/lib/util/RuntimeMode.js` | new — pure helper that reads `unit_test` launch arg from injected `Ti` (Android intent extra / iOS `Ti.App.Properties`). Node-testable. |
| `test/RuntimeMode_spec.js` | new — 9 node unit tests (Android, iOS, error path) |
| `walta-app/app/controllers/index.js` | new (was plugin-managed symlink) — real dispatcher, picks entry point at startup via `Alloy.createController(...)` |
| `plugins/unittest/1.0/hooks/unittest.js` | drops the `index.js` symlink management; spec symlink + Camera swap unchanged |
| `build-tests/unit/unittest_spec.js` | mirrors the plugin change (asserts plugin no longer touches `index.js`) |
| `Gruntfile.js` | `launch:<platform>:unit-test[-liveview]` adds `unit_test: true` to launchArgs |
| `install.sh` | drops the default-symlink fallback (`index.js` is now a tracked source file) |
| `.gitignore` / `walta-app/.gitignore` | un-ignore `walta-app/app/controllers/index.js` |

## Test plan

- [x] `npx grunt unit-test-node` — 95/95 passing (was 86, +9 from RuntimeMode tests)
- [x] Plugin/launcher unit tests — 58/58 passing
- [ ] Verify a regular debug build still launches the real app on simulator
- [ ] Verify a unit-test build still runs the on-device mocha suite (CI Android + iOS)
- [ ] Verify launching the same `.app` with `unit_test=true` runs specs without rebuilding (the local-dev win — easiest to demo on Android: `adb shell am start -W -S -n net.thewaterbug.waterbug/.WaterbugActivity --ez unit_test true`)

## Out of scope (separate cards)

- [WB-51](https://trello.com/c/ca3fYG8b): split iOS acceptance into "build" and "test" jobs and share `Waterbug.app` via workflow artifact.
- [WB-52](https://trello.com/c/CdwkmbsI): drop the iOS acceptance preflight after 5 consecutive green main runs.

The build-time `--unit-test` flag is kept for now — still gates the spec symlink. Stripping test code from release builds is a separate concern not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)