### PR TITLE
WB-74: harden install.sh ti.map download against transient HTTP errors

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ install_ti_module() {
   local url="https://github.com/appcelerator-modules/$module/releases/download/v$version$tag_suffix/$module-$platform-$version.zip"
   local tmp=$(mktemp -d)
   echo "Downloading $module $platform v$version..."
-  curl -sL "$url" -o "$tmp/module.zip"
+  curl -sSL --fail --retry 3 --retry-delay 2 --retry-all-errors "$url" -o "$tmp/module.zip"
   unzip -q "$tmp/module.zip" -d "$tmp"
   rm -rf "walta-app/modules/$platform/$module"
   mkdir -p "walta-app/modules/$platform/$module"


### PR DESCRIPTION
## Summary

iOS release [run 25592514130](https://github.com/TheWaterBugCompany/WALTA/actions/runs/25592514130/job/75132563094) failed at `install.sh` while downloading `ti.map android v5.7.0`:

```
End-of-central-directory signature not found.
unzip: cannot find zipfile directory
##[error]Process completed with exit code 9.
```

The Android job on the same workflow invocation succeeded — same script, same URL. The URL itself is healthy (verified: `301 → 302 → 200`, 285 KB zip).

## Root cause

`curl -sL` at [install.sh:43](install.sh#L43):
- No `--fail` → curl exits 0 on HTTP 4xx/5xx, writes the error body (HTML) to `module.zip`.
- No `--retry` → a single transient blip from GitHub's release-asset CDN (Azure blob storage with short-lived SAS tokens) kills the whole job.

`unzip` then chokes on the HTML and `set -e` aborts the script.

## Fix

Add `-S --fail --retry 3 --retry-delay 2 --retry-all-errors`:

```sh
curl -sSL --fail --retry 3 --retry-delay 2 --retry-all-errors "$url" -o "$tmp/module.zip"
```

Applies to all three module downloads (`ti.map iphone`, `ti.map android`, `ti.playservices android`) since they share the helper.

Trello: https://trello.com/c/iNQignKK

## Test plan

- [ ] CI green on this PR
- [ ] After merge, re-trigger the Release workflow and confirm the iOS job clears `install.sh`