### PR TITLE
WB-42: fix silent iOS TestFlight upload failure (+ WB-27)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,13 @@ on:
           - android
           - ios
         default: both
+      skip_ci_gate:
+        description: >
+          Skip the requirement that the latest CI run on the release SHA
+          succeeded. Use only when CI is red for a known unrelated reason
+          (e.g. an intermittent flake) and you've manually verified the build.
+        type: boolean
+        default: false
 
 # Only one release at a time
 concurrency:
@@ -39,9 +46,47 @@ env:
   GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
 
 jobs:
+  # ── Gate: latest CI run on this SHA must have succeeded ────────────────
+  ci-gate:
+    name: CI gate
+    if: ${{ !inputs.skip_ci_gate }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify latest CI on release SHA succeeded
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHA="$(git rev-parse HEAD)"
+          echo "Checking CI status for $SHA"
+          RESULT=$(gh run list \
+            --workflow=ci.yml \
+            --branch=main \
+            --commit="$SHA" \
+            --limit=1 \
+            --json conclusion,status,url)
+          if [ "$RESULT" = "[]" ]; then
+            echo "::error::No CI run found for $SHA — push and wait, or set skip_ci_gate=true."
+            exit 1
+          fi
+          STATUS=$(echo "$RESULT"     | jq -r '.[0].status')
+          CONCLUSION=$(echo "$RESULT" | jq -r '.[0].conclusion')
+          URL=$(echo "$RESULT"        | jq -r '.[0].url')
+          if [ "$STATUS" != "completed" ]; then
+            echo "::error::CI run on $SHA not complete (status=$STATUS). $URL"
+            exit 1
+          fi
+          if [ "$CONCLUSION" != "success" ]; then
+            echo "::error::CI run on $SHA conclusion=$CONCLUSION. $URL — fix or set skip_ci_gate=true."
+            exit 1
+          fi
+          echo "CI run on $SHA succeeded: $URL"
+
   # ── Compute version (shared by both platform jobs) ─────────────────────
   prepare:
     name: Compute version
+    needs: ci-gate
+    if: always() && (needs.ci-gate.result == 'success' || needs.ci-gate.result == 'skipped')
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,14 +279,23 @@ jobs:
       - name: Bump version in tiapp.xml
         run: |
           DISPLAY_VERSION="${{ needs.prepare.outputs.display_version }}"
+          VERSION="${{ needs.prepare.outputs.version }}"
           VERSION_CODE="${{ needs.prepare.outputs.version_code }}"
-          sed -i '' "s|<version>[^<]*</version>|<version>${DISPLAY_VERSION}</version>|" walta-app/tiapp.xml.template
+          # <version> maps to CFBundleVersion, which Apple requires to be
+          # composed of integers separated by periods only — so use the
+          # numeric VERSION (no -test suffix).
+          sed -i '' "s|<version>[^<]*</version>|<version>${VERSION}</version>|" walta-app/tiapp.xml.template
           sed -i '' "s|android:versionCode=\"[^\"]*\"|android:versionCode=\"${VERSION_CODE}\"|" walta-app/tiapp.xml.template
           sed -i '' "s|android:versionName=\"[^\"]*\"|android:versionName=\"${DISPLAY_VERSION}\"|" walta-app/tiapp.xml.template
+          # Inject CFBundleShortVersionString so the user-visible version
+          # in TestFlight carries the -test marker even though
+          # CFBundleVersion stays numeric.
+          NL=$'\n'
+          sed -i '' "s|^      </dict>$|        <key>CFBundleShortVersionString</key>\\${NL}        <string>${DISPLAY_VERSION}</string>\\${NL}      </dict>|" walta-app/tiapp.xml.template
           # Regenerate tiapp.xml from updated template
           sed "s/GOOGLE_MAPS_API_KEY_PLACEHOLDER/$GOOGLE_MAPS_API_KEY/" \
             walta-app/tiapp.xml.template > walta-app/tiapp.xml
-          echo "Updated to version $DISPLAY_VERSION (versionCode $VERSION_CODE)"
+          echo "Updated to version $VERSION (display $DISPLAY_VERSION, versionCode $VERSION_CODE)"
 
       - name: Create app config (production or test sandbox)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -437,10 +437,20 @@ jobs:
           echo "${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}" | base64 --decode \
             > ~/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}.p8
 
+          # altool has been observed to print "ERROR: …" and exit 0 on
+          # upload rejection (e.g. CFBundleVersion violations). Capture
+          # output and fail the step if any ERROR: line appears, even
+          # when altool itself reports success.
+          ALTOOL_LOG=$(mktemp)
           xcrun altool --upload-app --type ios \
             --file builds/release/Waterbug.ipa \
             --apiKey ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }} \
-            --apiIssuer ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+            --apiIssuer ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }} \
+            2>&1 | tee "$ALTOOL_LOG"
+          if grep -qE '^[0-9].* ERROR:' "$ALTOOL_LOG"; then
+            echo "::error::altool printed ERROR: lines despite exit 0 — upload rejected"
+            exit 1
+          fi
 
       - name: Cleanup keychain
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,6 +423,14 @@ jobs:
         run: |
           TAG_NAME="${{ needs.prepare.outputs.tag_name }}"
           DISPLAY_VERSION="${{ needs.prepare.outputs.display_version }}"
