### PR TITLE
WB-67: walta://reset deeplink for in-app per-scenario reset

### DIFF
--- a/features/support/cucumber.js
+++ b/features/support/cucumber.js
@@ -131,30 +131,31 @@ Before(async function () {
     this.isSimulator = global.isSimulator;
     setUpWorld(this);
     if (!global.first) {
-        // driver.reset() was removed in webdriverio v9 — terminate +
-        // relaunch is enough to restart the JS context and let the
-        // deeplink login re-authenticate. We deliberately do NOT wipe
-        // app data here: pm clear (Android) is fast but the iOS
-        // equivalent (removeApp + installApp) destabilises the
-        // simulator. Sample-DB leakage between scenarios is tolerable
-        // today; if it bites we'll reintroduce a cross-platform reset
-        // via a `walta://reset` deeplink action rather than per-platform
-        // hacks.
+        // WB-67: in-app reset via the `walta://reset` deeplink replaces
+        // the previous terminateApp + launch + foreground-poll cycle.
+        // The handler (lib/util/AppReset.js) clears auth tokens, wipes
+        // sample/taxa tables, re-instantiates Alloy.Models, and fires
+        // Topics.HOME. The action is only registered in non-production
+        // builds — release builds silently ignore the URL.
         const appId = global.launcher.appId;
-        await this.driver.terminateApp(appId);
-        await global.launcher.launch(appId, launchArgs());
-        // Wait until the app is actually in the foreground before
-        // proceeding — activateApp can return before the UI is ready,
-        // especially when WDA was started from a prebuilt cache.
-        if (global.platform === 'ios') {
-            // Reinstall + launch can take ~30s on a cold simulator;
-            // poll up to 60s before declaring the app stuck.
-            for (let i = 0; i < 120; i++) {
-                const state = await this.driver.execute('mobile: queryAppState', { bundleId: appId });
-                if (state === 4) break;
-                await new Promise(r => setTimeout(r, 500));
-            }
+        const url = 'walta://reset';
+        if (this.platform === 'android') {
+            await this.driver.execute('mobile: deepLink', {
+                url,
+                package: appId,
+                waitForLaunch: false,
+            });
+        } else {
+            await this.driver.execute('mobile: deepLink', {
+                url,
+                bundleId: appId,
+            });
         }
+        // Topics.HOME → Navigation.openController("Menu") is async; give
+        // the new Menu window a moment to land before the first step
+        // queries the UI. (Avoids the stale-element race the login step
+        // also guards against post-LOGGEDIN.)
+        await new Promise(r => setTimeout(r, 500));
     } else {
         global.first = false;
     }

--- a/test/UrlActions_spec.js
+++ b/test/UrlActions_spec.js
@@ -69,4 +69,29 @@ describe("UrlActions", function () {
       expect(actions.actions.login.handler).to.be.a("function");
     });
   });
+
+  describe("dispatch(reset)", function () {
+    // The reset action is the cucumber Before-hook fast path — replaces a
+    // slow `terminateApp + launch + poll` cycle. Production builds must not
+    // register it (a stray walta://reset URL must not wipe user data), so
+    // the action is gated behind an `appReset` callback that index-app.js
+    // only passes in non-production builds.
+    it("registers the reset action and invokes appReset when called", async function () {
+      const appReset = sinon.stub();
+      const withReset = UrlActions.create({ cerdiApi, onLoggedIn, appReset });
+      expect(withReset.actions.reset).to.exist;
+      expect(withReset.actions.reset.params).to.deep.equal([]);
+      await withReset.dispatch("walta://reset");
+      expect(appReset.calledOnce).to.be.true;
+    });
+
+    it("omits the reset action when no appReset callback is provided", function () {
+      // production-build safety: if index-app.js doesn't pass appReset
+      // (because Ti.App.deployType === 'production'), the action is absent
+      // from the registry and a walta://reset URL is silently ignored.
+      expect(actions.actions.reset).to.be.undefined;
+      const result = actions.dispatch("walta://reset");
+      expect(result).to.be.undefined;
+    });
+  });
 });

