### PR TITLE
Acceptance retry gate: skip retry when cucumber reports test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -847,14 +847,20 @@ jobs:
           avd-name: Medium_Phone_API_36.1
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          # Retry once on infrastructure flake (WB-54: AAPT
-          # `Theme.WaterbugApp not found` resource-linker glitch,
-          # Appium hiccups, etc.). Skip the retry if cucumber-js
-          # exited 1 → grunt exit 2 → wrapper exit 1: the failure is a
-          # deterministic test fail and a retry is just burning cycles.
-          # Same exit-code contract as the WB-48 unit-test gating.
-          # Wraps both preflight and acceptance so either phase being
-          # hit by an infra flake gets the second shot.
+          # Two phases — preflight then cucumber — each independently
+          # retry-wrapped, mirroring the iOS structure (preflight + Run
+          # iOS acceptance tests are separate steps there). The
+          # emulator-runner action runs each `script:` line via its own
+          # `sh -c`, so a failed preflight after retry doesn't
+          # short-circuit the cucumber phase — the cucumber phase will
+          # also fail and the overall step goes red. The wasted ~5 min
+          # is acceptable for the readability win in CI logs (each
+          # phase reports separately).
+          #
+          # Retry semantics on each phase: skip retry if grunt exits
+          # 2 (cucumber test failures, deterministic) — same exit-code
+          # contract established in WB-48.
           script: |
             echo "Emulator booted"
-            bash build-utils/run-unit-tests-with-retry.sh sh -c "npx grunt acceptance-preflight-test-android-emulator && npx grunt --platform=android --simulator --skip-build acceptance-test"
+            bash build-utils/run-unit-tests-with-retry.sh npx grunt acceptance-preflight-test-android-emulator
+            bash build-utils/run-unit-tests-with-retry.sh npx grunt --platform=android --simulator --skip-build acceptance-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -716,18 +716,12 @@ jobs:
       - name: Run iOS acceptance tests
         env:
           SIM_UDID: ${{ steps.sim.outputs.udid }}
-        # Retry once (WB-54). Cucumber suite takes ~15 min so a retry
-        # roughly doubles the cost on a deterministic failure — but
-        # acceptance flakes are common enough on macOS-15 runners that
-        # the trade-off favours green over fast-fail.
-        run: |
-          for attempt in 1 2; do
-            if npx grunt --platform=ios --simulator --skip-build acceptance-test; then
-              exit 0
-            fi
-            echo "::warning ::iOS acceptance attempt $attempt failed; retrying once (WB-54)"
-          done
-          exit 1
+        # Retry once on infrastructure flake (WB-54: macOS-15 runners,
+        # Appium / xcuitest hiccups). Skip the retry if cucumber-js
+        # exited 1 → grunt exit 2 → wrapper exit 1: the test failure
+        # is deterministic and a 15-min retry is wasted. Same exit-code
+        # contract as the WB-48 unit-test gating.
+        run: bash build-utils/run-unit-tests-with-retry.sh npx grunt --platform=ios --simulator --skip-build acceptance-test
 
       - name: Capture simulator diagnostics on failure
         if: failure()
@@ -853,11 +847,14 @@ jobs:
           avd-name: Medium_Phone_API_36.1
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          # Retry once on failure — same rationale as the unit-test job
-          # above (WB-54). Wraps both preflight and acceptance so either
-          # phase being hit by the AAPT flake gets a second shot.
-          # Single-line form per the action's `sh -c`-per-line execution
-          # model.
+          # Retry once on infrastructure flake (WB-54: AAPT
+          # `Theme.WaterbugApp not found` resource-linker glitch,
+          # Appium hiccups, etc.). Skip the retry if cucumber-js
+          # exited 1 → grunt exit 2 → wrapper exit 1: the failure is a
+          # deterministic test fail and a retry is just burning cycles.
+          # Same exit-code contract as the WB-48 unit-test gating.
+          # Wraps both preflight and acceptance so either phase being
+          # hit by an infra flake gets the second shot.
           script: |
             echo "Emulator booted"
