### PR TITLE
WB-51: share Waterbug.app/.apk between unit-test and acceptance jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,29 +272,6 @@ jobs:
       - name: Run install.sh
         run: sh install.sh
 
-      - name: Read Titanium SDK version
-        id: ti-version
-        run: |
-          TI_SDK=$(grep -o '<sdk-version>[^<]*' walta-app/tiapp.xml | cut -d'>' -f2)
-          echo "version=$TI_SDK" >> "$GITHUB_OUTPUT"
-
-      # SDK install is needed even with --skip-build because the unit-test
-      # grunt task starts with `titanium clean` (which expects an SDK present).
-      # Cached, so cheap.
-      - name: Restore Titanium SDK cache
-        id: ti-sdk-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/Library/Application Support/Titanium/mobilesdk/osx/${{ steps.ti-version.outputs.version }}
-          key: titanium-sdk-${{ steps.ti-version.outputs.version }}-osx
-
-      - name: Install Titanium SDK
-        if: steps.ti-sdk-cache.outputs.cache-hit != 'true'
-        run: npx titanium sdk install ${{ steps.ti-version.outputs.version }} --no-prompt
-
-      - name: Configure Titanium
-        run: npx titanium config cli.logLevel info
-
       - name: Download Waterbug.app artifact
         uses: actions/download-artifact@v4
         with:
@@ -507,28 +484,6 @@ jobs:
       - name: Run install.sh
         run: sh install.sh
 
-      - name: Read Titanium SDK version
-        id: ti-version
-        run: |
-          TI_SDK=$(grep -o '<sdk-version>[^<]*' walta-app/tiapp.xml | cut -d'>' -f2)
-          echo "version=$TI_SDK" >> "$GITHUB_OUTPUT"
-
-      # SDK install is needed even with --skip-build because the unit-test
-      # grunt task starts with `titanium clean`. Cache hit makes it cheap.
-      - name: Restore Titanium SDK cache
-        id: ti-sdk-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.titanium/mobilesdk/linux/${{ steps.ti-version.outputs.version }}
-          key: titanium-sdk-${{ steps.ti-version.outputs.version }}-linux
-
-      - name: Install Titanium SDK
-        if: steps.ti-sdk-cache.outputs.cache-hit != 'true'
-        run: npx titanium sdk install ${{ steps.ti-version.outputs.version }} --no-prompt
-
-      - name: Configure Titanium
-        run: npx titanium config cli.logLevel info
-
       - name: Download Waterbug.apk artifact
         uses: actions/download-artifact@v4
         with:
@@ -652,28 +607,6 @@ jobs:
 
       - name: Run install.sh
         run: sh install.sh
-
-      - name: Read Titanium SDK version
-        id: ti-version
-        run: |
-          TI_SDK=$(grep -o '<sdk-version>[^<]*' walta-app/tiapp.xml | cut -d'>' -f2)
-          echo "version=$TI_SDK" >> "$GITHUB_OUTPUT"
-
-      # SDK install needed for `titanium clean` (run by the acceptance grunt
-      # task) even though the build itself was done in ios-build. Cached.
-      - name: Restore Titanium SDK cache
-        id: ti-sdk-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/Library/Application Support/Titanium/mobilesdk/osx/${{ steps.ti-version.outputs.version }}
-          key: titanium-sdk-${{ steps.ti-version.outputs.version }}-osx
-
-      - name: Install Titanium SDK
-        if: steps.ti-sdk-cache.outputs.cache-hit != 'true'
-        run: npx titanium sdk install ${{ steps.ti-version.outputs.version }} --no-prompt
-
-      - name: Configure Titanium
-        run: npx titanium config cli.logLevel info
 
       - name: Download Waterbug.app artifact
         uses: actions/download-artifact@v4
@@ -837,28 +770,6 @@ jobs:
 
       - name: Run install.sh
         run: sh install.sh
