### PR TITLE
WB-54: retry Android and iOS jobs once on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,15 +379,14 @@ jobs:
           # Emulator stays booted across attempts so retry cost is just
           # the gradle+test cycle (~2.5 min). A genuine deterministic
           # failure still fails the job after the second attempt.
+          #
+          # `reactivecircus/android-emulator-runner@v2` runs each line
+          # of `script:` via a separate `sh -c`, so the retry has to
+          # fit on one logical line — `||` short-circuit is the
+          # cleanest fit.
           script: |
             echo "Emulator booted"
-            for attempt in 1 2; do
-              if npx grunt --platform=android --simulator unit-test; then
-                exit 0
-              fi
-              echo "::warning ::Android unit-test attempt $attempt failed; retrying once (WB-54)"
-            done
-            exit 1
+            npx grunt --platform=android --simulator unit-test || { echo "::warning ::Android unit-test first attempt failed; retrying once (WB-54)"; npx grunt --platform=android --simulator unit-test; }
 
   # ── 4. iOS simulator acceptance tests ─────────────────────────────────────
   ios-simulator-acceptance-tests:
@@ -699,13 +698,8 @@ jobs:
           # Retry once on failure — same rationale as the unit-test job
           # above (WB-54). Wraps both preflight and acceptance so either
           # phase being hit by the AAPT flake gets a second shot.
+          # Single-line form per the action's `sh -c`-per-line execution
+          # model.
           script: |
             echo "Emulator booted"
