### PR TITLE
WB-64 (3/7): acceptance test infra — --grep + Log in scenario

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,20 +715,12 @@ jobs:
           done
           exit 1
 
-      - name: Capture simulator diagnostics on failure
-        if: failure()
-        run: |
-          echo "=== Simulator screenshot ==="
-          xcrun simctl io ${{ steps.sim.outputs.udid }} screenshot /tmp/sim-screenshot.png || true
-          echo "=== Last 200 lines of ALL simulator syslog ==="
-          xcrun simctl spawn ${{ steps.sim.outputs.udid }} log show --last 5m --style syslog 2>&1 | grep -i "waterbug\|titanium\|TiAPI\|TiLog\|appium\|cucumber" | tail -200 || true
-
-      - name: Upload simulator screenshot
+      - name: Upload per-scenario failure artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ios-acceptance-screenshot
-          path: /tmp/sim-screenshot.png
+          name: acceptance-failures-ios
+          path: /tmp/acceptance-artifacts
           if-no-files-found: ignore
 
   # ── 5. Android emulator acceptance tests ──────────────────────────────────
@@ -847,3 +839,11 @@ jobs:
           script: |
             echo "Emulator booted"
             npx grunt --platform=android --simulator --skip-build acceptance-test || { echo "::warning ::Android acceptance first attempt failed; retrying once (WB-54)"; npx grunt --platform=android --simulator --skip-build acceptance-test; }
