### PR TITLE
WB-52: drop acceptance preflight from iOS and Android CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -699,20 +699,6 @@ jobs:
           restore-keys: |
             appium-cache-${{ runner.os }}-
 
-      - name: Acceptance preflight (Appium launcher integration test)
-        env:
-          SIM_UDID: ${{ steps.sim.outputs.udid }}
-        # Retry once (WB-54). The preflight is intentionally fast-fail
-        # so the cost of a retry is small (~1 min).
-        run: |
-          for attempt in 1 2; do
-            if npx grunt acceptance-preflight-test-ios-simulator; then
-              exit 0
-            fi
-            echo "::warning ::iOS preflight attempt $attempt failed; retrying once (WB-54)"
-          done
-          exit 1
-
       - name: Run iOS acceptance tests
         env:
           SIM_UDID: ${{ steps.sim.outputs.udid }}
@@ -860,4 +846,4 @@ jobs:
           # model.
           script: |
             echo "Emulator booted"
-            ( npx grunt acceptance-preflight-test-android-emulator && npx grunt --platform=android --simulator --skip-build acceptance-test ) || { echo "::warning ::Android acceptance first attempt failed; retrying once (WB-54)"; npx grunt acceptance-preflight-test-android-emulator && npx grunt --platform=android --simulator --skip-build acceptance-test; }
+            npx grunt --platform=android --simulator --skip-build acceptance-test || { echo "::warning ::Android acceptance first attempt failed; retrying once (WB-54)"; npx grunt --platform=android --simulator --skip-build acceptance-test; }


### PR DESCRIPTION
## Summary
Removes the `Acceptance preflight (Appium launcher integration test)` step from the iOS acceptance job, and the preflight wrapper from the Android emulator-runner script. Both grunt tasks stay in the Gruntfile as local fast-fail smoke tests.

[Trello WB-52](https://trello.com/c/CdwkmbsI/52-drop-ios-acceptance-preflight-once-acceptance-is-reliably-green). User asked to extend the original "iOS only when stable" trigger to both platforms after looking at the recent CI history.

## Empirical case for dropping it

Checked the last 25 main CI runs:

- **0 preflight retries / failures** across 8 recent successful runs on iOS *and* Android (all preflight steps passed first-attempt).
- **3 main failures total**, of which:
  - 2 had both acceptance jobs succeed (failures were elsewhere — unit tests, build).
  - 1 had iOS acceptance fail at the cucumber step *after preflight passed* (so preflight didn't catch it).
- Preflight has not caught a real issue in the recent window — it's just adding ~4-5 min to iOS and ~30s to Android per run.

## Expected savings
- iOS acceptance: ~4-5 min off per run (HelloWorld xcodebuild + appium launcher integration test go away)
- Android acceptance: ~30s off per run

Stacked with WB-51, iOS acceptance lands well under 20 min total.

## Test plan
- [x] YAML lints clean
- [ ] CI green on this PR
- [ ] After merge: iOS + Android acceptance still green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)