-
-      - name: Read Titanium SDK version
-        id: ti-version
-        run: |
-          TI_SDK=$(grep -o '<sdk-version>[^<]*' walta-app/tiapp.xml | cut -d'>' -f2)
-          echo "version=$TI_SDK" >> "$GITHUB_OUTPUT"
-
-      # SDK install kept for `titanium clean` parity with unit-test job;
-      # cache hit makes it cheap.
-      - name: Restore Titanium SDK cache
-        id: ti-sdk-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.titanium/mobilesdk/linux/${{ steps.ti-version.outputs.version }}
-          key: titanium-sdk-${{ steps.ti-version.outputs.version }}-linux
-
-      - name: Install Titanium SDK
-        if: steps.ti-sdk-cache.outputs.cache-hit != 'true'
-        run: npx titanium sdk install ${{ steps.ti-version.outputs.version }} --no-prompt
-
-      - name: Configure Titanium
-        run: npx titanium config cli.logLevel info
 
       - name: Download Waterbug.apk artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,21 +102,34 @@ jobs:
         run: npx grunt build-test
 
   # ── 2. iOS simulator unit tests ───────────────────────────────────────────
-  ios-simulator-tests:
-    name: iOS simulator unit tests
+  # ── 2a. iOS simulator build ───────────────────────────────────────────────
+  # Builds Waterbug.app once and uploads it as a workflow artifact so the
+  # iOS unit and acceptance jobs can both consume it instead of each
+  # rebuilding from scratch (WB-51). Tarballed before upload to preserve
+  # the .app bundle's executable bits and framework symlinks, which
+  # actions/upload-artifact@v4 strips otherwise.
+  ios-build:
+    name: iOS simulator build
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
     runs-on: macos-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
+    env:
+      # Pinned to match the acceptance job's WDA cache key — also used by
+      # ios-simulator-tests, so all three iOS jobs share the same Xcode.
+      XCODE_VERSION: "26.3"
     steps:
       - uses: actions/checkout@v4
 
-      - name: Select latest Xcode
+      - name: Select pinned Xcode
         run: |
-          # Pick the highest Xcode version available (matches our App Store target)
-          LATEST_XCODE=$(ls /Applications | grep -E '^Xcode_[0-9]+\.[0-9]+(\.[0-9]+)?\.app$' | sort -V | tail -1)
-          echo "Selecting $LATEST_XCODE"
-          sudo xcode-select -s "/Applications/$LATEST_XCODE/Contents/Developer"
+          XCODE_APP="/Applications/Xcode_${XCODE_VERSION}.app"
+          if [ ! -d "$XCODE_APP" ]; then
+            echo "Xcode ${XCODE_VERSION} not installed on this runner. Available:" >&2
+            ls /Applications | grep -E '^Xcode_' >&2
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE_APP/Contents/Developer"
           xcodebuild -version
 
       - uses: actions/setup-node@v4
@@ -179,7 +192,123 @@ jobs:
       - name: Select iOS simulator
         id: sim
         run: |