--- a/walta-app/app/alloy.js
+++ b/walta-app/app/alloy.js
@@ -22,6 +22,19 @@ if (OS_ANDROID) {
         var intent = Ti.Android.currentActivity.intent;
         serverUrl = intent.getStringExtra("cerdiServerUrl");
         apiSecret = intent.getStringExtra("cerdiApiSecret");
+        // Persist test launchargs so subsequent cold-launches recover them.
+        // `mobile: deepLink` (used by acceptance tests for walta://reset)
+        // restarts the activity with only the URI in the intent — no extras.
+        // Without this, alloy.js would fall back to the production sandbox
+        // URL and login would never reach the mock. Guarded on deployType
+        // so release builds never write these (and a release install never
+        // carries the extras anyway, so reads stay null).
+        if (Ti.App.deployType !== 'production') {
+            if (serverUrl) Ti.App.Properties.setString("cerdiServerUrl", serverUrl);
+            if (apiSecret) Ti.App.Properties.setString("cerdiApiSecret", apiSecret);
+            if (!serverUrl) serverUrl = Ti.App.Properties.getString("cerdiServerUrl");
+            if (!apiSecret) apiSecret = Ti.App.Properties.getString("cerdiApiSecret");
+        }
         Ti.API.debug(`[walta-launchargs] android intent.data=${intent.data} cerdiServerUrl=${serverUrl}`);
     } catch (e) {
         Ti.API.debug(`[walta-launchargs] android intent read failed: ${e && e.message}`);

--- a/walta-app/app/controllers/Menu.js
+++ b/walta-app/app/controllers/Menu.js
@@ -8,7 +8,14 @@ if (Alloy.CFG.environment === "production") {
   $.appVersion.text = `Test Server v${Ti.App.version}`;
   $.appVersion.color = Alloy.CFG.colors.errorDark;
 }
+// Refresh the login label whenever auth state changes — lets the menu stay
+// correct without needing to be recreated (which Navigation.openController
+// won't do anyway when Menu is already current; see WB-67).
+function onLoggedIn() { updateLoginText(); }
+Topics.subscribe(Topics.LOGGEDIN, onLoggedIn);
+
 $.TopLevelWindow.addEventListener('close', function cleanUp() {
+  Topics.unsubscribe(Topics.LOGGEDIN, onLoggedIn);
   $.destroy();
   $.off();
   $.TopLevelWindow.removeEventListener('close', cleanUp );

--- a/walta-app/app/controllers/index-app.js
+++ b/walta-app/app/controllers/index-app.js
@@ -6,6 +6,7 @@ var Topics = require('ui/Topics');
 var SampleSync = require("logic/SampleSync");
 var PlatformSpecific = require("logic/PlatformSpecific");
 var UrlActions = require("UrlActions");
+var AppReset = require("util/AppReset");
 var { System } = require("logic/System");
 var { View } = require("logic/View");
 var { Survey } = require("logic/Survey");
@@ -19,9 +20,14 @@ Alloy.Globals.CerdiApi = CerdiApi.createCerdiApi( Alloy.CFG.cerdiServerUrl, Allo
 // `walta://` URL scheme dispatcher — see UrlActions.js for the action
 // registry. Acceptance tests use `walta://login?email=...&password=...`
 // to bypass the login UI; the same surface is available in production.
+//
+// `walta://reset` (cucumber Before-hook fast path) is registered only in
+// non-production builds (WB-67) — release builds must not be wiped by a
+// stray reset URL.
 var urlActions = UrlActions.create({
   cerdiApi: Alloy.Globals.CerdiApi,
   onLoggedIn: function () { Topics.fireTopicEvent(Topics.LOGGEDIN); },
+  appReset: Ti.App.deployType !== 'production' ? AppReset.reset : undefined,
 });
 function handleDeeplink(url) {
   Logger.log(`[walta-deeplink] dispatch url=${url}`);

--- a/walta-app/app/lib/UrlActions.js
+++ b/walta-app/app/lib/UrlActions.js
@@ -1,4 +1,4 @@
-function create({ cerdiApi, onLoggedIn }) {
+function create({ cerdiApi, onLoggedIn, appReset }) {
   const actions = {
     login: {
       params: ["email", "password"],
@@ -18,6 +18,17 @@ function create({ cerdiApi, onLoggedIn }) {
       }
     }
   };
+
+  // walta://reset — cucumber Before-hook fast path. Only registered when
+  // an appReset callback is supplied (i.e. non-production builds), so a
+  // release build silently ignores walta://reset URLs and can't have its
+  // user data wiped by a stray deeplink.
+  if (appReset) {
+    actions.reset = {
+      params: [],
+      handler: () => Promise.resolve(appReset()),
+    };
+  }
 
   function parse(url) {
     // Manual parser — Titanium 13.x's V8 doesn't expose the WHATWG URL

--- a/walta-app/app/lib/logic/Navigation.js
+++ b/walta-app/app/lib/logic/Navigation.js
@@ -92,30 +92,10 @@ Navigation.prototype.garbageCollectControllers = async function (page) {
 
 }
 
-// Two pages are "the same screen" if they show the same controller for the
-// same key node (or no node at all, e.g. Home).
-function isSameScreen(a, b) {
-    if (a.ctl !== b.ctl) return false;
-    const nodeA = a.args && a.args.node && a.args.node.id;
-    const nodeB = b.args && b.args.node && b.args.node.id;
-    return nodeA === nodeB;
-}
-
 Navigation.prototype.openController = async function (ctl, args) {
         if (!args) args = {};
         if (!args.slide) args.slide = "none";
         let page = { ctl: ctl, args: args };
-
-        // Going to the screen we're already on is a no-op. Saves a redundant
-        // controller construction + window transition, and avoids back-to-back
-        // openController calls confusing the platform driver in deeplink-driven
-        // flows (e.g. walta://login firing Topics.LOGGEDIN → Topics.HOME while
-        // already on Menu — see WB-67).
-        const top = this.history[this.history.length - 1];
-        if (top && isSameScreen(top, page)) {
-            return;
-        }
-
         try {
             await this.garbageCollectControllers(page);
 

--- a/walta-app/app/lib/logic/Navigation.js
+++ b/walta-app/app/lib/logic/Navigation.js
@@ -92,14 +92,33 @@ Navigation.prototype.garbageCollectControllers = async function (page) {
 
 }
 
+// Two pages are "the same screen" if they show the same controller for the
+// same key node (or no node at all, e.g. Home).
+function isSameScreen(a, b) {
+    if (a.ctl !== b.ctl) return false;
+    const nodeA = a.args && a.args.node && a.args.node.id;
+    const nodeB = b.args && b.args.node && b.args.node.id;
+    return nodeA === nodeB;
+}
+
 Navigation.prototype.openController = async function (ctl, args) {
         if (!args) args = {};
-        if (!args.slide) args.slide = "none";    
+        if (!args.slide) args.slide = "none";
         let page = { ctl: ctl, args: args };
-        
+
+        // Going to the screen we're already on is a no-op. Saves a redundant
+        // controller construction + window transition, and avoids back-to-back
+        // openController calls confusing the platform driver in deeplink-driven
+        // flows (e.g. walta://login firing Topics.LOGGEDIN → Topics.HOME while
+        // already on Menu — see WB-67).
+        const top = this.history[this.history.length - 1];
+        if (top && isSameScreen(top, page)) {
+            return;
+        }
+
         try {
             await this.garbageCollectControllers(page);
-            
+
             this.history.push(page);
             dumpHistory(this.history);
             await this.onOpenView(ctl, args);

--- a/walta-app/app/lib/util/AppReset.js
+++ b/walta-app/app/lib/util/AppReset.js
@@ -1,0 +1,42 @@
+// Brings the running app back to a clean per-scenario state without a
+// process restart. Triggered by the `walta://reset` deeplink action,
+// which is itself only registered in non-production builds — see
+// controllers/index-app.js. Used by features/support/cucumber.js to
+// replace the slow per-scenario `terminateApp + launch + poll` cycle
+// (WB-67).
+
+const Topics = require('ui/Topics');
+
+function reset() {
+  // Logout — drop the persistent user/app tokens so the next scenario
+  // starts unauthenticated. CerdiApi.storeUserToken handles
+  // userAccessUsername + userAccessTokenLive; appAccessTokenLive is a
+  // separate key.
+  Alloy.Globals.CerdiApi.storeUserToken(null, null);
+  Ti.App.Properties.removeProperty('appAccessTokenLive');
+
+  // Wipe the local sample/taxa tables. Same DELETE pattern as
+  // walta-app/app/spec/util/TestUtils.clearDatabase.
+  const db = Ti.Database.open('samples');
+  db.execute('DELETE FROM sample');
+  db.execute('DELETE FROM taxa');
+  db.close();
+
+  // Re-instantiate Alloy.Models / Collections so in-memory caches don't
+  // leak across scenarios.
+  Alloy.Models.sample = null;
+  Alloy.Models.taxa = null;
+  Alloy.Collections.sample = null;
+  Alloy.Collections.taxa = null;
+  Alloy.Collections.instance('sample');
+  Alloy.Collections.instance('taxa');
+  Alloy.Models.instance('sample');
+  Alloy.Models.instance('taxa');
+
+  // Topics.HOME → Navigation.openController("Menu") (see Main.js). The
+  // navigation logic truncates the history and fires PAGES_UNLOADED so
+  // intermediate controllers clean themselves up.
+  Topics.fireTopicEvent(Topics.HOME);
+}
+
+exports.reset = reset;


### PR DESCRIPTION
## Summary
- New `walta://reset` deeplink action that, when fired into the running app, performs an in-app reset: clears auth tokens, wipes the local sample/taxa tables, re-instantiates `Alloy.Models`, and fires `Topics.HOME` to navigate back to the menu.
- Cucumber's per-scenario `Before` hook now fires the deeplink (`mobile: deepLink`) instead of `terminateApp + launch + foreground-poll`. That sequence was hitting the 60s default Before-hook timeout on iOS sim flakes (XCTDaemon "Timed out attempting to launch app") — see PR #216 for the failure that motivated this work.
- **Production safety**: the `reset` action is only registered when `UrlActions.create()` receives an `appReset` callback, and `index-app.js` only passes one when `Ti.App.deployType !== 'production'`. Release builds never know the action exists.

[Trello WB-67](https://trello.com/c/8v87ndxJ/67-replace-per-scenario-terminatelaunch-with-walta-reset-deeplink). Follow-up: [WB-68](https://trello.com/c/hqTjWkKg/68-encapsulate-device-prep-into-androidlauncher-iossimulatorlauncher-drop-redundant-beforeall-commands) covers moving the BeforeAll `adb`/`simctl` device-prep into the launcher classes.

## Why this approach over PR #216's exit-code gate

cucumber-js exits 1 for *both* assertion failures *and* hook failures — they're indistinguishable from the exit code alone. PR #216's WB-54 retry-gate misclassified an XCTDaemon hook timeout as a deterministic test failure and skipped retry. Eliminating the hook flake at the source (no slow per-scenario relaunch) is cheaper than parsing cucumber output to tell flakes from real failures.

## Test plan
- [x] `npx grunt unit-test-node` — 119 specs pass (new `dispatch(reset)` cases in `UrlActions_spec`)
- [x] `npx grunt build-test` — 67 specs pass
- [ ] CI green (iOS + Android acceptance, end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)