### PR TITLE
WB-64 (7/7): stop syncing when the user logs out

### DIFF
--- a/walta-app/app/controllers/Menu.js
+++ b/walta-app/app/controllers/Menu.js
@@ -25,6 +25,7 @@ $.TopLevelWindow.addEventListener('close', function cleanUp() {
 
 function logOut() {
   Alloy.Globals.CerdiApi.storeUserToken(null, null);
+  Topics.fireTopicEvent( Topics.LOGGEDOUT, null );
   updateLoginText();
 }
 

--- a/walta-app/app/lib/logic/CerdiApi.js
+++ b/walta-app/app/lib/logic/CerdiApi.js
@@ -117,6 +117,12 @@ function createCerdiApi( serverUrl, client_secret  ) {
                 return Ti.App.Properties.getObject('userAccessTokenLive');
             },
 
+            _requireAccessToken() {
+                const token = this.retrieveUserToken();
+                if (!token) throw new Error("Not logged in");
+                return token.accessToken;
+            },
+
             retrieveUserId() {
                 let token = this.retrieveUserToken();
                 if ( token ) {
@@ -182,7 +188,7 @@ function createCerdiApi( serverUrl, client_secret  ) {
 
             submitSitePhoto( serverSampleId, photoPath ) {
                 var photoBlob = loadPhoto(photoPath);
-                let accessToken = this.retrieveUserToken().accessToken;
+                let accessToken = this._requireAccessToken();
                 if ( accessToken == undefined )
                     throw new Error("Not logged in - cannot submit sample");
                 return makeImagePostRequest( `${this.serverUrl}/samples/${serverSampleId}/photos`, photoBlob, {}, accessToken );
@@ -190,26 +196,26 @@ function createCerdiApi( serverUrl, client_secret  ) {
 
             submitCreaturePhoto( serverSampleId, creatureId, photoPath ) {
                 var photoBlob = loadPhoto(photoPath);
-                let accessToken = this.retrieveUserToken().accessToken;
+                let accessToken = this._requireAccessToken();
                 if ( accessToken == undefined )
                     throw new Error("Not logged in - cannot submit sample");
                 return makeImagePostRequest( `${this.serverUrl}/samples/${serverSampleId}/creatures/${creatureId}/photos`, photoBlob, {}, accessToken );
             },
 
             retrievePhoto(photoId,photoPath) {
-                let accessToken = this.retrieveUserToken().accessToken;
+                let accessToken = this._requireAccessToken();
                 if ( accessToken == undefined )
                     throw new Error("Not logged in - cannot submit sample");
                 return retrievePhoto(photoId,this.serverUrl,accessToken,photoPath)
             },
 
             retrievePhotoMetadata(photoId) {
-                let accessToken = this.retrieveUserToken().accessToken;
+                let accessToken = this._requireAccessToken();
                 return makeJsonGetRequest(`${this.serverUrl}/photos/${photoId}`, accessToken )
             },
 
             retrieveSitePhoto( serverSampleId,photoPath ) {
-                let accessToken = this.retrieveUserToken().accessToken;
+                let accessToken = this._requireAccessToken();
                 let serverUrl = this.serverUrl;
                 if ( accessToken == undefined )
                     throw new Error("Not logged in - cannot submit sample");
@@ -219,7 +225,7 @@ function createCerdiApi( serverUrl, client_secret  ) {
             },
 
             retrieveCreaturePhoto( serverSampleId,creatureId,photoPath ) {
-                let accessToken = this.retrieveUserToken().accessToken;
+                let accessToken = this._requireAccessToken();
                 let serverUrl = this.serverUrl;
                 if ( accessToken == undefined )
                     throw new Error("Not logged in - cannot submit sample");
@@ -228,21 +234,21 @@ function createCerdiApi( serverUrl, client_secret  ) {
             },
 
             submitSample( sample ) {
-                let accessToken = this.retrieveUserToken().accessToken;
+                let accessToken = this._requireAccessToken();
                 if ( accessToken == undefined )
                     throw new Error("Not logged in - cannot submit sample");
                 return makeJsonPostRequest( this.serverUrl + '/samples', sample, accessToken );
             },
 
             retrieveSampleById(serverSampleId) {
-                let accessToken = this.retrieveUserToken().accessToken;
+                let accessToken = this._requireAccessToken();
                 if ( accessToken == undefined )
                     throw new Error("Not logged in - cannot submit sample");
                 return makeJsonGetRequest( `${this.serverUrl}/samples/${serverSampleId}`, accessToken );
             },
 
             updateSampleById(serverSampleId,sample) {
-                let accessToken = this.retrieveUserToken().accessToken;
+                let accessToken = this._requireAccessToken();
                 if ( accessToken == undefined )
                     throw new Error("Not logged in - cannot submit sample");
                 return makeJsonPutRequest( `${this.serverUrl}/samples/${serverSampleId}`, sample, accessToken );
@@ -250,7 +256,7 @@ function createCerdiApi( serverUrl, client_secret  ) {
             
             updateUnknownCreature(unknownCreatureId,count,photoPath) {
                 var photoBlob = loadPhoto(photoPath);
-                let accessToken = this.retrieveUserToken().accessToken;
+                let accessToken = this._requireAccessToken();
                 if ( accessToken == undefined )
                     throw new Error("Not logged in - cannot submit sample");
                 return makeImagePutRequest( `${this.serverUrl}/unknownSampledCreatures/${unknownCreatureId}`, photoBlob, { count: count }, accessToken );
@@ -259,14 +265,14 @@ function createCerdiApi( serverUrl, client_secret  ) {
 
             submitUnknownCreature(serverSampleId,count,photoPath) {
                 var photoBlob = loadPhoto(photoPath);
-                let accessToken = this.retrieveUserToken().accessToken;
+                let accessToken = this._requireAccessToken();
                 if ( accessToken == undefined )
                     throw new Error("Not logged in - cannot submit sample");
                 return makeImagePostRequest( `${this.serverUrl}/samples/${serverSampleId}/unknownCreatures`, photoBlob, { count: count }, accessToken );
             },
 
             deleteUnknownCreature(unknownCreatureId) {
-                let accessToken = this.retrieveUserToken().accessToken;
+                let accessToken = this._requireAccessToken();
                 if ( accessToken == undefined )
                     throw new Error("Not logged in - cannot submit sample");
                 return makeJsonDeleteRequest( `${this.serverUrl}/unknownSampledCreatures/${unknownCreatureId}`, accessToken );
@@ -274,7 +280,7 @@ function createCerdiApi( serverUrl, client_secret  ) {
             },
 
             retrieveUnknownCreatures(serverSampleId) {
-                let accessToken = this.retrieveUserToken().accessToken;
+                let accessToken = this._requireAccessToken();
                 if ( accessToken == undefined )
                     throw new Error("Not logged in - cannot submit sample");
                 return makeJsonGetRequest( `${this.serverUrl}/samples/${serverSampleId}/unknownCreatures`, accessToken );
@@ -282,7 +288,7 @@ function createCerdiApi( serverUrl, client_secret  ) {
 
 
             retrieveSamples() {
-                let accessToken = this.retrieveUserToken().accessToken;
+                let accessToken = this._requireAccessToken();
                 if ( accessToken == undefined )
                     throw new Error("Not logged in - cannot submit sample");
                 return makeJsonGetRequest( this.serverUrl + '/samples', accessToken );

--- a/walta-app/app/lib/logic/SampleSync.js
+++ b/walta-app/app/lib/logic/SampleSync.js
@@ -7,7 +7,10 @@ var { createSampleDownloader } = require("logic/SampleDownloader");
 
 var SYNC_INTERVAL = 1000*60*30; // 30 minutes
 var isSyncing = false;
+var cancelled = false;
 var syncStore = new SyncStore();
+
+const CANCELLED_MARKER = "__sync_cancelled__";
 
 function areWeSyncing() {
     return isSyncing;
@@ -61,8 +64,15 @@ function init() {
     log("Initialising SampleSync...");
     Ti.Network.addEventListener( "change", networkChanged );
     Topics.subscribe( Topics.LOGGEDIN, startSynchronise );
+    Topics.subscribe( Topics.LOGGEDOUT, onLoggedOut );
     Topics.subscribe( Topics.UPLOAD_PROGRESS, handleUploadProgress );
     startSynchronise();
+}
+
+function onLoggedOut() {
+    info("Logged out — cancelling any in-flight sync and stopping the schedule.");
+    cancelled = true;
+    clearUploadTimer();
 }
 
 function forceUpload(options) {
@@ -76,9 +86,14 @@ function startSynchronise(options) {
     let sampleDownloader = createSampleDownloader(delay);
     debug(`Starting sample syncronisation process... (delay=${delay})`);
 
+    cancelled = false;
 
     function rescheduleSync() {
         isSyncing = false;
+        if ( cancelled ) {
+           debug("Sync cancelled — not rescheduling.");
+           return Promise.resolve();
+        }
         if ( options && !_.isUndefined(options.noschedule) ) {
            debug("Not rescheduling sync");
         } else {
@@ -86,6 +101,10 @@ function startSynchronise(options) {
            timeoutHandler = setTimeout( () => startSynchronise(options), SYNC_INTERVAL );
         }
         return Promise.resolve();
+    }
+
+    function checkCancelled() {
+        if ( cancelled ) throw new Error(CANCELLED_MARKER);
     }
 
     if (isSyncing) {
@@ -113,13 +132,20 @@ function startSynchronise(options) {
     Topics.fireTopicEvent( Topics.SYNC_STARTED );
     return Promise.resolve()
         .then(() => sampleDownloader.downloadSamples() )
+        .then(checkCancelled)
         .then(() => sampleUploader.uploadSamples() )
+        .then(checkCancelled)
         .then(() => {
             syncStore.recordSuccess();
             info("Sync finished successfully");
             Topics.fireTopicEvent( Topics.SYNC_FINISHED, { success: true } );
         })
         .catch( err => {
+            if ( err && err.message === CANCELLED_MARKER ) {
+                info("Sync aborted: user logged out.");
+                Topics.fireTopicEvent( Topics.SYNC_FINISHED, { success: false, cancelled: true } );
+                return;
+            }
             error("Sync finished with errors");
             Logger.recordException( err );
             syncStore.recordError( err );

--- a/walta-app/app/lib/ui/Topics.js
+++ b/walta-app/app/lib/ui/Topics.js
@@ -8,6 +8,8 @@ var topics = {
 
 	LOGGEDIN: 'loggedin',
 
+	LOGGEDOUT: 'loggedout',
+
 	HOME: 'home',
 	SETTINGS: 'settings',
 	INFO: 'info',


### PR DESCRIPTION
Part of the WB-64 split — see [#223](https://github.com/TheWaterBugCompany/WALTA/pull/223) for the parent PR. **Stacked on #230 (Logger arch).**

Logging out previously left the scheduled sync running, and the in-flight chain crashed with a cryptic \`null is not an object\` because each authed CerdiApi method dereferenced \`retrieveUserToken()\` directly.

## Changes

- **New \`LOGGEDOUT\` topic** — \`Menu.logOut()\` fires it after clearing the user token.
- **\`SampleSync\` subscribes**: clears the rescheduled timer and sets a cancel flag the chain checks between download → upload and before \`recordSuccess\`. The catch handler treats the sentinel as expected (info log, fires \`SYNC_FINISHED { cancelled: true }\`, no \`recordError\`).
- **\`CerdiApi._requireAccessToken()\` helper** — the 14 authed methods route their token read through it. A token cleared mid-sync now rejects with \`Not logged in\` instead of the \`null is not an object\` TypeError, and the deep catch handlers in the downloader/uploader treat it as any other request failure.

## Test plan
- [x] \`npx grunt unit-test-node\`
- [ ] Manual: log in, force a sync, log out mid-sync — should see \`Sync aborted: user logged out\` in the log pane and no further activity
- [ ] \`npx grunt --platform=android --simulator acceptance-test\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)