### PR TITLE
Coding style: async/await everywhere, opportunistic migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 WALTA (Waterbug App) is a cross-platform mobile app for iOS and Android that enables dichotomous key-based insect identification for water quality monitoring. It is built on the Titanium/Alloy MVC framework.
 
+## Coding Style
+
+See [CODING-STYLE.md](CODING-STYLE.md) for JavaScript conventions — module system per directory, async/await direction, and incremental migration guidance.
+
 ## Methodology
 
 Folloing as test driven development philsophy, as Kent Beck intended, here is the breakdown:

--- a/CODING-STYLE.md
+++ b/CODING-STYLE.md
@@ -2,17 +2,19 @@
 
 ## JavaScript
 
-New code in `build-utils/` and `build-tests/` should follow modern JavaScript practices:
+### Async style — `async`/`await` everywhere
 
-- **Modules:** Use `import`/`export` (ES modules) instead of `require`/`module.exports`
-- **Async:** Use `async`/`await` instead of `.then()`/`.catch()` chains
+Default to `async`/`await` for all new code, including in `walta-app/`. Modern Titanium SDKs (13.x+) support it natively at the language level — the legacy `.then()` chains in app code reflect when they were written, not a runtime constraint.
 
-`build-utils/` and `build-tests/` have a `package.json` with `"type": "module"` which
-enables ES module syntax for all `.js` files within them. The mocha commands for these
-tests use `NODE_OPTIONS=--experimental-vm-modules` to support ESM.
+When editing a file that uses `.then()` chains, convert the chains you touch to `async`/`await` as part of the change. **Opportunistic, not big-bang** — don't rewrite an entire file unless that's the task. The intent is to migrate the codebase incrementally as we move through it, without dedicated migration work.
 
-`Gruntfile.js` is CommonJS (`module.exports`, `require`) for Grunt compatibility — new
-code added to it should use `async`/`await` where possible, but `import`/`export` is not
-available there. Use dynamic `import()` to consume ES modules from the Gruntfile.
+### Module system — depends on the directory
 
-Legacy code in `walta-app/` uses CommonJS and `.then()` chains — leave those as-is.
+| Directory | Module style | Reason |
+|-----------|-------------|--------|
+| `build-utils/` | ES modules (`import`/`export`) | Has `package.json` with `"type": "module"` |
+| `build-tests/` | ES modules (`import`/`export`) | Has `package.json` with `"type": "module"`; mocha runs with `NODE_OPTIONS=--experimental-vm-modules` |
+| `Gruntfile.js` | CommonJS (`module.exports`, `require`) | Grunt 1.6+ supports `Gruntfile.mjs` for ESM — tracked in WB-55. Until that lands, use dynamic `import()` to consume ES modules. |
+| `walta-app/` | CommonJS (`require`, `module.exports`) | **Alloy's build pipeline is CommonJS-only.** Switching to ESM would require rewriting Alloy itself. Keep `require()` and `module.exports` in app code. |
+
+The Alloy constraint only applies to module syntax. `async`/`await` is just JavaScript syntax and works fine inside a CommonJS file.


### PR DESCRIPTION
## Summary

Updates `CODING-STYLE.md` to flip the async direction from "leave legacy alone" to "modernise as we touch":

- **Async/await is the default everywhere**, including \`walta-app/\`. Modern Titanium SDKs (13.x+) support it natively — the legacy \`.then()\` chains reflect when the code was written, not a runtime constraint.
- **Opportunistic migration**: when editing a file with \`.then()\` chains, convert what you touch. Not a big-bang rewrite.
- **ESM stays scoped** to \`build-utils/\` and \`build-tests/\`. Alloy's build pipeline is CommonJS-only, so \`walta-app/\` keeps \`require()\` / \`module.exports\`. \`async/await\` is just syntax — it works fine inside a CJS file.
- Adds a "Coding Style" pointer at the top of \`CLAUDE.md\` so future Claude sessions pick up the conventions automatically.

## Why now

Surfaced during WB-48 (PR #212) — adding an ESM helper to the Gruntfile required a \`Promise.all([..., import(...)])\` dance, which prompted a wider conversation about why the codebase mixes styles. Most of the legacy \`.then()\` style predates the author's awareness/use of \`async/await\`, not a deliberate choice.

## Test plan

- [x] No code changes, just docs — nothing to test
- [ ] CI green on the docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)