### PR TITLE
WB-64 (1/7): grunt build/dev workflow tweaks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,11 @@ npx grunt --platform=ios debug
 npx grunt --platform=android clean release
 npx grunt --platform=ios clean release
 npx grunt --platform=android preview   # Live development with fast iteration
+
+# Add --simulator to target the emulator/iOS simulator instead of a device.
+# Add --reset to wipe Ti.App.Properties / sqlite before launch (handy when a
+# stale auth token from a prior session is poisoning login).
+npx grunt --platform=ios --simulator --reset debug
 ```
 
 ### Test

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -604,6 +604,30 @@ const KobitonAPI = require("./features/support/kobiton");
         .catch((err) => { grunt.fail.fatal(err); done(false); });
     });
 
+    // Wipe persistent app state (Ti.App.Properties / NSUserDefaults / sqlite)
+    // so the next launch starts clean. Android: `pm clear` keeps the app
+    // installed and clears /data. iOS sim: no `pm clear` equivalent, so
+    // uninstall + reinstall the freshly-built bundle. iOS device is not
+    // supported (use `grunt install` for that path).
+    grunt.registerTask("reset-app", function(platform, buildType) {
+      const isSimulator = grunt.option('simulator') || false;
+      const { execFileSync } = require('child_process');
+      if (platform === 'android') {
+        const adbBin = process.env.ANDROID_SDK_ROOT
+          ? `${process.env.ANDROID_SDK_ROOT}/platform-tools/adb`
+          : 'adb';
+        execFileSync(adbBin, ['shell', 'pm', 'clear', APP_ID], { stdio: 'inherit' });
+      } else if (platform === 'ios' && isSimulator) {
+        if (!SIM_UDID) grunt.fail.fatal('SIM_UDID environment variable must be set');
+        const appPath = resolveAppPath(platform, buildType, isSimulator);
+        // simctl uninstall is a no-op (exits 0) if the app isn't installed.
+        execFileSync('xcrun', ['simctl', 'uninstall', SIM_UDID, APP_ID], { stdio: 'inherit' });
+        execFileSync('xcrun', ['simctl', 'install', SIM_UDID, appPath], { stdio: 'inherit' });
+      } else {
+        grunt.log.writeln('--reset is only supported for Android and iOS simulator; skipping');
+      }
+    });
+
     grunt.registerTask("install", function(platform, build_type) {
       const done = this.async();
       const isSimulator = grunt.option('simulator') || false;
@@ -994,8 +1018,18 @@ const KobitonAPI = require("./features/support/kobiton");
           done();
         }).catch(err => { grunt.fail.fatal(err); done(); });
       } else {
-        grunt.task.run(`newer:debug_${platform}`);
-        grunt.task.run(`launch:${platform}:debug`);
+        // The `debug` build type targets device (signed dev build); `test-sim`
+        // targets the simulator. Same dev build, different deploy target —
+        // see Gruntfile.js:151 (dev) vs :161 (emulator). Without this branch,
+        // `--simulator debug` installs the device binary on the sim and fails
+        // with EXEC_BAD_FORMAT.
+        const buildType = isSimulator ? 'test-sim' : 'debug';
+        const newerTarget = isSimulator ? `test_sim_${platform}` : `debug_${platform}`;
+        grunt.task.run(`newer:${newerTarget}`);
+        if (grunt.option('reset')) {
+          grunt.task.run(`reset-app:${platform}:${buildType}`);
+        }
+        grunt.task.run(`launch:${platform}:${buildType}`);
         grunt.task.run(`output-logs:${platform}:preview`);
       }
     });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -631,12 +631,19 @@ const KobitonAPI = require("./features/support/kobiton");
         .then(done);
     });
 
+    function isLiveViewBuildType(buildType) {
+      return buildType === 'unit-test-liveview' || buildType === 'debug-liveview';
+    }
+
     function resolveAppPath(platform, buildType, isSimulator) {
       if (!buildType) return null;
-      if (grunt.option('liveview-reuse') && buildType === 'unit-test-liveview') return null;
+      if (grunt.option('liveview-reuse') && isLiveViewBuildType(buildType)) return null;
 
       // LiveView builds come from the Titanium build dir, not builds/
-      if (buildType === 'unit-test-liveview') {
+      // — same raw output for both unit-test-liveview and debug-liveview;
+      // the only difference is whether `unit_test=true` is set as a launch
+      // arg (see launch task below).
+      if (isLiveViewBuildType(buildType)) {
         if (platform === 'android') return './walta-app/build/android/app/build/outputs/apk/debug/app-debug.apk';
         if (isSimulator) return './walta-app/build/iphone/build/Products/Debug-iphonesimulator/Waterbug.app';
         return './walta-app/build/iphone/build/Products/Debug-iphoneos/Waterbug.app';
@@ -982,7 +989,7 @@ const KobitonAPI = require("./features/support/kobiton");
             await liveview.stop();
             await liveview.start();
           }
-          grunt.task.run(`launch:${platform}:unit-test-liveview`);
+          grunt.task.run(`launch:${platform}:debug-liveview`);
           grunt.task.run(`output-logs:${platform}:preview`);
           done();
         }).catch(err => { grunt.fail.fatal(err); done(); });


### PR DESCRIPTION
Part of the WB-64 split — see [#223](https://github.com/TheWaterBugCompany/WALTA/pull/223) for the parent PR.

Two small grunt fixes that surfaced while iterating on the rest of the WB-64 work, but unrelated to the diagnostic-logging story.

## Changes

- **\`grunt debug --liveview\` no longer boots into the test runner.** \`unit_test\` arg was being set unconditionally; now only set for \`unit-test\` build types.
- **\`grunt debug --simulator\` now actually targets the simulator** (was building \`Debug-iphoneos\` and failing on install with \`EXEC_BAD_FORMAT\`). Routes to the existing \`test-sim\` build/launch path when \`--simulator\` is set.
- **New \`--reset\` flag** on \`grunt debug\` — \`simctl uninstall\` + \`install\` on iOS sim, \`adb shell pm clear\` on Android — for wiping \`Ti.App.Properties\` / sqlite between iterations (e.g. when a stale auth token is poisoning login).

## Test plan
- [ ] \`npx grunt --platform=ios --simulator debug\` — installs and launches on the sim
- [ ] \`npx grunt --platform=ios --simulator --reset debug\` — uninstalls + reinstalls before launch
- [ ] \`npx grunt --platform=android --simulator --reset debug\` — \`pm clear\` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)