### PR TITLE
WB-64 (5/7): SyncFeedback diagnostic UX — bar colour, tail-scroll, padding

### DIFF
--- a/test/models/SyncStore_spec.js
+++ b/test/models/SyncStore_spec.js
@@ -1,12 +1,17 @@
 require("mocha");
 const { expect } = require("chai");
 const SyncStore = require("../../walta-app/app/lib/models/SyncStore");
+const Logger = require("../../walta-app/app/lib/util/Logger");
 
 describe("SyncStore", function () {
   let store;
 
   beforeEach(function () {
     store = new SyncStore();
+  });
+
+  afterEach(function () {
+    if (store) store.dispose();
   });
 
   describe("initial state", function () {
@@ -16,6 +21,57 @@ describe("SyncStore", function () {
       expect(store.statusText).to.equal("");
       expect(store.logLines).to.deep.equal([]);
       expect(store.errorMessage).to.equal(null);
+      expect(store.hasErrors).to.equal(false);
+    });
+  });
+
+  describe("hasErrors (Logger error during syncing window)", function () {
+    it("flips to true when Logger.error fires on facility=sync while syncing", function () {
+      store.recordStart();
+      Logger.error("Failed to download photo", "sync");
+      expect(store.hasErrors).to.equal(true);
+    });
+
+    it("ignores Logger.error before recordStart (stale errors don't poison the next run)", function () {
+      Logger.error("Failed to download photo", "sync");
+      expect(store.hasErrors).to.equal(false);
+    });
+
+    it("ignores errors on other facilities", function () {
+      store.recordStart();
+      Logger.error("Network down", "auth");
+      expect(store.hasErrors).to.equal(false);
+    });
+
+    it("ignores warn-level entries (only error counts as a sync failure)", function () {
+      store.recordStart();
+      Logger.warn("Missing photo on server", "sync");
+      expect(store.hasErrors).to.equal(false);
+    });
+
+    it("recordStart resets hasErrors so a fresh sync starts clean", function () {
+      store.recordStart();
+      Logger.error("boom", "sync");
+      expect(store.hasErrors).to.equal(true);
+      store.recordStart();
+      expect(store.hasErrors).to.equal(false);
+    });
+
+    it("recordSuccess preserves hasErrors so the UI can flag a partial-success run", function () {
+      store.recordStart();
+      Logger.error("boom", "sync");
+      store.recordSuccess();
+      expect(store.hasErrors).to.equal(true);
+    });
+  });
+
+  describe("dispose()", function () {
+    it("unsubscribes from Logger so post-dispose entries don't flip hasErrors", function () {
+      store.recordStart();
+      store.dispose();
+      Logger.error("late", "sync");
+      expect(store.hasErrors).to.equal(false);
+      store = null;
     });
   });
 

--- a/test/models/SyncStore_spec.js
+++ b/test/models/SyncStore_spec.js
@@ -29,6 +29,11 @@ describe("SyncStore", function () {
       expect(store.errorMessage).to.equal(null);
     });
 
+    it("seeds statusText so the UI isn't bare before the first progress milestone", function () {
+      store.recordStart();
+      expect(store.statusText).to.equal("Starting sync");
+    });
+
     it("notifies listeners", function () {
       const seen = [];
       store.addListener(() => seen.push(store.status));

--- a/test/viewmodels/SyncFeedback_spec.js
+++ b/test/viewmodels/SyncFeedback_spec.js
@@ -173,9 +173,9 @@ describe("SyncFeedbackViewModel", function () {
       expect(vm.progressText).to.equal("15% Uploading taxa 141 photo");
     });
 
-    it("is just the percent when syncing with no statusText", function () {
+    it("renders the seeded statusText after recordStart", function () {
       store.recordStart();
-      expect(vm.progressText).to.equal("0%");
+      expect(vm.progressText).to.equal("0% Starting sync");
     });
 
     it("is 0% when offline regardless of percent", function () {
@@ -276,10 +276,10 @@ describe("SyncFeedbackViewModel", function () {
       expect(vm.logText).to.equal("");
     });
 
-    it("joins log entries as '[facility] message' with newlines", function () {
+    it("joins log entries by message with newlines (no facility prefix — pane is sync-only)", function () {
       Logger.info("first", "sync");
       Logger.warn("second", "sync");
-      expect(vm.logText).to.equal("[sync] first\n[sync] second");
+      expect(vm.logText).to.equal("first\nsecond");
     });
   });
 

--- a/test/viewmodels/SyncFeedback_spec.js
+++ b/test/viewmodels/SyncFeedback_spec.js
@@ -160,6 +160,12 @@ describe("SyncFeedbackViewModel", function () {
       store.recordError(new Error("boom"));
       expect(vm.progressColor).to.equal(Palette.error);
     });
+
+    it("is Palette.error when soft errors occurred during sync (hasErrors)", function () {
+      store.recordStart();
+      Logger.error("Failed to download photo", "sync");
+      expect(vm.progressColor).to.equal(Palette.error);
+    });
   });
 
   describe("progressText (presentation)", function () {

--- a/walta-app/app/controllers/SyncFeedback.js
+++ b/walta-app/app/controllers/SyncFeedback.js
@@ -48,9 +48,13 @@ applyDynamicMargins();
 vm.addListener(applyDynamicMargins);
 
 let lastLogCount = vm.logLines.length;
+let lastLogVisible = vm.logVisible;
 function tailLogPane() {
-    if (vm.logLines.length === lastLogCount) return;
+    const justOpened = vm.logVisible && !lastLogVisible;
+    const grew = vm.logLines.length !== lastLogCount;
     lastLogCount = vm.logLines.length;
+    lastLogVisible = vm.logVisible;
+    if (!justOpened && !grew) return;
     // setTimeout: defer until after the Label has re-laid-out, otherwise
     // scrollToBottom uses the pre-update content height.
     setTimeout(() => $.logScroll.scrollToBottom(), 0);

--- a/walta-app/app/controllers/SyncFeedback.js
+++ b/walta-app/app/controllers/SyncFeedback.js
@@ -47,6 +47,16 @@ function applyDynamicMargins() {
 applyDynamicMargins();
 vm.addListener(applyDynamicMargins);
 
+let lastLogCount = vm.logLines.length;
+function tailLogPane() {
+    if (vm.logLines.length === lastLogCount) return;
+    lastLogCount = vm.logLines.length;
+    // setTimeout: defer until after the Label has re-laid-out, otherwise
+    // scrollToBottom uses the pre-update content height.
+    setTimeout(() => $.logScroll.scrollToBottom(), 0);
+}
+vm.addListener(tailLogPane);
+
 vm.on("close", function () { $.trigger("close"); });
 vm.on("diagnostics", function () { Topics.fireTopicEvent(Topics.DIAGNOSTICS); });
 

--- a/walta-app/app/lib/logic/SampleDownloader.js
+++ b/walta-app/app/lib/logic/SampleDownloader.js
@@ -6,6 +6,7 @@ var log = (m, tag = "sync") => Logger.log(m, tag);
 var debug = (m, tag = "sync") => Logger.debug(m, tag);
 var info = (m, tag = "sync") => Logger.info(m, tag);
 var warn = (m, tag = "sync") => Logger.warn(m, tag);
+var error = (m, tag = "sync") => Logger.error(m, tag);
 function createSampleDownloader(delay) {
     return {
         downloadSamples() {
@@ -116,7 +117,7 @@ function createSampleDownloader(delay) {
                             return [sample,serverSample];
                         })
                         .catch( err => {
-                            warn(`Failed to download photo for [serverSampleId=${serverSample.id}]`)
+                            error(`Failed to download photo for [serverSampleId=${serverSample.id}]`)
                             Logger.recordException(err);
                             return [sample, serverSample];
                         });
@@ -164,7 +165,7 @@ function createSampleDownloader(delay) {
                             Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: taxon.getSampleId() } );
                         })
                         .catch( err => {
-                            warn(`Failed to download photo for [serverSampleId=${serverSample.id},taxonId=${taxonId}]`);
+                            error(`Failed to download photo for [serverSampleId=${serverSample.id},taxonId=${taxonId}]`);
                             Logger.recordException(err)
                         });
             }

--- a/walta-app/app/lib/logic/SampleDownloader.js
+++ b/walta-app/app/lib/logic/SampleDownloader.js
@@ -117,7 +117,8 @@ function createSampleDownloader(delay) {
                         })
                         .catch( err => {
                             warn(`Failed to download photo for [serverSampleId=${serverSample.id}]`)
-                            Logger.recordException(err)
+                            Logger.recordException(err);
+                            return [sample, serverSample];
                         });
                 } else {
                     return Promise.resolve([sample,serverSample]);

--- a/walta-app/app/lib/logic/SampleSync.js
+++ b/walta-app/app/lib/logic/SampleSync.js
@@ -24,7 +24,7 @@ function removeListener(cb) {
 // Expose the store's read-side getters on the module so consumers
 // that treat SampleSync as a syncController can read `.status`,
 // `.percent`, etc. directly — same shape as SyncStore itself.
-["status", "percent", "statusText", "logLines", "errorMessage"].forEach(function (attr) {
+["status", "percent", "statusText", "logLines", "errorMessage", "hasErrors"].forEach(function (attr) {
     Object.defineProperty(exports, attr, { get: function () { return syncStore[attr]; }, enumerable: true });
 });
 

--- a/walta-app/app/lib/logic/SampleUploader.js
+++ b/walta-app/app/lib/logic/SampleUploader.js
@@ -4,6 +4,7 @@ var log = (m, tag = "sync") => Logger.log(m, tag);
 var debug = (m, tag = "sync") => Logger.debug(m, tag);
 var info = (m, tag = "sync") => Logger.info(m, tag);
 var warn = (m, tag = "sync") => Logger.warn(m, tag);
+var error = (m, tag = "sync") => Logger.error(m, tag);
 
 var Topics = require('ui/Topics');
 var moment = require("lib/moment");
@@ -103,7 +104,7 @@ function uploadTaxaPhoto(sample,t,delay) {
                         Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: sampleId, message: `Uploading taxa ${taxonId} photo` } );
                     })
                     .catch( (err) => {
-                        warn(`Error when attempting to upload taxon photo [serverSampleId=${sampleId},taxonId=${taxonId}]`)
+                        error(`Error when attempting to upload taxon photo [serverSampleId=${sampleId},taxonId=${taxonId}]`)
                         Logger.recordException(err)
                     });
                         

--- a/walta-app/app/lib/models/SyncStore.js
+++ b/walta-app/app/lib/models/SyncStore.js
@@ -1,4 +1,5 @@
 const ChangeNotifier = require("../util/ChangeNotifier");
+const Logger = require("../util/Logger");
 
 const PROGRESS_STEP = 15;
 const PROGRESS_CAP = 95;
@@ -10,12 +11,21 @@ const INITIAL_STATE = {
   statusText: "",
   logLines: [],
   errorMessage: null,
+  hasErrors: false,
 };
 
 class SyncStore extends ChangeNotifier {
   constructor() {
     super();
     this._state = { ...INITIAL_STATE };
+    this._unsubscribeLogger = Logger.subscribe(
+      { facility: "sync", minLevel: "error" },
+      () => {
+        if (this._state.status === "syncing") {
+          this._setState({ hasErrors: true });
+        }
+      }
+    );
   }
 
   get status()       { return this._state.status; }
@@ -23,6 +33,12 @@ class SyncStore extends ChangeNotifier {
   get statusText()   { return this._state.statusText; }
   get logLines()     { return this._state.logLines; }
   get errorMessage() { return this._state.errorMessage; }
+  get hasErrors()    { return this._state.hasErrors; }
+
+  dispose() {
+    if (this._unsubscribeLogger) this._unsubscribeLogger();
+    super.dispose();
+  }
 
   recordStart() {
     this._setState({ ...INITIAL_STATE, status: "syncing", statusText: "Starting sync" });

--- a/walta-app/app/lib/models/SyncStore.js
+++ b/walta-app/app/lib/models/SyncStore.js
@@ -25,7 +25,7 @@ class SyncStore extends ChangeNotifier {
   get errorMessage() { return this._state.errorMessage; }
 
   recordStart() {
-    this._setState({ ...INITIAL_STATE, status: "syncing" });
+    this._setState({ ...INITIAL_STATE, status: "syncing", statusText: "Starting sync" });
   }
 
   recordProgress(message) {

--- a/walta-app/app/lib/viewmodels/SyncFeedback.js
+++ b/walta-app/app/lib/viewmodels/SyncFeedback.js
@@ -74,7 +74,7 @@ class SyncFeedbackViewModel extends ChangeNotifier {
   }
 
   get logText() {
-    return this._logEntries.map(e => `[${e.facility}] ${e.message}`).join("\n");
+    return this._logEntries.map(e => e.message).join("\n");
   }
 
   get logPaneHeight() {

--- a/walta-app/app/lib/viewmodels/SyncFeedback.js
+++ b/walta-app/app/lib/viewmodels/SyncFeedback.js
@@ -51,7 +51,7 @@ class SyncFeedbackViewModel extends ChangeNotifier {
   }
 
   get progressColor() {
-    return this.status === "error" ? Palette.error : Palette.primary;
+    return (this.status === "error" || this._syncController.hasErrors) ? Palette.error : Palette.primary;
   }
 
   get progressWidth() {

--- a/walta-app/app/spec/SampleSync_spec.js
+++ b/walta-app/app/spec/SampleSync_spec.js
@@ -662,6 +662,43 @@ describe("SampleSync", function () {
 
         });
 
+        it('should keep going (download taxa photos) when the site photo fetch fails', async function() {
+            // Regression: downloadSitePhoto's catch used to return undefined,
+            // which then crashed downloadCreaturePhotos when it destructured
+            // [sample, serverSample] from undefined. The chain must survive
+            // a 404 on the site photo and still process the taxa photos.
+            let creatureMock = {
+                id: 1948,
+                photo: Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "/spec/resources/simpleKey1/media/amphipoda_01.jpg"),
+            };
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveUnknownCreatures")
+                .resolveWith([]);
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveSamples")
+                .resolveWith([makeCerdiSampleData({
+                    photos: [{ "id": 1948 }],
+                    sampled_creatures: [{
+                        "id": 2390,
+                        "sample_id": 473,
+                        "creature_id": 1,
+                        "count": 2,
+                        "photos_count": 0
+                    }]
+                })]);
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveSitePhoto")
+                .rejectWith({ message: "HTTP error" });
+            Alloy.Globals.CerdiApi.retrieveCreaturePhoto = function(serverSampleId, creatureId, photoPath) {
+                creatureMock.photo.copy(Ti.Filesystem.applicationDataDirectory + Ti.Filesystem.separator + photoPath);
+                return Promise.resolve(creatureMock);
+            };
+
+            await createSampleDownloader().downloadSamples();
+
+            let sample = Alloy.Models.instance("sample");
+            sample.loadByServerId(473);
+            let taxon = sample.loadTaxa().at(0);
+            expect(taxon.get("serverCreaturePhotoId")).to.equal(creatureMock.id);
+        });
+
         it('should download taxa photos if they are new',async function() {
             // TODO: Make sure the temporary photo is filed into the correct
             // place.

--- a/walta-app/app/spec/SyncFeedback_spec.js
+++ b/walta-app/app/spec/SyncFeedback_spec.js
@@ -81,15 +81,29 @@ describe("SyncFeedback controller", function () {
         it("renders prior-run entries in the log pane after toggling Show Log", () => {
             ctl.logToggleButton.fireEvent("click");
             expect(ctl.logPane.visible).to.equal(true);
-            expect(ctl.logText.text).to.equal("[sync] starting upload\n[sync] rate limit hit");
+            expect(ctl.logText.text).to.equal("starting upload\nrate limit hit");
         });
 
         it("live-updates the rendered text when Logger.error fires while the popup is open", () => {
             ctl.logToggleButton.fireEvent("click");
             Logger.error("upload failed", "sync");
             expect(ctl.logText.text).to.equal(
-                "[sync] starting upload\n[sync] rate limit hit\n[sync] upload failed"
+                "starting upload\nrate limit hit\nupload failed"
             );
+        });
+    });
+
+    describe("just started (no progress yet)", function () {
+        beforeEach(async () => {
+            var { syncController, store } = createSyncController(SyncStore);
+            store.recordStart();
+            ctl = Alloy.createController("SyncFeedback", { syncController });
+            win = wrapViewInWindow(ctl.getView());
+            await windowOpenTest(win);
+        });
+
+        it("shows the seeded statusText so the bar isn't bare while we wait for the first milestone", () => {
+            expect(ctl.progressText.text).to.equal("0% Starting sync");
         });
     });
 

--- a/walta-app/app/spec/SyncFeedback_spec.js
+++ b/walta-app/app/spec/SyncFeedback_spec.js
@@ -110,14 +110,20 @@ describe("SyncFeedback controller", function () {
             simple.restore();
         });
 
-        it("scrolls to the bottom when the user opens the pane (seeded entries are at the bottom)", async () => {
+        // iOS Titanium proxies have native methods that aren't replaceable
+        // via JS assignment — simple.mock's `obj[key] = mockFn` silently
+        // no-ops, so the spy never registers a call. The Android coverage
+        // is enough to lock in the controller behaviour.
+        it("scrolls to the bottom when the user opens the pane (seeded entries are at the bottom)", async function () {
+            if (Ti.Platform.osname === "iphone" || Ti.Platform.osname === "ipad") this.skip();
             const spy = simple.mock(ctl.logScroll, "scrollToBottom");
             ctl.logToggleButton.fireEvent("click");
             await waitForTick(200)();
             expect(spy.callCount).to.equal(1);
         });
 
-        it("scrolls to the bottom when a new log entry lands while the pane is open", async () => {
+        it("scrolls to the bottom when a new log entry lands while the pane is open", async function () {
+            if (Ti.Platform.osname === "iphone" || Ti.Platform.osname === "ipad") this.skip();
             ctl.logToggleButton.fireEvent("click");
             await waitForTick(200)();
             const spy = simple.mock(ctl.logScroll, "scrollToBottom");

--- a/walta-app/app/spec/SyncFeedback_spec.js
+++ b/walta-app/app/spec/SyncFeedback_spec.js
@@ -113,16 +113,16 @@ describe("SyncFeedback controller", function () {
         it("scrolls to the bottom when the user opens the pane (seeded entries are at the bottom)", async () => {
             const spy = simple.mock(ctl.logScroll, "scrollToBottom");
             ctl.logToggleButton.fireEvent("click");
-            await waitForTick(10)();
+            await waitForTick(200)();
             expect(spy.callCount).to.equal(1);
         });
 
         it("scrolls to the bottom when a new log entry lands while the pane is open", async () => {
             ctl.logToggleButton.fireEvent("click");
-            await waitForTick(10)();
+            await waitForTick(200)();
             const spy = simple.mock(ctl.logScroll, "scrollToBottom");
             Logger.info("new line", "sync");
-            await waitForTick(10)();
+            await waitForTick(200)();
             expect(spy.callCount).to.equal(1);
         });
     });

--- a/walta-app/app/spec/SyncFeedback_spec.js
+++ b/walta-app/app/spec/SyncFeedback_spec.js
@@ -1,6 +1,7 @@
 require("spec/lib/ti-mocha");
+var simple = require("spec/lib/simple-mock");
 var { expect } = require("spec/lib/chai");
-var { closeWindow, wrapViewInWindow, windowOpenTest, removeDatabase } = require("spec/util/TestUtils");
+var { closeWindow, wrapViewInWindow, windowOpenTest, removeDatabase, waitForTick } = require("spec/util/TestUtils");
 var SyncStore = require("models/SyncStore");
 var Logger = require("util/Logger");
 var LogRepository = require("repository/LogRepository");
@@ -90,6 +91,39 @@ describe("SyncFeedback controller", function () {
             expect(ctl.logText.text).to.equal(
                 "starting upload\nrate limit hit\nupload failed"
             );
+        });
+    });
+
+    describe("tail-scrolls the log pane", function () {
+        beforeEach(async () => {
+            logRepository = makeTestLogRepository([
+                { ts: 100, level: "info", facility: "sync", message: "earlier line 1" },
+                { ts: 200, level: "info", facility: "sync", message: "earlier line 2" },
+            ]);
+            var { syncController } = createSyncController(SyncStore);
+            ctl = Alloy.createController("SyncFeedback", { syncController, logRepository });
+            win = wrapViewInWindow(ctl.getView());
+            await windowOpenTest(win);
+        });
+
+        afterEach(() => {
+            simple.restore();
+        });
+
+        it("scrolls to the bottom when the user opens the pane (seeded entries are at the bottom)", async () => {
+            const spy = simple.mock(ctl.logScroll, "scrollToBottom");
+            ctl.logToggleButton.fireEvent("click");
+            await waitForTick(10)();
+            expect(spy.callCount).to.equal(1);
+        });
+
+        it("scrolls to the bottom when a new log entry lands while the pane is open", async () => {
+            ctl.logToggleButton.fireEvent("click");
+            await waitForTick(10)();
+            const spy = simple.mock(ctl.logScroll, "scrollToBottom");
+            Logger.info("new line", "sync");
+            await waitForTick(10)();
+            expect(spy.callCount).to.equal(1);
         });
     });
 

--- a/walta-app/app/spec/SyncFeedback_spec.js
+++ b/walta-app/app/spec/SyncFeedback_spec.js
@@ -1,5 +1,4 @@
 require("spec/lib/ti-mocha");
-var simple = require("spec/lib/simple-mock");
 var { expect } = require("spec/lib/chai");
 var { closeWindow, wrapViewInWindow, windowOpenTest, removeDatabase, waitForTick } = require("spec/util/TestUtils");
 var SyncStore = require("models/SyncStore");
@@ -95,41 +94,38 @@ describe("SyncFeedback controller", function () {
     });
 
     describe("tail-scrolls the log pane", function () {
+        // Seed enough entries that the rendered text overflows the
+        // pane's viewport — otherwise scrollToBottom is a no-op and
+        // contentOffset.y stays 0, so we can't tell the trigger fired.
+        function seedManyEntries(count) {
+            const entries = [];
+            for (let i = 0; i < count; i++) {
+                entries.push({ ts: 1000 + i, level: "info", facility: "sync", message: `line ${i}` });
+            }
+            return entries;
+        }
+
         beforeEach(async () => {
-            logRepository = makeTestLogRepository([
-                { ts: 100, level: "info", facility: "sync", message: "earlier line 1" },
-                { ts: 200, level: "info", facility: "sync", message: "earlier line 2" },
-            ]);
+            logRepository = makeTestLogRepository(seedManyEntries(40));
             var { syncController } = createSyncController(SyncStore);
             ctl = Alloy.createController("SyncFeedback", { syncController, logRepository });
             win = wrapViewInWindow(ctl.getView());
             await windowOpenTest(win);
         });
 
-        afterEach(() => {
-            simple.restore();
+        it("scrolls past the top when the user opens the pane (seeded entries are at the bottom)", async () => {
+            ctl.logToggleButton.fireEvent("click");
+            await waitForTick(400)();
+            expect(ctl.logScroll.contentOffset.y).to.be.greaterThan(0);
         });
 
-        // iOS Titanium proxies have native methods that aren't replaceable
-        // via JS assignment — simple.mock's `obj[key] = mockFn` silently
-        // no-ops, so the spy never registers a call. The Android coverage
-        // is enough to lock in the controller behaviour.
-        it("scrolls to the bottom when the user opens the pane (seeded entries are at the bottom)", async function () {
-            if (Ti.Platform.osname === "iphone" || Ti.Platform.osname === "ipad") this.skip();
-            const spy = simple.mock(ctl.logScroll, "scrollToBottom");
+        it("scrolls further down when a new log entry lands while the pane is open", async () => {
             ctl.logToggleButton.fireEvent("click");
-            await waitForTick(200)();
-            expect(spy.callCount).to.equal(1);
-        });
-
-        it("scrolls to the bottom when a new log entry lands while the pane is open", async function () {
-            if (Ti.Platform.osname === "iphone" || Ti.Platform.osname === "ipad") this.skip();
-            ctl.logToggleButton.fireEvent("click");
-            await waitForTick(200)();
-            const spy = simple.mock(ctl.logScroll, "scrollToBottom");
-            Logger.info("new line", "sync");
-            await waitForTick(200)();
-            expect(spy.callCount).to.equal(1);
+            await waitForTick(400)();
+            const before = ctl.logScroll.contentOffset.y;
+            for (let i = 0; i < 5; i++) Logger.info(`fresh line ${i}`, "sync");
+            await waitForTick(400)();
+            expect(ctl.logScroll.contentOffset.y).to.be.greaterThan(before);
         });
     });
 

--- a/walta-app/app/spec/fixtures/SyncController_fixture.js
+++ b/walta-app/app/spec/fixtures/SyncController_fixture.js
@@ -16,6 +16,7 @@ function createSyncController(SyncStore) {
         get statusText()   { return store.statusText; },
         get logLines()     { return store.logLines; },
         get errorMessage() { return store.errorMessage; },
+        get hasErrors()    { return store.hasErrors; },
         addListener:    function (cb) { store.addListener(cb); },
         removeListener: function (cb) { store.removeListener(cb); },
         forceUpload:    function ()   { forceUploadCalls++; },

--- a/walta-app/app/styles/SyncFeedback.tss
+++ b/walta-app/app/styles/SyncFeedback.tss
@@ -76,7 +76,8 @@
 ".logScroll": {
     width: Ti.UI.FILL,
     height: Ti.UI.FILL,
-    layout: "vertical"
+    layout: "vertical",
+    showVerticalScrollIndicator: true
 }
 
 ".logText": {

--- a/walta-app/app/styles/SyncFeedback.tss
+++ b/walta-app/app/styles/SyncFeedback.tss
@@ -75,7 +75,8 @@
 
 ".logScroll": {
     width: Ti.UI.FILL,
-    height: Ti.UI.FILL,
+    top: "4dp",
+    bottom: "8dp",
     layout: "vertical",
     showVerticalScrollIndicator: true
 }


### PR DESCRIPTION
Part of the WB-64 split — see [#223](https://github.com/TheWaterBugCompany/WALTA/pull/223) for the parent PR. **Stacked on #230 (Logger arch).**

User-facing UX improvements to the sync diagnostic pane that piggyback on the new Logger infrastructure.

## Changes

- **SampleDownloader chain survives a 404 on the site photo** — the catch handler now returns the \`[sample, serverSample]\` tuple it was missing, so a single bad photo doesn't abort the rest of the sync. (Foundation for the bar-colour change.)
- **Bar turns red when soft errors are logged during a sync** — \`SyncStore\` subscribes to Logger for \`error\`+ on \`sync\` facility and flips a \`hasErrors\` flag. Soft-failure logs in downloader/uploader promoted from \`warn\` to \`error\` so they trip it.
- **Bar reads \"0% Starting sync\"** between \`recordStart\` and the first progress milestone (was bare \"0%\").
- **Drop the \`[facility]\` prefix** from log pane lines — pane is filtered to \`sync\` only, so prefixing every line was redundant.
- **Tail-follow** the log pane on first open and on new entries (\`scrollToBottom\`). Visible scrollbar.
- **Padding** so the latest entry isn't flush against the frame border.
- **Behaviour-level device tests** — assert the real \`contentOffset.y\` changes after the trigger, not a mock spy on \`scrollToBottom\` (Titanium iOS proxies are non-replaceable, defeating spies).

## Test plan
- [x] \`npx grunt unit-test-node\`
- [x] \`npx grunt --platform=android --simulator --liveview --reuse-server unit-test --grep=\"SyncFeedback\"\`
- [ ] \`npx grunt --platform=ios --simulator unit-test\`
- [ ] \`npx grunt --platform=android --simulator acceptance-test\` — visual sanity on the diagnostic pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)