-          # Pick the iPhone running the highest iOS runtime
+          # Build needs a valid sim UDID for `-C`, but doesn't require it
+          # to be booted (build-only target).
+          SELECTED=$(xcrun simctl list devices available -j | jq -r '
+            [.devices | to_entries[]
+             | select(.key | test("iOS-[0-9]"))
+             | {runtime: (.key | capture("iOS-(?<v>[0-9-]+)").v),
+                devices: [.value[] | select(.name | contains("iPhone")) | select(.isAvailable)]}]
+            | sort_by(.runtime | split("-") | map(tonumber)) | reverse
+            | .[0]
+            | .devices[0] | "\(.udid) \(.name)"')
+          UDID=$(echo "$SELECTED" | cut -d" " -f1)
+          NAME=$(echo "$SELECTED" | cut -d" " -f2-)
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+          echo "Selected: $NAME ($UDID)"
+
+      - name: Build Waterbug.app for iOS simulator
+        env:
+          SIM_UDID: ${{ steps.sim.outputs.udid }}
+        run: npx grunt exec:build:ios:test-sim
+
+      - name: Tarball Waterbug.app (preserves perms + symlinks)
+        run: tar -czf /tmp/waterbug-ios-sim.tgz -C builds/test-sim Waterbug.app
+
+      - name: Upload Waterbug.app artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: waterbug-ios-sim
+          path: /tmp/waterbug-ios-sim.tgz
+          retention-days: 1
+
+  # ── 2b. iOS simulator unit tests ──────────────────────────────────────────
+  ios-simulator-tests:
+    name: iOS simulator unit tests
+    needs: [changes, ios-build]
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: macos-latest
+    timeout-minutes: 30
+    env:
+      XCODE_VERSION: "26.3"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select pinned Xcode
+        run: |
+          XCODE_APP="/Applications/Xcode_${XCODE_VERSION}.app"
+          if [ ! -d "$XCODE_APP" ]; then
+            echo "Xcode ${XCODE_VERSION} not installed on this runner. Available:" >&2
+            ls /Applications | grep -E '^Xcode_' >&2
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE_APP/Contents/Developer"
+          xcodebuild -version
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Restore node_modules cache
+        id: node-modules-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+
+      - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: npm install --ignore-scripts
+
+      - name: Save node_modules cache
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Run install.sh
+        run: sh install.sh
+
+      - name: Read Titanium SDK version
+        id: ti-version
+        run: |
+          TI_SDK=$(grep -o '<sdk-version>[^<]*' walta-app/tiapp.xml | cut -d'>' -f2)
+          echo "version=$TI_SDK" >> "$GITHUB_OUTPUT"
+
+      # SDK install is needed even with --skip-build because the unit-test
+      # grunt task starts with `titanium clean` (which expects an SDK present).
+      # Cached, so cheap.
+      - name: Restore Titanium SDK cache
+        id: ti-sdk-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/Library/Application Support/Titanium/mobilesdk/osx/${{ steps.ti-version.outputs.version }}
+          key: titanium-sdk-${{ steps.ti-version.outputs.version }}-osx
+
+      - name: Install Titanium SDK
+        if: steps.ti-sdk-cache.outputs.cache-hit != 'true'
+        run: npx titanium sdk install ${{ steps.ti-version.outputs.version }} --no-prompt
+
+      - name: Configure Titanium
+        run: npx titanium config cli.logLevel info
+
+      - name: Download Waterbug.app artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: waterbug-ios-sim
+          path: /tmp
+
+      - name: Extract Waterbug.app to builds/test-sim
+        run: |
+          mkdir -p builds/test-sim
+          tar -xzf /tmp/waterbug-ios-sim.tgz -C builds/test-sim
+
+      - name: Select iOS simulator
+        id: sim
+        run: |
           SELECTED=$(xcrun simctl list devices available -j | jq -r '
             [.devices | to_entries[]
              | select(.key | test("iOS-[0-9]"))
@@ -195,9 +324,6 @@ jobs:
 
       - name: Boot iOS simulator
         run: |
-          # `bootstatus` without `-b` waits for the in-flight boot started
-          # above; with `-b` it races to issue a second boot and fails with
-          # SimError 405 once the device has reached "Booted" state.
           xcrun simctl boot ${{ steps.sim.outputs.udid }} || true
           xcrun simctl bootstatus ${{ steps.sim.outputs.udid }}
           echo "Simulator booted"
@@ -216,7 +342,7 @@ jobs:
         # if the device-side mocha runner emitted UNIT_TESTS_FAILED — a
         # deterministic failure won't pass on re-run, so retrying just
         # burns ~15 min for nothing. See WB-48.
-        run: bash build-utils/run-unit-tests-with-retry.sh npx grunt --platform=ios --simulator unit-test
+        run: bash build-utils/run-unit-tests-with-retry.sh npx grunt --platform=ios --simulator --skip-build unit-test
 
       - name: Capture simulator diagnostics on failure
         if: failure()
@@ -382,7 +508,7 @@ jobs:
   # ── 4. iOS simulator acceptance tests ─────────────────────────────────────
   ios-simulator-acceptance-tests:
     name: iOS simulator acceptance tests
-    needs: changes
+    needs: [changes, ios-build]
     if: needs.changes.outputs.relevant == 'true'
     runs-on: macos-latest
     timeout-minutes: 30
@@ -443,6 +569,8 @@ jobs:
           TI_SDK=$(grep -o '<sdk-version>[^<]*' walta-app/tiapp.xml | cut -d'>' -f2)
           echo "version=$TI_SDK" >> "$GITHUB_OUTPUT"
 
+      # SDK install needed for `titanium clean` (run by the acceptance grunt
+      # task) even though the build itself was done in ios-build. Cached.
       - name: Restore Titanium SDK cache
         id: ti-sdk-cache
         uses: actions/cache/restore@v4
@@ -454,18 +582,19 @@ jobs:
         if: steps.ti-sdk-cache.outputs.cache-hit != 'true'
         run: npx titanium sdk install ${{ steps.ti-version.outputs.version }} --no-prompt
 
-      - name: Save Titanium SDK cache
-        if: steps.ti-sdk-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ~/Library/Application Support/Titanium/mobilesdk/osx/${{ steps.ti-version.outputs.version }}
-          key: titanium-sdk-${{ steps.ti-version.outputs.version }}-osx
-
       - name: Configure Titanium
         run: npx titanium config cli.logLevel info
 
-      - name: Apply SDK patches
-        run: npm run patch-sdk
+      - name: Download Waterbug.app artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: waterbug-ios-sim
+          path: /tmp
+
+      - name: Extract Waterbug.app to builds/test-sim
+        run: |
+          mkdir -p builds/test-sim
+          tar -xzf /tmp/waterbug-ios-sim.tgz -C builds/test-sim
 
       - name: Select iOS simulator
         id: sim
@@ -554,7 +683,7 @@ jobs:
         # the trade-off favours green over fast-fail.
         run: |
           for attempt in 1 2; do
-            if npx grunt --platform=ios --simulator acceptance-test; then
+            if npx grunt --platform=ios --simulator --skip-build acceptance-test; then
               exit 0
             fi
             echo "::warning ::iOS acceptance attempt $attempt failed; retrying once (WB-54)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,12 +371,16 @@ jobs:
   # - API 30 google_apis: last Android API level with x86 system images ✓
   # - ubuntu-latest: cheapest runner option ✓
   # The AVD name "Medium_Phone_API_36.1" matches AndroidEmulatorLauncher.js.
-  android-emulator-tests:
-    name: Android emulator unit tests
+  # ── 3a. Android emulator build ────────────────────────────────────────────
+  # Builds Waterbug.apk once for the x86 emulator and uploads it as a
+  # workflow artifact. Smaller savings than the iOS equivalent (Linux
+  # gradle is fast) but kept symmetric with iOS for clarity (WB-51).
+  android-build:
+    name: Android emulator build
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -445,6 +449,92 @@ jobs:
       - name: Apply SDK patches
         run: npm run patch-sdk
 
+      - name: Build Waterbug.apk for emulator
+        run: npx grunt exec:build:android:test-sim
+
+      - name: Upload Waterbug.apk artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: waterbug-android-sim
+          path: builds/test-sim/Waterbug.apk
+          retention-days: 1
+
+  # ── 3b. Android emulator unit tests ───────────────────────────────────────
+  # Runs on ubuntu-latest (x86_64) with an x86 emulator image.
+  # - x86_64 ubuntu: KVM supports x86 guests natively ✓
+  # - x86 arch: bundled Titanium modules ship x86 libs ✓
+  # - API 30 google_apis: last Android API level with x86 system images ✓
+  # - ubuntu-latest: cheapest runner option ✓
+  # The AVD name "Medium_Phone_API_36.1" matches AndroidEmulatorLauncher.js.
+  android-emulator-tests:
+    name: Android emulator unit tests
+    needs: [changes, android-build]
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Restore node_modules cache
+        id: node-modules-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+
+      - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: npm install --ignore-scripts
+
+      - name: Save node_modules cache
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Run install.sh
+        run: sh install.sh
+
+      - name: Read Titanium SDK version
+        id: ti-version
+        run: |
+          TI_SDK=$(grep -o '<sdk-version>[^<]*' walta-app/tiapp.xml | cut -d'>' -f2)
+          echo "version=$TI_SDK" >> "$GITHUB_OUTPUT"
+
+      # SDK install is needed even with --skip-build because the unit-test
+      # grunt task starts with `titanium clean`. Cache hit makes it cheap.
+      - name: Restore Titanium SDK cache
+        id: ti-sdk-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.titanium/mobilesdk/linux/${{ steps.ti-version.outputs.version }}
+          key: titanium-sdk-${{ steps.ti-version.outputs.version }}-linux
+
+      - name: Install Titanium SDK
+        if: steps.ti-sdk-cache.outputs.cache-hit != 'true'
+        run: npx titanium sdk install ${{ steps.ti-version.outputs.version }} --no-prompt
+
+      - name: Configure Titanium
+        run: npx titanium config cli.logLevel info
+
+      - name: Download Waterbug.apk artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: waterbug-android-sim
+          path: builds/test-sim
+
       - name: Enable KVM for hardware acceleration
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -503,7 +593,7 @@ jobs:
           # cycle for nothing. See WB-48.
           script: |
             echo "Emulator booted"
-            bash build-utils/run-unit-tests-with-retry.sh npx grunt --platform=android --simulator unit-test
+            bash build-utils/run-unit-tests-with-retry.sh npx grunt --platform=android --simulator --skip-build unit-test
 
   # ── 4. iOS simulator acceptance tests ─────────────────────────────────────
   ios-simulator-acceptance-tests:
@@ -709,7 +799,7 @@ jobs:
   # ── 5. Android emulator acceptance tests ──────────────────────────────────
   android-emulator-acceptance-tests:
     name: Android emulator acceptance tests
-    needs: changes
+    needs: [changes, android-build]
     if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -748,15 +838,14 @@ jobs:
       - name: Run install.sh
         run: sh install.sh
 
-      - name: Add x86 ABI for emulator builds
-        run: sed -i 's|<abi>arm64-v8a,armeabi-v7a</abi>|<abi>arm64-v8a,armeabi-v7a,x86</abi>|' walta-app/tiapp.xml
-
       - name: Read Titanium SDK version
         id: ti-version
         run: |
           TI_SDK=$(grep -o '<sdk-version>[^<]*' walta-app/tiapp.xml | cut -d'>' -f2)
           echo "version=$TI_SDK" >> "$GITHUB_OUTPUT"
 
+      # SDK install kept for `titanium clean` parity with unit-test job;
+      # cache hit makes it cheap.
       - name: Restore Titanium SDK cache
         id: ti-sdk-cache
         uses: actions/cache/restore@v4
@@ -768,18 +857,14 @@ jobs:
         if: steps.ti-sdk-cache.outputs.cache-hit != 'true'
         run: npx titanium sdk install ${{ steps.ti-version.outputs.version }} --no-prompt
 
-      - name: Save Titanium SDK cache
-        if: steps.ti-sdk-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ~/.titanium/mobilesdk/linux/${{ steps.ti-version.outputs.version }}
-          key: titanium-sdk-${{ steps.ti-version.outputs.version }}-linux
-
       - name: Configure Titanium
         run: npx titanium config cli.logLevel info
 
-      - name: Apply SDK patches
-        run: npm run patch-sdk
+      - name: Download Waterbug.apk artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: waterbug-android-sim
+          path: builds/test-sim
 
       - name: Enable KVM for hardware acceleration
         run: |
@@ -848,4 +933,4 @@ jobs:
           # model.
           script: |
             echo "Emulator booted"
-            ( npx grunt acceptance-preflight-test-android-emulator && npx grunt --platform=android --simulator acceptance-test ) || { echo "::warning ::Android acceptance first attempt failed; retrying once (WB-54)"; npx grunt acceptance-preflight-test-android-emulator && npx grunt --platform=android --simulator acceptance-test; }
+            ( npx grunt acceptance-preflight-test-android-emulator && npx grunt --platform=android --simulator --skip-build acceptance-test ) || { echo "::warning ::Android acceptance first attempt failed; retrying once (WB-54)"; npx grunt acceptance-preflight-test-android-emulator && npx grunt --platform=android --simulator --skip-build acceptance-test; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,6 +426,22 @@ jobs:
       - name: Apply SDK patches
         run: npm run patch-sdk
 
+      # Cache Maven Central / Google jars so a Maven 403 (or rate-limit)
+      # only bites the first build per cache miss instead of every run.
+      # Key on the Titanium SDK version (which pins AGP / gradle) + tiapp.xml
+      # (where module versions are declared); restore-keys lets a stale
+      # cache populate most of the deps when only one bumps.
+      - name: Cache gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-ti${{ steps.ti-version.outputs.version }}-${{ hashFiles('walta-app/tiapp.xml') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-ti${{ steps.ti-version.outputs.version }}-
+            gradle-${{ runner.os }}-
+
       - name: Build Waterbug.apk for emulator
         run: npx grunt exec:build:android:test-sim
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -873,7 +873,13 @@ const KobitonAPI = require("./features/support/kobiton");
           done();
         }).catch(err => { grunt.fail.fatal(err); done(); });
       } else {
-        grunt.task.run('clean');
+        // Clean only makes sense as a "fresh build" guarantee — when
+        // --skip-build is set (e.g. CI consuming a prebuilt artifact),
+        // skip clean too so we don't need the Titanium SDK at runtime
+        // and don't clobber the prebuilt outputs (WB-51).
+        if (!grunt.option('skip-build')) {
+          grunt.task.run('clean');
+        }
         // Simulator builds share the canonical test-sim binary with the
         // acceptance suite (WB-51). Device unit-test builds keep their
         // own newer-target since the device path is distinct.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -236,19 +236,6 @@ const KobitonAPI = require("./features/support/kobiton");
           }
           break;
 
-        case "unit-test-sim":
-          emulator();
-          args.push("--unit-test");
-          post_cmds.push("mkdir -p ./builds/unit-test");
-          if ( platform === "android" ) {
-            args.push("--output-dir builds/unit-test");
-            post_cmds.push("cp ./walta-app/build/android/app/build/outputs/apk/debug/app-debug.apk ./builds/unit-test/Waterbug.apk");
-          } else if ( platform === "ios" ) {
-            post_cmds.push("rm -rf ./builds/unit-test/Waterbug.app");
-            post_cmds.push("cp -r ./walta-app/build/iphone/build/Products/Debug-iphonesimulator/Waterbug.app ./builds/unit-test/Waterbug.app");
-          }
-          break;
-
         case "release":
           production();
           args.push("--output-dir builds/release");
@@ -337,7 +324,7 @@ const KobitonAPI = require("./features/support/kobiton");
           },
 
           clean_dist: {
-            command: 'rm -r ./builds/{release,debug,test,unit-test,unit-test-sim}/*.{apk,ipa,aab,app}',
+            command: 'rm -r ./builds/{release,debug,test,test-sim,unit-test}/*.{apk,ipa,aab,app}',
             exitCode: [ 0, 1 ],
             stdout: "inherit", stderr: "false",
             options: {
@@ -529,9 +516,6 @@ const KobitonAPI = require("./features/support/kobiton");
           unit_test_android: build_if_newer_options("android", "unit-test"),
           unit_test_ios: build_if_newer_options("ios", "unit-test"),
 
-          unit_test_android_sim: build_if_newer_options("android", "unit-test-sim"),
-          unit_test_ios_sim: build_if_newer_options("ios", "unit-test-sim"),
-
           test_android: build_if_newer_options("android", "test"),
           test_ios: build_if_newer_options("ios", "test"),
 
@@ -653,9 +637,18 @@ const KobitonAPI = require("./features/support/kobiton");
         return './walta-app/build/iphone/build/Products/Debug-iphoneos/Waterbug.app';
       }
 
-      // Everything else is packaged into builds/<buildType>/
+      // WB-51: simulator builds share one canonical artifact regardless of
+      // buildType — `unit-test`/`test-sim` produce identical binaries since
+      // WB-25's runtime dispatcher decides modes via a launch arg.
+      if (isSimulator) {
+        return platform === 'android'
+          ? './builds/test-sim/Waterbug.apk'
+          : './builds/test-sim/Waterbug.app';
+      }
+
+      // Device packages still live under builds/<buildType>/
       const ext = platform === 'android' ? 'apk'
-        : ['debug', 'unit-test', 'test-sim'].includes(buildType) ? 'app'
+        : ['debug', 'unit-test'].includes(buildType) ? 'app'
         : 'ipa';
       return `./builds/${buildType}/Waterbug.${ext}`;
     }
@@ -881,7 +874,10 @@ const KobitonAPI = require("./features/support/kobiton");
         }).catch(err => { grunt.fail.fatal(err); done(); });
       } else {
         grunt.task.run('clean');
-        grunt.task.run(`newer:unit_test_${platform}${isSimulator?"_sim":""}`);
+        // Simulator builds share the canonical test-sim binary with the
+        // acceptance suite (WB-51). Device unit-test builds keep their
+        // own newer-target since the device path is distinct.
+        grunt.task.run(`newer:${isSimulator ? `test_sim_${platform}` : `unit_test_${platform}`}`);
 
         let mockServer = createMockCerdiServer();
         mockServer.makeMockSample();


### PR DESCRIPTION
## Summary
- New `iOS simulator build` and `Android emulator build` jobs build the test artifact once and upload it as a workflow artifact (tarballed for iOS to preserve `.app` perms + framework symlinks).
- Unit-test and acceptance jobs on each platform now `download-artifact` and run with `--skip-build`.
- The unit-test grunt task skips its leading `clean` when `--skip-build` is set, which lets us drop the Titanium SDK install/cache from all four test jobs (clean was the only thing requiring it).
- New `gradle dependencies` cache in the Android build job — Maven Central 403 flakes only bite the first build per cache miss now.
- Drive-by Gruntfile cleanup: the `unit-test-sim` build_type is gone (it produced the same binary as `test-sim` post-WB-25). Both flows share `./builds/test-sim/Waterbug.{app,apk}` — also a small local-dev win.

[Trello WB-51](https://trello.com/c/ca3fYG8b/51-ci-share-waterbugapp-between-ios-unit-test-and-acceptance-jobs). Depends on WB-25 (already shipped — runtime dispatcher in `app/controllers/index.js` makes the shared binary safe).

## CI savings (measured, run 25430874053)

| Job | Before | After | Saved |
|---|---|---|---|
| iOS simulator unit tests | 9m04s | **4m29s** | −4m35s |
| iOS simulator acceptance tests | 30m14s (hit cap) | **23m44s** | −6m30s |
| Android emulator unit tests | ~9m | **3m45s** | −5m15s |
| Android emulator acceptance tests | 6m21s | **4m54s** | −1m27s |
| New iOS build job | — | +2m20s | |
| New Android build job | — | +2m47s | |

Net ~**12 min compute saved per run**. iOS acceptance now lands inside the 30-min cap (was hitting it on PR #222). Unblocks WB-52.

## Test plan
- [x] `npx grunt unit-test-node` (117) and `npx grunt build-test` (67) green
- [x] `npx grunt exec:build:android:test-sim` lands at `./builds/test-sim/Waterbug.apk` with no `./builds/unit-test/` residue
- [x] CI green: all four test jobs consume the artifact and pass; both build jobs produce the artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)