### PR TITLE
WB-53: GPS step — continuous broadcaster instead of racing with listener attach

### DIFF
--- a/features/step_definitions/gps_steps.js
+++ b/features/step_definitions/gps_steps.js
@@ -1,22 +1,64 @@
 'use strict';
-const { Given } = require('@cucumber/cucumber');
+const { Given, After } = require('@cucumber/cucumber');
 
-// Melbourne CBD — arbitrary but plausible. Sample form requires a GPS
-// lock before Done is enabled, so any scenario that taps Done needs
-// this step before SiteDetails opens (Ti.Geolocation starts listening
-// when SiteDetails opens; the emulator broadcasts its current fix to
-// the new listener within ~1s of attach).
+// Melbourne CBD — arbitrary but plausible. The sample form requires a
+// GPS lock before Done is enabled, so any scenario that taps Done
+// needs this step.
 const TEST_LAT = -37.8136;
 const TEST_LNG = 144.9631;
 
-// Sets a GPS fix at a stable test location and re-broadcasts a few
-// times to ensure the app's Ti.Geolocation listener — which only
-// attaches when SiteDetails opens later in the scenario — catches an
-// event regardless of the relative timing of "set" vs "attach".
-Given('the GPS has a fix', {timeout: 10000}, async function () {
-    for (let i = 0; i < 4; i++) {
-        try { await global.launcher.setLocation(TEST_LAT, TEST_LNG); }
-        catch (_) { /* best-effort */ }
-        await new Promise(r => setTimeout(r, 500));
-    }
+// 1Hz mirrors a real GPS unit's update rate closely enough; iOS
+// listeners that attach mid-scenario catch the next broadcast within
+// a second.
+const BROADCAST_INTERVAL_MS = 1000;
+
+// Drives the simulator GPS as if it were a real GPS unit: continuous
+// broadcasts at ~1Hz for the lifetime of the scenario. This decouples
+// the test from the app-side listener-attach timing — Ti.Geolocation
+// only attaches its listener when SiteDetails opens, but as long as
+// the broadcaster is ticking, whenever attach happens the next event
+// arrives within ~1s.
+//
+// The previous "set 4 times in a 10s window" loop was both a race
+// (relied on at least one broadcast landing after attach) and a
+// timeout flake (4× xcrun spawn cost on contended macOS runners
+// could exceed the cucumber 10s step timeout). See WB-53.
+async function startGpsBroadcaster(world, lat, lng) {
+    if (world._gpsBroadcaster) return;
+    const broadcaster = { stopped: false, timer: null };
+    world._gpsBroadcaster = broadcaster;
+
+    const tick = async () => {
+        if (broadcaster.stopped) return;
+        try {
+            await global.launcher.setLocation(lat, lng);
+        } catch (_) {
+            // Best-effort. A failed simctl/adb call doesn't kill the
+            // broadcaster — next tick may succeed once the simulator
+            // is less contended.
+        }
+        if (!broadcaster.stopped) {
+            broadcaster.timer = setTimeout(tick, BROADCAST_INTERVAL_MS);
+        }
+    };
+
+    // Await the first broadcast so the step doesn't return until at
+    // least one location has been pushed to the simulator.
+    await tick();
+}
+
+function stopGpsBroadcaster(world) {
+    const broadcaster = world._gpsBroadcaster;
+    if (!broadcaster) return;
+    broadcaster.stopped = true;
+    if (broadcaster.timer) clearTimeout(broadcaster.timer);
+    world._gpsBroadcaster = null;
+}
+
+Given('the GPS has a fix', async function () {
+    await startGpsBroadcaster(this, TEST_LAT, TEST_LNG);
+});
+
+After(function () {
+    stopGpsBroadcaster(this);
 });


### PR DESCRIPTION
## Summary

Replaces the racing 4×`xcrun simctl location set` loop in `features/step_definitions/gps_steps.js` with a 1Hz continuous broadcaster that mirrors how a real GPS unit behaves. Started by the step, torn down in an `After` hook.

Trello: https://trello.com/c/qKYmtGoB

## Why now

This is the actual cause of the iOS-acceptance flake on PR #208 (run 25103118012). Cucumber step timed out at 10s — on contended macOS-15 runners 4×`xcrun` calls can exceed the budget. PR #208 is blocked until this lands.

## Why a broadcaster (not a tighter loop or a longer timeout)

The loop was a hack tied to an iOS-simulator implementation detail:

1. `xcrun simctl location set` is one-shot — no replay to listeners that attach later.
2. The app's Ti.Geolocation listener only attaches when `SiteDetails` opens.

So the loop was hoping at least one of 4 broadcasts landed after attach. Two problems:

- **Test-side race**: order-of-attach-vs-broadcast determines pass/fail.
- **Implementation coupling**: a fix that re-broadcasts in `SiteDetailsScreen.waitFor()` (an earlier draft) ties the test framework to a specific screen — wrong, because a real GPS unit doesn't know about the app's UI.

The broadcaster decouples both: it ticks for the lifetime of the scenario regardless of what the app is doing. When the listener attaches — whenever that is — the next event arrives within ~1s. Same model as a real device.

## Test plan

- [x] Node unit tests: 86/86 passing (no app-code change; sanity only)
- [ ] iOS acceptance on this PR's CI — the failing scenario from #208
- [ ] Android acceptance on this PR's CI (no regression: broadcaster is idempotent on Android — emulator already replays current fix to new listeners)
- [ ] After merge: rebase #208 onto main so its CI re-runs with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)