+
+      - name: Upload per-scenario failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: acceptance-failures-android
+          path: /tmp/acceptance-artifacts
+          if-no-files-found: ignore

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -586,13 +586,14 @@ const KobitonAPI = require("./features/support/kobiton");
     grunt.registerTask("cucumber", function () {
       const done = this.async();
       const tags = grunt.option('cucumber-tags') || 'not @skip';
+      const name = grunt.option('grep') || null;
       const appiumOptions = {
         platform: grunt.option('platform'),
         isSimulator: !!grunt.option('simulator'),
         host: grunt.option('kobiton') ? 'kobiton' : 'local',
       };
       import("./build-utils/CucumberLauncher.js")
-        .then(({ default: CucumberLauncher }) => new CucumberLauncher({ tags, appiumOptions }).run())
+        .then(({ default: CucumberLauncher }) => new CucumberLauncher({ tags, name, appiumOptions }).run())
         .then((code) => {
           if (code !== 0) {
             grunt.log.error(`cucumber-js exited with code ${code}`);

--- a/build-tests/unit/CucumberLauncher_spec.js
+++ b/build-tests/unit/CucumberLauncher_spec.js
@@ -110,7 +110,7 @@ describe("CucumberLauncher", function() {
       expect(args).to.deep.equal(["cucumber-js", "--tags", "@smoke", "--force-exit"]);
     });
 
-    it("defaults tags to @only when none are provided", async function() {
+    it("defaults tags to 'not @skip' when none are provided", async function() {
       const launcher = new CucumberLauncher({
         spawn: fakeSpawn,
         isAppiumRunning: fakeIsRunning,
@@ -118,7 +118,21 @@ describe("CucumberLauncher", function() {
       const promise = launcher.run();
       await exitAfterSpawn(fakeSpawn, 0, 0);
       await promise;
-      expect(fakeSpawn.firstCall.args[1]).to.deep.equal(["cucumber-js", "--tags", "@only", "--force-exit"]);
+      expect(fakeSpawn.firstCall.args[1]).to.deep.equal(["cucumber-js", "--tags", "not @skip", "--force-exit"]);
+    });
+
+    it("passes --name <pattern> to cucumber-js when name is provided", async function() {
+      const launcher = new CucumberLauncher({
+        name: "Log in with existing",
+        spawn: fakeSpawn,
+        isAppiumRunning: fakeIsRunning,
+      });
+      const promise = launcher.run();
+      await exitAfterSpawn(fakeSpawn, 0, 0);
+      await promise;
+      expect(fakeSpawn.firstCall.args[1]).to.deep.equal(
+        ["cucumber-js", "--tags", "not @skip", "--name", "Log in with existing", "--force-exit"]
+      );
     });
 
     it("serializes appiumOptions as APPIUM_OPTIONS env var", async function() {

--- a/build-utils/CucumberLauncher.js
+++ b/build-utils/CucumberLauncher.js
@@ -3,10 +3,11 @@ import { isAppiumRunning as defaultIsAppiumRunning } from "./AppiumLauncher.js";
 
 class CucumberLauncher {
   constructor({
-    tags = "@only", appiumOptions = {}, spawn = defaultSpawn,
+    tags = "not @skip", name = null, appiumOptions = {}, spawn = defaultSpawn,
     isAppiumRunning = defaultIsAppiumRunning, killProcess = null,
   } = {}) {
     this._tags = tags;
+    this._name = name;
     this._appiumOptions = appiumOptions;
     this._spawn = spawn;
     this._isAppiumRunning = isAppiumRunning;
@@ -45,7 +46,11 @@ class CucumberLauncher {
     const code = await new Promise((resolve) => {
       const child = this._spawn(
         "npx",
-        ["cucumber-js", "--tags", this._tags, "--force-exit"],
+        [
+          "cucumber-js", "--tags", this._tags,
+          ...(this._name ? ["--name", this._name] : []),
+          "--force-exit",
+        ],
         {
           stdio: "inherit",
           env: {

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -66,13 +66,13 @@ describe.only("My module", function() {
 
 **Device unit tests** (`walta-app/app/spec/`): same `.only` approach, or use `--grep="..."` (see [LiveView § Runtime Test Config](#runtime-test-config---grep-and---manual)) to filter without editing the file.
 
-**Acceptance tests** (Cucumber features): add the `@only` tag above a scenario:
+**Acceptance tests** (Cucumber features): pass `--grep="<scenario name>"` (regex against the `Scenario:` text) to filter without editing the file:
 
-```gherkin
-@only
-Scenario: Download samples from server
-  Given I have existing samples stored on the server
+```bash
+npx grunt --platform=ios --simulator --grep="Log in with existing account" acceptance-test
 ```
+
+`--grep` maps to cucumber-js's `--name` flag. Use `--cucumber-tags=<expr>` if you want to filter by tag instead (defaults to `not @skip`).
 
 ## Run *both* Node and device suites before pushing changes to `walta-app/app/lib/`
 

--- a/features/registration.feature
+++ b/features/registration.feature
@@ -1,8 +1,8 @@
-@skip
 Feature: Registration
 
 I want to be able to register with WaterbugBlitz to allow uploading samples.
 
+@skip
 Scenario: Register
   Given I am not logged in
     And the user "testuser@example.com" does not exist
@@ -10,6 +10,7 @@ Scenario: Register
   Then I am registered on the server
    And I am logged in
 
+@skip
 Scenario: Remember log in over app restart
   Given The "testuser@example.com" account exists with password "t3stPassw0rd"
      And I am not logged in
@@ -17,25 +18,28 @@ Scenario: Remember log in over app restart
      And I restart the application
     Then I am logged in
 
- 
+@skip
 Scenario: Correctly responds to server login errors
   Given the server is returning a 500 error
     And I am not logged in
     When I log in via username and password
     Then I get an error message
 
+@skip
 Scenario: Correctly responds to server registration errors
   Given the server is returning a 500 error
     And I am not logged in
     When I register as "testuser@example.com"
     Then I get an error message
 
+@skip
 Scenario: Register with existing email address
   Given I am not logged in
     And the user "testuser@example.com" is already registered
    When I register as "testuser@example.com"
    Then I get an error message
-   
+
+@skip
 Scenario: Log in with bad credentials
  Given The "testuser@example.com" account exists with password "t3stPassw0rd"
      And I am not logged in
@@ -45,5 +49,5 @@ Scenario: Log in with bad credentials
 Scenario: Log in with existing account
    Given The "testuser@example.com" account exists with password "t3stPassw0rd"
      And I am not logged in
-    When I log in via username and password
-    Then I am logged in 
+    When I log in with "testuser@example.com" and password "t3stPassw0rd"
+    Then I am logged in

--- a/features/step_definitions/registration.js
+++ b/features/step_definitions/registration.js
@@ -67,12 +67,13 @@ Then('I am registered on the server', function() {
    expect( serverReq["share_name_consent"] ).to eq(false) */
 });
 
-Then('I am logged in', function() {
-/*     expect( @current_page.loggedIn? ).to eq(true) */
+Then('I am logged in', {timeout: 60000}, async function() {
+    await this.menu.waitForLabel("You are Logged in");
 });
 
-When('I log in with "([^"]*)" and password "([^"]*)"', function(emailAddress, password) {
-/*     @current_page = RegistrationDriver.login( emailAddress, password ) */
+When('I log in with {string} and password {string}', {timeout: 60000}, async function(emailAddress, password) {
+    await this.menu.waitFor();
+    await this.menu.login(emailAddress, password);
 });
 
 When('I register as "([^"]*)"', function(emailAddress) {
@@ -86,14 +87,8 @@ When('I register as "([^"]*)"', function(emailAddress) {
     @current_page = @current_page.register_via_email( emailAddress, "Test User", "t3stPassw0rd") */
 });
 
-Given('The "([^"]*)" account exists with password "([^"]*)"', function(emailAddress, password) {
-/*     @emailAddress = emailAddress
-    @password = password
-    MockServer.create_account() */
-});
-  
-When('I log in via username and password', function() {
-/*    @current_page = RegistrationDriver.login( @emailAddress, @password ) */
+Given('The {string} account exists with password {string}', function(emailAddress, password) {
+    global.mockCerdiServer.registerAccount({ email: emailAddress, password });
 });
 
 When('I restart the application', function() {

--- a/features/support/failure-diagnostics.js
+++ b/features/support/failure-diagnostics.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const { After, BeforeAll, Status } = require('@cucumber/cucumber');
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ARTIFACTS_ROOT = '/tmp/acceptance-artifacts';
+
+BeforeAll(function () {
+    fs.rmSync(ARTIFACTS_ROOT, { recursive: true, force: true });
+    fs.mkdirSync(ARTIFACTS_ROOT, { recursive: true });
+});
+
+After({ timeout: 30000 }, async function ({ pickle, result }) {
+    if (result.status !== Status.FAILED) return;
+
+    const slug = pickle.name.replace(/[^a-zA-Z0-9-]+/g, '_').slice(0, 80);
+    const dir = path.join(ARTIFACTS_ROOT, slug);
+    fs.mkdirSync(dir, { recursive: true });
+
+    await capturePageSource(this.driver, dir);
+    await captureScreenshot(this.driver, dir);
+    captureDeviceLog(this.platform, dir);
+});
+
+async function capturePageSource(driver, dir) {
+    try {
+        const source = await driver.getPageSource();
+        fs.writeFileSync(path.join(dir, 'page-source.xml'), source);
+    } catch (e) {
+        fs.writeFileSync(path.join(dir, 'page-source.error.txt'), `getPageSource() threw: ${e && e.message}`);
+    }
+}
+
+async function captureScreenshot(driver, dir) {
+    try {
+        const png = await driver.takeScreenshot();
+        fs.writeFileSync(path.join(dir, 'screenshot.png'), png, 'base64');
+    } catch (e) {
+        fs.writeFileSync(path.join(dir, 'screenshot.error.txt'), `takeScreenshot() threw: ${e && e.message}`);
+    }
+}
+
+function captureDeviceLog(platform, dir) {
+    try {
+        if (platform === 'android') {
+            const adb = process.env.ANDROID_SDK_ROOT
+                ? path.join(process.env.ANDROID_SDK_ROOT, 'platform-tools', 'adb')
+                : 'adb';
+            const out = execFileSync(adb, ['logcat', '-d', '-t', '500', '-s', 'TiAPI:V']);
+            fs.writeFileSync(path.join(dir, 'device.log'), out);
+        } else if (platform === 'ios' && process.env.SIM_UDID) {
+            const out = execFileSync('xcrun', [
+                'simctl', 'spawn', process.env.SIM_UDID,
+                'log', 'show', '--last', '5m', '--style', 'syslog',
+            ]);
+            const filtered = out.toString()
+                .split('\n')
+                .filter((l) => /waterbug|titanium|TiAPI|TiLog|appium/i.test(l))
+                .slice(-500)
+                .join('\n');
+            fs.writeFileSync(path.join(dir, 'device.log'), filtered);
+        }
+    } catch (e) {
+        fs.writeFileSync(path.join(dir, 'device.log.error.txt'), `device-log capture threw: ${e && e.message}`);
+    }
+}

--- a/features/support/failure-diagnostics.js
+++ b/features/support/failure-diagnostics.js
@@ -42,19 +42,24 @@ async function captureScreenshot(driver, dir) {
     }
 }
 
+// `simctl log show --last 5m` on iOS easily produces tens of MB of
+// syslog. Default spawnSync maxBuffer (1 MB) overflows with ENOBUFS,
+// so bump it generously here.
+const SPAWN_OPTS = { maxBuffer: 64 * 1024 * 1024 };
+
 function captureDeviceLog(platform, dir) {
     try {
         if (platform === 'android') {
             const adb = process.env.ANDROID_SDK_ROOT
                 ? path.join(process.env.ANDROID_SDK_ROOT, 'platform-tools', 'adb')
                 : 'adb';
-            const out = execFileSync(adb, ['logcat', '-d', '-t', '500', '-s', 'TiAPI:V']);
+            const out = execFileSync(adb, ['logcat', '-d', '-t', '500', '-s', 'TiAPI:V'], SPAWN_OPTS);
             fs.writeFileSync(path.join(dir, 'device.log'), out);
         } else if (platform === 'ios' && process.env.SIM_UDID) {
             const out = execFileSync('xcrun', [
                 'simctl', 'spawn', process.env.SIM_UDID,
                 'log', 'show', '--last', '5m', '--style', 'syslog',
-            ]);
+            ], SPAWN_OPTS);
             const filtered = out.toString()
                 .split('\n')
                 .filter((l) => /waterbug|titanium|TiAPI|TiLog|appium/i.test(l))

--- a/features/support/login-screen.js
+++ b/features/support/login-screen.js
@@ -9,7 +9,25 @@ class LoginScreen extends BaseScreen {
     async login( email, password ) {
         await this.enter('login_email_textfield', email );
         await this.enter('login_password_textfield', password );
-        return this.click('login_login_button');
+        await this.click('login_login_button');
+        if (this.isIos()) await this.dismissSavePasswordSheet();
+    }
+
+    // iOS pops a system-level "Save Password?" sheet after the login form
+    // submits and persists across app terminations into the next scenario,
+    // occluding the menu. The cucumber.js BeforeAll disables-AutoFill +
+    // keychain-reset don't suppress it. autoDismissAlerts doesn't catch
+    // it because it's not a UIAlertController. Dismiss it explicitly via
+    // the "Not Now" button (3s wait — absent on a fast-enough machine
+    // that the sheet hasn't appeared yet, but harmless when missing).
+    async dismissSavePasswordSheet() {
+        try {
+            const btn = await this.driver.$("-ios predicate string:label == 'Not Now'");
+            await btn.waitForDisplayed({ timeout: 3000 });
+            await btn.click();
+        } catch (e) {
+            // Sheet didn't appear — fine.
+        }
     }
 } 
 module.exports = LoginScreen

--- a/features/support/mock-cerdi-server.js
+++ b/features/support/mock-cerdi-server.js
@@ -71,27 +71,25 @@ function createMockCerdiServer(callback) {
         shutdown() {
             this.server.close();
         },
-        makeMockSample() {
-            let accessToken = "testusertoken";
-            // set up user account responses
+        registerAccount({ email, password }) {
             this.hockServer
-                .post("/token/create",{
-                    "password":"password",
-                    "email":"test@example.com"
-                })
+                .post("/token/create", { password, email })
                 .many()
-                .reply(200,{
+                .reply(200, {
                     "id": 38,
-                    "name": "Test Example",
-                    "email": "testlogin@example.com",
+                    "name": "Test User",
+                    "email": email,
                     "created_at": "2018-09-07 08:55:30",
                     "updated_at": "2018-09-07 08:55:30",
                     "group": 0,
                     "survey_consent": 0,
                     "share_name_consent": 0,
                     "oauth_network": null,
-                    "accessToken": accessToken
+                    "accessToken": "testusertoken"
                 });
+        },
+        makeMockSample() {
+            this.registerAccount({ email: "test@example.com", password: "password" });
             // set up samples response
             let sampleData = makeCerdiSampleData({
                 photos: [{"id": 1}],


### PR DESCRIPTION
Part of the WB-64 split — see [#223](https://github.com/TheWaterBugCompany/WALTA/pull/223) for the parent PR.

Two improvements bundled here, both touching the acceptance test infrastructure:

## WB-64 acceptance tweaks

- **`--grep="<scenario name>"` filter** on `acceptance-test` (maps to cucumber-js's `--name`) — same convention as the device-unit-test grep. Default tag filter switched from `@only` to `not @skip`. Documented in [docs/testing.md](docs/testing.md).
- **"Log in with existing account" scenario** implemented end-to-end: the `I log in with "..." and password "..."` step drives the LoginScreen against the mock CERDI server's stubbed `/token/create`. Other registration scenarios per-tagged with `@skip`.

## WB-72 ([Trello](https://trello.com/c/apJNbcMZ)) — per-scenario failure artifacts

Cucumber `After` hook in [features/support/failure-diagnostics.js](features/support/failure-diagnostics.js) writes per-scenario diagnostics on `result.status === FAILED`:

- `page-source.xml` — `await driver.getPageSource()`
- `screenshot.png` — `await driver.takeScreenshot()`
- `device.log` — last 5 min of TiAPI / Titanium / waterbug / appium lines

CI uploads `/tmp/acceptance-artifacts` as `acceptance-failures-ios` / `acceptance-failures-android`. Replaces the iOS end-of-job single-screenshot block that only captured the last scenario's terminal state — a run failing on scenario 1 of 5 used to produce nothing diagnosable.

Landing here (rather than its own branch) because #229 is reliably hitting the deeplink-login `MenuScreen not present` flake today, so the next CI run produces real diagnostic data for that race.

## Test plan
- [ ] iOS sim acceptance fails as expected → `acceptance-failures-ios` artifact contains a per-scenario folder for the deeplink-login failure
- [ ] Page source / screenshot / log clearly show what state the menu was in when the wait timed out
- [ ] `npx grunt --platform=android --simulator --grep="Log in with existing" acceptance-test` — passes
- [ ] `npx grunt --platform=ios --simulator --grep="Log in with existing" acceptance-test` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)