-            ( npx grunt acceptance-preflight-test-android-emulator && npx grunt --platform=android --simulator --skip-build acceptance-test ) || { echo "::warning ::Android acceptance first attempt failed; retrying once (WB-54)"; npx grunt acceptance-preflight-test-android-emulator && npx grunt --platform=android --simulator --skip-build acceptance-test; }
+            bash build-utils/run-unit-tests-with-retry.sh sh -c "npx grunt acceptance-preflight-test-android-emulator && npx grunt --platform=android --simulator --skip-build acceptance-test"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -589,12 +589,25 @@ const KobitonAPI = require("./features/support/kobiton");
       import("./build-utils/CucumberLauncher.js")
         .then(({ default: CucumberLauncher }) => new CucumberLauncher({ tags, appiumOptions }).run())
         .then((code) => {
-          if (code !== 0) {
-            grunt.log.error(`cucumber-js exited with code ${code}`);
-            done(false);
+          if (code === 0) {
+            done();
             return;
           }
-          done();
+          if (code === 1) {
+            // cucumber-js exit 1 = ran to completion, reported test
+            // failures. Deterministic — no point retrying. Use exit
+            // code 2 so the CI retry wrapper
+            // (build-utils/run-unit-tests-with-retry.sh) skips its
+            // retry. Same convention as the on-device unit-test path
+            // established in WB-48.
+            grunt.log.error(`cucumber-js reported test failures (exit 1) — not retrying`);
+            process.exit(2);
+          }
+          // Other non-zero — pre-launch / appium / infrastructure
+          // failure. Let grunt's normal failure path run so the wrapper
+          // retries once.
+          grunt.log.error(`cucumber-js exited with code ${code}`);
+          done(false);
         })
         .catch((err) => { grunt.fail.fatal(err); done(false); });
     });

--- a/build-utils/run-unit-tests-with-retry.sh
+++ b/build-utils/run-unit-tests-with-retry.sh
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
-# Runs the on-device unit-test command with one retry on infrastructure
-# flake — but not on a deterministic test failure. Used by the iOS +
-# Android unit-test jobs in .github/workflows/ci.yml.
+# Runs an on-device test command with one retry on infrastructure
+# flake — but not on a deterministic test failure. Used by both the
+# unit-test jobs (WB-48) and the acceptance/cucumber jobs (WB-54
+# follow-up) in .github/workflows/ci.yml.
 #
-# Exit-code contract from `npx grunt unit-test`:
+# Exit-code contract from the wrapped grunt task (unit-test or
+# acceptance-test):
 #   - 0  → all tests passed
 #   - 2  → tests ran to completion and reported failures (do not retry)
-#   - any other non-zero → infrastructure/build/AAPT flake (retry once)
+#   - any other non-zero → infrastructure/build/AAPT/Appium flake
+#                          (retry once)
 #
 # This wrapper's exit code:
 #   - 0 → all passed
 #   - 1 → deterministic test failure (CI job goes red, no retry)
 #   - whatever the second attempt exits with on infra flake
 #
-# See WB-48.
+# Filename retains the historical "unit-tests" name; renaming is
+# pure cosmetic and tracked as a future cleanup.
 
 "$@"
 EXIT=$?


### PR DESCRIPTION
## Why

Extends the [WB-48](https://trello.com/c/iKBTKnlE) unit-test gating pattern to acceptance tests. Today the Android and iOS acceptance jobs retry once on **any** non-zero exit ([WB-54](https://trello.com/c/PZ5tnhi5)), which means a deterministic test failure burns ~15 min on iOS / ~7 min on Android re-running a suite that's guaranteed to fail again.

Surfaced today on PR #214 — Android acceptance failed at the close-popup step and the retry took a full second pass before reporting red.

## What

Cucumber-js exit codes:
- \`0\` — all scenarios passed
- \`1\` — ran to completion, some scenarios failed (deterministic)
- \`*\` — pre-launch / framework / infrastructure failure

Changes:

- \`Gruntfile.js\` cucumber task branches on the launcher's exit code:
  - \`0\` → \`done()\`
  - \`1\` → \`process.exit(2)\` (deterministic, no retry)
  - other → \`done(false)\` (infra flake, retry)

- \`ci.yml\` Android acceptance: replaces the inline \`||\` retry block with \`bash build-utils/run-unit-tests-with-retry.sh sh -c "preflight && acceptance"\`. Wrapper already keys off exit 2 from WB-48.

- \`ci.yml\` iOS acceptance: replaces the \`for attempt in 1 2\` loop with the same wrapper. iOS preflight retry left untouched — it's not cucumber, all failures there are infra-ish.

- \`build-utils/run-unit-tests-with-retry.sh\` header comments updated to reflect dual use. Filename retained; cosmetic rename is a follow-up.

The 5 existing wrapper unit tests already cover the exit-code contract.

## Test plan

- [x] \`npx grunt build-test\` — 67 passing locally.
- [ ] **CI on this PR**: expect all jobs green (acceptance suites pass on main today, no scenarios failing).
- [ ] **Real verification** comes when a deterministic acceptance failure lands — the failing job should report red on the **first attempt**, with no retry-cycle wasted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)