### PR TITLE
WB-31: fix heredoc indent in release.yml app-config step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,20 +159,16 @@ jobs:
       - name: Create app config (production or test sandbox)
         run: |
           if [ "${{ inputs.environment }}" = "test" ]; then
-            cat > walta-app/app/app-config.test.json << EOF
-            {
-              "cerdiServerUrl": "${{ secrets.CERDI_TEST_SERVER_URL }}",
-              "cerdiApiSecret": "${{ secrets.CERDI_TEST_API_SECRET }}"
-            }
-            EOF
+            printf '{\n  "cerdiServerUrl": "%s",\n  "cerdiApiSecret": "%s"\n}\n' \
+              "${{ secrets.CERDI_TEST_SERVER_URL }}" \
+              "${{ secrets.CERDI_TEST_API_SECRET }}" \
+              > walta-app/app/app-config.test.json
             echo "Wrote app-config.test.json — sandbox API"
           else
-            cat > walta-app/app/app-config.production.json << EOF
-            {
-              "cerdiServerUrl": "${{ secrets.CERDI_SERVER_URL }}",
-              "cerdiApiSecret": "${{ secrets.CERDI_API_SECRET }}"
-            }
-            EOF
+            printf '{\n  "cerdiServerUrl": "%s",\n  "cerdiApiSecret": "%s"\n}\n' \
+              "${{ secrets.CERDI_SERVER_URL }}" \
+              "${{ secrets.CERDI_API_SECRET }}" \
+              > walta-app/app/app-config.production.json
             echo "Wrote app-config.production.json — production API"
           fi
 
@@ -295,20 +291,16 @@ jobs:
       - name: Create app config (production or test sandbox)
         run: |
           if [ "${{ inputs.environment }}" = "test" ]; then
-            cat > walta-app/app/app-config.test.json << EOF
-            {
-              "cerdiServerUrl": "${{ secrets.CERDI_TEST_SERVER_URL }}",
-              "cerdiApiSecret": "${{ secrets.CERDI_TEST_API_SECRET }}"
-            }
-            EOF
+            printf '{\n  "cerdiServerUrl": "%s",\n  "cerdiApiSecret": "%s"\n}\n' \
+              "${{ secrets.CERDI_TEST_SERVER_URL }}" \
+              "${{ secrets.CERDI_TEST_API_SECRET }}" \
+              > walta-app/app/app-config.test.json
             echo "Wrote app-config.test.json — sandbox API"
           else
-            cat > walta-app/app/app-config.production.json << EOF
-            {
-              "cerdiServerUrl": "${{ secrets.CERDI_SERVER_URL }}",
-              "cerdiApiSecret": "${{ secrets.CERDI_API_SECRET }}"
-            }
-            EOF
+            printf '{\n  "cerdiServerUrl": "%s",\n  "cerdiApiSecret": "%s"\n}\n' \
+              "${{ secrets.CERDI_SERVER_URL }}" \
+              "${{ secrets.CERDI_API_SECRET }}" \
+              > walta-app/app/app-config.production.json
             echo "Wrote app-config.production.json — production API"
           fi
 


### PR DESCRIPTION
## Summary

- Indented `cat << EOF` heredoc inside the if/else block of the "Create app config" step never terminated, breaking the Android + iOS release jobs ([failed run 25167105050](https://github.com/TheWaterBugCompany/WALTA/actions/runs/25167105050))
- Replace heredoc with `printf` so the JSON literal isn't sensitive to the shell-block's indentation
- Apply symmetrically to Android (line 159) and iOS (line 295) jobs

## Background

PR #215 wrapped the existing `cat << EOF` in an `if [ "$environment" = "test" ]; then ... else ... fi`, which indented the closing `EOF` to match the new block. Bash heredocs without `<<-` require `EOF` at column 0 — the indented `EOF` got consumed as heredoc body and the script ran off the end with `syntax error: unexpected end of file`. The new `printf` form is dedent-safe.

## Test plan

- [ ] CI green
- [ ] After merge, re-dispatch the Release workflow with `environment=test` and confirm the Android + iOS app-config step now writes valid JSON to `walta-app/app/app-config.test.json` and the build proceeds past `tiapp.xml` regeneration