### PR TITLE
WB-31: test-server build environment in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,22 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
+      environment:
+        description: >
+          Build environment.
+          'production' = real CERDI API + clean tag (v2.1.0.4).
+          'test' = sandbox CERDI API + version suffix (-test) in TestFlight /
+          Play Console + tag (v2.1.0.4-test). Default is production —
+          accidental triggers are safe.
+        type: choice
+        options:
+          - production
+          - test
+        default: production
       version:
         description: >
           Version (e.g. 2.0.5.1). Leave empty to auto-increment the build
-          number from the latest v* git tag.
+          number from the latest v* git tag (test or prod).
         required: false
         type: string
       platforms:
@@ -33,7 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      display_version: ${{ steps.version.outputs.display_version }}
       version_code: ${{ steps.version.outputs.version_code }}
+      tag_name: ${{ steps.version.outputs.tag_name }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -42,13 +56,19 @@ jobs:
       - name: Compute version and versionCode
         id: version
         run: |
+          ENVIRONMENT="${{ inputs.environment }}"
+
           if [ -n "${{ inputs.version }}" ]; then
             VERSION="${{ inputs.version }}"
           else
-            # Auto-increment build number from the latest release tag
+            # Auto-increment build number from the latest release tag.
+            # Test releases (v*-test) and production releases (v*) share
+            # one build-number sequence so they never collide. Strip any
+            # `-test` suffix before parsing the numeric.
             LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
             if [ -n "$LATEST_TAG" ]; then
               CURRENT="${LATEST_TAG#v}"
+              CURRENT="${CURRENT%-test}"
             else
               # No tags yet — fall back to 2.0.4.0 as the base version
               CURRENT="2.0.4.0"
@@ -62,9 +82,25 @@ jobs:
           IFS='.' read -r major minor patch build <<< "$VERSION"
           VERSION_CODE=$(( major * 1000000000 + minor * 10000000 + patch * 10000 + build ))
 
+          # Test builds carry a -test suffix in the human-visible
+          # version (tiapp.xml <version>, Android versionName,
+          # CFBundleShortVersionString) and in the git tag, so John
+          # / TestFlight / Play Console can tell them apart from prod.
+          # versionCode stays purely numeric.
+          if [ "$ENVIRONMENT" = "test" ]; then
+            DISPLAY_VERSION="${VERSION}-test"
+            TAG_NAME="v${VERSION}-test"
+          else
+            DISPLAY_VERSION="$VERSION"
+            TAG_NAME="v${VERSION}"
+          fi
+
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "display_version=$DISPLAY_VERSION" >> "$GITHUB_OUTPUT"
           echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
-          echo "Version: $VERSION (versionCode: $VERSION_CODE)"
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "Environment: $ENVIRONMENT"
+          echo "Version: $DISPLAY_VERSION (versionCode: $VERSION_CODE, tag: $TAG_NAME)"
 
   # ── Android release ────────────────────────────────────────────────────
   release-android:
@@ -110,24 +146,35 @@ jobs:
 
       - name: Bump version in tiapp.xml
         run: |
-          VERSION="${{ needs.prepare.outputs.version }}"
+          DISPLAY_VERSION="${{ needs.prepare.outputs.display_version }}"
           VERSION_CODE="${{ needs.prepare.outputs.version_code }}"
-          sed -i "s|<version>[^<]*</version>|<version>${VERSION}</version>|" walta-app/tiapp.xml.template
+          sed -i "s|<version>[^<]*</version>|<version>${DISPLAY_VERSION}</version>|" walta-app/tiapp.xml.template
           sed -i "s|android:versionCode=\"[^\"]*\"|android:versionCode=\"${VERSION_CODE}\"|" walta-app/tiapp.xml.template
-          sed -i "s|android:versionName=\"[^\"]*\"|android:versionName=\"${VERSION}\"|" walta-app/tiapp.xml.template
+          sed -i "s|android:versionName=\"[^\"]*\"|android:versionName=\"${DISPLAY_VERSION}\"|" walta-app/tiapp.xml.template
           # Regenerate tiapp.xml from updated template
           sed "s/GOOGLE_MAPS_API_KEY_PLACEHOLDER/$GOOGLE_MAPS_API_KEY/" \
             walta-app/tiapp.xml.template > walta-app/tiapp.xml
-          echo "Updated to version $VERSION (versionCode $VERSION_CODE)"
+          echo "Updated to version $DISPLAY_VERSION (versionCode $VERSION_CODE)"
 
-      - name: Create production app config
+      - name: Create app config (production or test sandbox)
         run: |
-          cat > walta-app/app/app-config.production.json << EOF
-          {
-            "cerdiServerUrl": "${{ secrets.CERDI_SERVER_URL }}",
-            "cerdiApiSecret": "${{ secrets.CERDI_API_SECRET }}"
-          }
-          EOF
+          if [ "${{ inputs.environment }}" = "test" ]; then
+            cat > walta-app/app/app-config.test.json << EOF
+            {
+              "cerdiServerUrl": "${{ secrets.CERDI_TEST_SERVER_URL }}",
+              "cerdiApiSecret": "${{ secrets.CERDI_TEST_API_SECRET }}"
+            }
+            EOF
+            echo "Wrote app-config.test.json — sandbox API"
+          else
+            cat > walta-app/app/app-config.production.json << EOF
+            {
+              "cerdiServerUrl": "${{ secrets.CERDI_SERVER_URL }}",
+              "cerdiApiSecret": "${{ secrets.CERDI_API_SECRET }}"
+            }
+            EOF
+            echo "Wrote app-config.production.json — production API"
+          fi
 
       - name: Read Titanium SDK version
         id: ti-version
@@ -167,7 +214,12 @@ jobs:
           KEYSTORE: /tmp/release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEYSTORE_SUBKEY: ${{ secrets.KEYSTORE_SUBKEY }}
-        run: npx grunt --platform=android clean release
+        run: |
+          if [ "${{ inputs.environment }}" = "test" ]; then
+            npx grunt --platform=android --override-app-config=test clean release
+          else
+            npx grunt --platform=android clean release
+          fi
 
       - name: Upload to Google Play (internal track)
         uses: r0adkll/upload-google-play@v1
@@ -181,7 +233,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: android-release-${{ needs.prepare.outputs.version }}
+          name: android-release-${{ needs.prepare.outputs.display_version }}
           path: builds/release/Waterbug.*
 
   # ── iOS release ────────────────────────────────────────────────────────
@@ -230,24 +282,35 @@ jobs:
 
       - name: Bump version in tiapp.xml
         run: |
-          VERSION="${{ needs.prepare.outputs.version }}"
+          DISPLAY_VERSION="${{ needs.prepare.outputs.display_version }}"
           VERSION_CODE="${{ needs.prepare.outputs.version_code }}"
-          sed -i '' "s|<version>[^<]*</version>|<version>${VERSION}</version>|" walta-app/tiapp.xml.template
+          sed -i '' "s|<version>[^<]*</version>|<version>${DISPLAY_VERSION}</version>|" walta-app/tiapp.xml.template
           sed -i '' "s|android:versionCode=\"[^\"]*\"|android:versionCode=\"${VERSION_CODE}\"|" walta-app/tiapp.xml.template
-          sed -i '' "s|android:versionName=\"[^\"]*\"|android:versionName=\"${VERSION}\"|" walta-app/tiapp.xml.template
+          sed -i '' "s|android:versionName=\"[^\"]*\"|android:versionName=\"${DISPLAY_VERSION}\"|" walta-app/tiapp.xml.template
           # Regenerate tiapp.xml from updated template
           sed "s/GOOGLE_MAPS_API_KEY_PLACEHOLDER/$GOOGLE_MAPS_API_KEY/" \
             walta-app/tiapp.xml.template > walta-app/tiapp.xml
-          echo "Updated to version $VERSION (versionCode $VERSION_CODE)"
+          echo "Updated to version $DISPLAY_VERSION (versionCode $VERSION_CODE)"
 
-      - name: Create production app config
+      - name: Create app config (production or test sandbox)
         run: |
-          cat > walta-app/app/app-config.production.json << EOF
-          {
-            "cerdiServerUrl": "${{ secrets.CERDI_SERVER_URL }}",
-            "cerdiApiSecret": "${{ secrets.CERDI_API_SECRET }}"
-          }
-          EOF
+          if [ "${{ inputs.environment }}" = "test" ]; then
+            cat > walta-app/app/app-config.test.json << EOF
+            {
+              "cerdiServerUrl": "${{ secrets.CERDI_TEST_SERVER_URL }}",
+              "cerdiApiSecret": "${{ secrets.CERDI_TEST_API_SECRET }}"
+            }
+            EOF
+            echo "Wrote app-config.test.json — sandbox API"
+          else
+            cat > walta-app/app/app-config.production.json << EOF
+            {
+              "cerdiServerUrl": "${{ secrets.CERDI_SERVER_URL }}",
+              "cerdiApiSecret": "${{ secrets.CERDI_API_SECRET }}"
+            }
+            EOF
+            echo "Wrote app-config.production.json — production API"
+          fi
 
       - name: Read Titanium SDK version
         id: ti-version
@@ -315,7 +378,12 @@ jobs:
         env:
           DEVELOPER: ${{ secrets.IOS_DEVELOPER_NAME }}
           PROFILE_DIST: ${{ secrets.IOS_PROFILE_UUID }}
-        run: npx grunt --platform=ios clean release
+        run: |
+          if [ "${{ inputs.environment }}" = "test" ]; then
+            npx grunt --platform=ios --override-app-config=test clean release
+          else
+            npx grunt --platform=ios clean release
+          fi
 
       - name: Upload to TestFlight
         run: |
@@ -335,7 +403,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ios-release-${{ needs.prepare.outputs.version }}
+          name: ios-release-${{ needs.prepare.outputs.display_version }}
           path: builds/release/Waterbug.ipa
 
   # ── Tag the release ────────────────────────────────────────────────────
@@ -352,8 +420,9 @@ jobs:
 
       - name: Create and push tag
         run: |
-          VERSION="${{ needs.prepare.outputs.version }}"
+          TAG_NAME="${{ needs.prepare.outputs.tag_name }}"
+          DISPLAY_VERSION="${{ needs.prepare.outputs.display_version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${VERSION}" -m "Release ${VERSION}"
-          git push origin "v${VERSION}"
+          git tag -a "${TAG_NAME}" -m "Release ${DISPLAY_VERSION}"
+          git push origin "${TAG_NAME}"


### PR DESCRIPTION
Fixes [WB-31](https://trello.com/c/UFhQWJCA/31-make-cerdi-test-server-builds-visually-distinct).

## Why now

Tonight's release goes to TestFlight + Play Internal pointing at the **CERDI sandbox API** so John can stress-test sync without risking production data. With test-server logic baked into a build, the existing "promote internal to production" no-rebuild flow becomes a foot-gun — a test build promoted to production would ship users at the sandbox.

Two protections this PR adds:

1. **Build-time choice**, with prod as the safe default. Accidental workflow triggers build production.
2. **Visually distinct test artifacts** so they can't be mistaken for prod in TestFlight, Play Console, bug reports, or on the device.

## What

- New `environment: production|test` input (default `production`) on `release.yml`.
- `prepare` job: strips trailing \`-test\` from the latest tag before parsing the numeric, so test and prod share one build-number sequence with no collisions.
- Three derived outputs feed the platform jobs:
  - \`version\` — numeric (\`2.1.0.4\`) for Android \`versionCode\`.
  - \`display_version\` — \`2.1.0.4-test\` or \`2.1.0.4\` for tiapp \`<version>\`, Android \`versionName\`, CFBundleShortVersionString, artifact names.
  - \`tag_name\` — \`v2.1.0.4-test\` or \`v2.1.0.4\`.
- Both Android + iOS jobs branch on \`inputs.environment\`:
  - **test** → write \`CERDI_TEST_SERVER_URL\` + \`CERDI_TEST_API_SECRET\` to \`app-config.test.json\`, build with \`--override-app-config=test\`.
  - **production** → unchanged from today (writes \`app-config.production.json\`, no override flag).
- Tag step uses \`tag_name\` — test releases get \`v*-test\` tags without polluting the prod \`v*\` namespace.

## Two new secrets required before the first test release

| Secret | Value |
|---|---|
| \`CERDI_TEST_SERVER_URL\` | \`https://api-sandbox.waterbugblitz.org.au/v1\` |
| \`CERDI_TEST_API_SECRET\` | Sandbox-specific secret (per Paul, currently identical to prod, but kept separate for future divergence) |

## iOS validation note (turns out to be a feature)

\`CFBundleShortVersionString\` traditionally rejects non-numeric components when validated for App Store submission. TestFlight is more lenient, so \`2.1.0.4-test\` should pass for John's builds. If Apple ever rejects, that's the **desired** outcome — it physically blocks accidental promotion of a test build to App Store production.

## Test plan

- [ ] Add the two new GitHub secrets.
- [ ] Trigger \`Release\` workflow with \`environment=test\` → expect:
  - Artifacts named \`android-release-X.Y.Z.B-test\` / \`ios-release-X.Y.Z.B-test\`.
  - Tag pushed: \`vX.Y.Z.B-test\`.
  - TestFlight + Play Internal show \`X.Y.Z.B-test\` as the version.
  - In-app: tapping CERDI calls hit \`api-sandbox.waterbugblitz.org.au\`.
- [ ] Trigger \`Release\` workflow with no inputs (defaults to production) → expect prod build (sanity check the default still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)