### PR TITLE
WB-63: deterministically dismiss iOS Save Password sheet after login

### DIFF
--- a/features/support/login-screen.js
+++ b/features/support/login-screen.js
@@ -14,20 +14,29 @@ class LoginScreen extends BaseScreen {
     }
 
     // iOS pops a system-level "Save Password?" sheet after the login form
-    // submits and persists across app terminations into the next scenario,
-    // occluding the menu. The cucumber.js BeforeAll disables-AutoFill +
-    // keychain-reset don't suppress it. autoDismissAlerts doesn't catch
-    // it because it's not a UIAlertController. Dismiss it explicitly via
-    // the "Not Now" button (3s wait — absent on a fast-enough machine
-    // that the sheet hasn't appeared yet, but harmless when missing).
+    // submits. It persists across app terminations and walta://reset
+    // because it's a system overlay, not a UIAlertController — neither the
+    // BeforeAll AutoFill/keychain reset nor autoDismissAlerts suppress it.
+    // Tapping "Not Now" makes iOS not re-present the sheet for that
+    // credential, so dismissing it once deterministically here keeps it
+    // out of every subsequent scenario.
+    //
+    // Three steps, all required:
+    //   1. Wait for the sheet to appear — generous timeout because on
+    //      contended macOS-15 runners it can take >10s to render.
+    //   2. Tap "Not Now".
+    //   3. Wait for the sheet to actually animate away — otherwise the
+    //      next step races the dismiss animation and finds the sheet
+    //      still occluding the menu.
     async dismissSavePasswordSheet() {
+        const btn = await this.driver.$("-ios predicate string:label == 'Not Now'");
         try {
-            const btn = await this.driver.$("-ios predicate string:label == 'Not Now'");
-            await btn.waitForDisplayed({ timeout: 3000 });
-            await btn.click();
+            await btn.waitForDisplayed({ timeout: 20000 });
         } catch (e) {
-            // Sheet didn't appear — fine.
+            return; // sheet never appeared — nothing to dismiss
         }
+        await btn.click();
+        await btn.waitForDisplayed({ timeout: 5000, reverse: true });
     }
 } 
 module.exports = LoginScreen


### PR DESCRIPTION
## Summary

The 3s `waitForDisplayed` in `LoginScreen.dismissSavePasswordSheet()` was losing to slow macOS-15 runners. When the sheet appeared after the timeout, the dismiss gave up and the sheet persisted into subsequent scenarios — `walta://reset` doesn't clear it because it's a system overlay, not in-app state.

This change makes the dismiss deterministic:

1. Wait up to **20s** for the sheet to appear (generous for contended runners).
2. Tap **Not Now**.
3. Wait for the sheet to animate **away** before returning, so the next step doesn't race the dismiss.

Once `Not Now` is tapped, iOS won't re-present the sheet for that credential — so a single, well-formed dismiss in the login scenario keeps it out of every subsequent scenario in the run.

## Evidence (WB-72 artifacts from run 25596367636)

Three scenarios failed; per-scenario artifacts captured:

- `Log_in_with_existing_account` — sheet visible **after** "You are Logged in" appeared → previous 3s wait gave up before the sheet rendered.
- `Sample_collection` — sheet visible over a **not-logged-in Menu** → sheet from the earlier login scenario persisted across `walta://reset`.
- `User_initiates_sync_from_sample_history` — byte-identical artifact to Sample_collection (same persisted sheet).

Trello: https://trello.com/c/WCXG4Hfb

## Test plan

- [ ] CI green on iOS acceptance for several consecutive runs
- [ ] If a run fails, WB-72 artifacts no longer show a Save Password sheet (i.e. either we found a different bug, or the dismiss timeout needs to grow further)