+          # Skip if the tag already exists on the remote — supports
+          # iOS-only retries at the version Android already shipped.
+          # Existing tag stays put; for a same-version retry the app
+          # commit is unchanged so the tag is still accurate.
+          if git ls-remote --exit-code --tags origin "${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already on remote — skipping (likely a single-platform retry)"
+            exit 0
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "${TAG_NAME}" -m "Release ${DISPLAY_VERSION}"

--- a/walta-app/tiapp.xml.template
+++ b/walta-app/tiapp.xml.template
@@ -39,10 +39,6 @@
         <true/>
         <key>UIStatusBarStyle</key>
         <string>UIStatusBarStyleDefault</string>
-        <key>NSLocationAlwaysUsageDescription</key>
-        <string>
-            We need to record the location of the waterbody survey.
-        </string>
         <key>NSLocationWhenInUseUsageDescription</key>
         <string>
             We need to record the location of the waterbody survey.


### PR DESCRIPTION
## Summary

A pile of release-pipeline fixes bundled because they all touch `release.yml` and together unblock the v2.0.4.22-test iOS retry — and harden the pipeline so the same silent failure can't recur.

### WB-42a — silent TestFlight upload failure (the original symptom)
Trello: https://trello.com/c/jzs2l62K/42-setup-test-server-builds

The v2.0.4.22-test release went green in CI but never reached TestFlight. Root cause: Titanium maps `tiapp.xml` `<version>` to `CFBundleVersion`, which Apple requires to be 1–3 period-separated integers. The `-test` suffix made altool reject the IPA — but altool exited 0, so the workflow step passed and the next step uploaded the (rejected) IPA as a build artifact. From the iOS run log:

```
ERROR: CFBundleVersion, "2.0.4.22-test", must be composed of one to three period-separated integers. (-19239)
Failed to upload archive at 'builds/release/Waterbug.ipa'.
```

Fix: in the iOS bump-version step, write the **numeric** `VERSION` into `<version>` (so `CFBundleVersion` stays integer-only), and inject `CFBundleShortVersionString` into the iOS plist set to the display version so TestFlight users still see the `-test` marker.

### WB-42b — fail upload step when altool prints ERROR but exits 0

The reason WB-42a went silently green: altool's exit code didn't reflect the rejection. Tee altool output to a temp file and grep for timestamped `ERROR:` lines after the call — fail the step explicitly if any are found. Stops the next silent failure from sneaking through.

### WB-42c — tag-release blocks single-platform retries

`tag-release` did an unforced `git tag -a` + push, which would fail when retrying iOS at a version Android already shipped (the tag exists). Pre-check `git ls-remote` and skip cleanly if so. The existing tag stays put — for a same-version retry the app commit is unchanged, so the tag is still accurate.

### WB-42d — gate Release on latest CI for the SHA being released

Release was pure `workflow_dispatch` with no check that CI on the release SHA had passed — it would happily build a known-red commit. New `ci-gate` job calls `gh run list` and fails fast if the latest CI run on the release SHA isn't complete + successful. Adds `skip_ci_gate` boolean input as an escape hatch for the rare case CI is red for an unrelated reason. Side benefit: implicitly enforces "release from main".

### WB-27 — ITMS-90683 location-purpose-string warning
Trello: https://trello.com/c/Re5sRXe6/27-ios-missing-nslocationalwaysandwheninuseusagedescription-in-infoplist

Apple flagged v2.0.4.20 over missing always-location purpose strings. The app only ever requests `Ti.Geolocation.AUTHORIZATION_WHEN_IN_USE` (see [GeoLocationService.js:72-76](walta-app/app/lib/logic/GeoLocationService.js#L72-L76)), so the cleanest fix is to remove the iOS 10-era `NSLocationAlwaysUsageDescription` entirely and keep only `NSLocationWhenInUseUsageDescription`. The plist now matches actual runtime behaviour. If ITMS-90683 still fires after the next test release (e.g. `ti.map` referencing always-APIs at the binary level), we'll add `NSLocationAlwaysAndWhenInUseUsageDescription` back.

## Test plan

- [x] Local simulation of new iOS bump step against template copy: `<version>` numeric, `CFBundleShortVersionString` carries `-test`, location keys match new shape (verification script `/tmp/wb42-verify.sh`)
- [ ] Trigger Release with `environment=test, platforms=ios, version=2.0.4.22` — exercises the bump fix, the altool ERROR check, the tag-skip path, and the CI gate in one run
- [ ] Confirm test build appears in TestFlight with version label `2.0.4.22-test`
- [ ] Confirm next ITMS-90683 warning email does **not** arrive — if it does, add the always-key back
- [ ] Tag `v2.0.4.22-test` stays pointing at `6d7608a1` (Android's app-commit); workflow run goes fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)