-            for attempt in 1 2; do
-              if npx grunt acceptance-preflight-test-android-emulator \
-                 && npx grunt --platform=android --simulator acceptance-test; then
-                exit 0
-              fi
-              echo "::warning ::Android acceptance attempt $attempt failed; retrying once (WB-54)"
-            done
-            exit 1
+            ( npx grunt acceptance-preflight-test-android-emulator && npx grunt --platform=android --simulator acceptance-test ) || { echo "::warning ::Android acceptance first attempt failed; retrying once (WB-54)"; npx grunt acceptance-preflight-test-android-emulator && npx grunt --platform=android --simulator acceptance-test; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,16 @@ jobs:
       - name: Run iOS simulator unit tests
         env:
           SIM_UDID: ${{ steps.sim.outputs.udid }}
-        run: npx grunt --platform=ios --simulator unit-test
+        # Same retry rationale as the Android jobs (WB-54): defence in
+        # depth against transient SDK / runner flakes.
+        run: |
+          for attempt in 1 2; do
+            if npx grunt --platform=ios --simulator unit-test; then
+              exit 0
+            fi
+            echo "::warning ::iOS unit-test attempt $attempt failed; retrying once (WB-54)"
+          done
+          exit 1
 
       - name: Capture simulator diagnostics on failure
         if: failure()
@@ -365,9 +374,20 @@ jobs:
           avd-name: Medium_Phone_API_36.1
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          # Retry once on failure to absorb the intermittent AAPT
+          # `Theme.WaterbugApp not found` resource-linker flake (WB-54).
+          # Emulator stays booted across attempts so retry cost is just
+          # the gradle+test cycle (~2.5 min). A genuine deterministic
+          # failure still fails the job after the second attempt.
           script: |
             echo "Emulator booted"
-            npx grunt --platform=android --simulator unit-test
+            for attempt in 1 2; do
+              if npx grunt --platform=android --simulator unit-test; then
+                exit 0
+              fi
+              echo "::warning ::Android unit-test attempt $attempt failed; retrying once (WB-54)"
+            done
+            exit 1
 
   # ── 4. iOS simulator acceptance tests ─────────────────────────────────────
   ios-simulator-acceptance-tests:
@@ -511,12 +531,32 @@ jobs:
       - name: Acceptance preflight (Appium launcher integration test)
         env:
           SIM_UDID: ${{ steps.sim.outputs.udid }}
-        run: npx grunt acceptance-preflight-test-ios-simulator
+        # Retry once (WB-54). The preflight is intentionally fast-fail
+        # so the cost of a retry is small (~1 min).
+        run: |
+          for attempt in 1 2; do
+            if npx grunt acceptance-preflight-test-ios-simulator; then
+              exit 0
+            fi
+            echo "::warning ::iOS preflight attempt $attempt failed; retrying once (WB-54)"
+          done
+          exit 1
 
       - name: Run iOS acceptance tests
         env:
           SIM_UDID: ${{ steps.sim.outputs.udid }}
-        run: npx grunt --platform=ios --simulator acceptance-test
+        # Retry once (WB-54). Cucumber suite takes ~15 min so a retry
+        # roughly doubles the cost on a deterministic failure — but
+        # acceptance flakes are common enough on macOS-15 runners that
+        # the trade-off favours green over fast-fail.
+        run: |
+          for attempt in 1 2; do
+            if npx grunt --platform=ios --simulator acceptance-test; then
+              exit 0
+            fi
+            echo "::warning ::iOS acceptance attempt $attempt failed; retrying once (WB-54)"
+          done
+          exit 1
 
       - name: Capture simulator diagnostics on failure
         if: failure()
@@ -656,7 +696,16 @@ jobs:
           avd-name: Medium_Phone_API_36.1
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          # Retry once on failure — same rationale as the unit-test job
+          # above (WB-54). Wraps both preflight and acceptance so either
+          # phase being hit by the AAPT flake gets a second shot.
           script: |
             echo "Emulator booted"
-            npx grunt acceptance-preflight-test-android-emulator
-            npx grunt --platform=android --simulator acceptance-test
+            for attempt in 1 2; do
+              if npx grunt acceptance-preflight-test-android-emulator \
+                 && npx grunt --platform=android --simulator acceptance-test; then
+                exit 0
+              fi
+              echo "::warning ::Android acceptance attempt $attempt failed; retrying once (WB-54)"
+            done
+            exit 1


### PR DESCRIPTION
## Summary

Adds a one-shot retry around the gradle/test invocations in **all** Android and iOS jobs in [.github/workflows/ci.yml](.github/workflows/ci.yml). Mitigates the intermittent AAPT `Theme.WaterbugApp not found` resource-linker flake observed on PR #210, plus defence-in-depth for analogous transient SDK/runner flakes on iOS.

Trello: https://trello.com/c/S1dkgaRi

## What's wrapped

| Job | Step |
|-----|------|
| `android-emulator-tests` | `npx grunt --platform=android --simulator unit-test` |
| `android-emulator-acceptance-tests` | `npx grunt acceptance-preflight-test-android-emulator && npx grunt --platform=android --simulator acceptance-test` |
| `ios-simulator-tests` | `npx grunt --platform=ios --simulator unit-test` |
| `ios-simulator-acceptance-tests` | `npx grunt acceptance-preflight-test-ios-simulator` (separate retry) |
| `ios-simulator-acceptance-tests` | `npx grunt --platform=ios --simulator acceptance-test` (separate retry) |

The Android pair share one retry because they're inside the `reactivecircus/android-emulator-runner@v2` script block (single shell). The iOS preflight + acceptance run as two separate workflow steps with their own env vars, so they each get their own retry.

## Why retry, not root-cause fix

- Flake happens inside the Titanium SDK's pre-gradle resource copy. Fixing it means monkey-patching the SDK builder — out of scope.
- `gh run rerun --failed` resolved it without code changes. Confirms transience.
- Until we have a pattern, CI-side retry is cheapest.

## Trade-off

- **Win**: transient flakes no longer fail jobs; emulators/simulators stay booted across attempts so retry cost is just the gradle+test cycle.
- **Cost**: a deterministic failure takes one extra cycle (~2.5 min Android unit, ~5 min iOS unit, ~15 min iOS acceptance) before the job fails red. Worth it given flake rate vs deterministic-failure rate.

## Test plan

- [ ] All four CI jobs pass on this PR with no warnings (clean first attempts)
- [ ] Spot-check the warning text format if any retry actually fires (`::warning ::...` annotations should appear in the run summary)

## Out of scope

- Root-causing the Titanium SDK resource race ([linked in WB-54 description](https://trello.com/c/S1dkgaRi))
- Retrying the Node.js unit tests job — it's not been observed flaking and runs in 35s anyway

🤖 Generated with [Claude Code](https://claude.com/claude-code)