### PR TITLE
WB-83: require IOS_DEVICE_UDID for iOS device, drop hardcoded caps

### DIFF
--- a/build-tests/unit/AppiumLauncher_spec.js
+++ b/build-tests/unit/AppiumLauncher_spec.js
@@ -140,6 +140,40 @@ describe("AppiumLauncher", function() {
     });
   });
 
+  describe("iOS device capabilities", function() {
+    let originalUdid;
+
+    beforeEach(function() {
+      originalUdid = process.env.IOS_DEVICE_UDID;
+    });
+
+    afterEach(function() {
+      if (originalUdid === undefined) delete process.env.IOS_DEVICE_UDID;
+      else process.env.IOS_DEVICE_UDID = originalUdid;
+    });
+
+    it("throws when IOS_DEVICE_UDID is not set", async function() {
+      delete process.env.IOS_DEVICE_UDID;
+      const launcher = new AppiumLauncher("ios", { isSimulator: false, startAppium: fakeStartAppium });
+      let caught;
+      try { await launcher.connect(); } catch (e) { caught = e; }
+      expect(caught).to.exist;
+      expect(caught.message).to.match(/IOS_DEVICE_UDID/);
+    });
+
+    it("passes IOS_DEVICE_UDID through as appium:udid", async function() {
+      process.env.IOS_DEVICE_UDID = "0123-fake-iphone-udid";
+      const launcher = new AppiumLauncher("ios", { isSimulator: false, startAppium: fakeStartAppium });
+      await launcher.connect();
+      const caps = fakeStartAppium.firstCall.args[0];
+      expect(caps["appium:udid"]).to.equal("0123-fake-iphone-udid");
+      // Hardcoded device-specific values dropped — Appium discovers them
+      // from the connected device.
+      expect(caps).to.not.have.property("appium:platformVersion");
+      expect(caps).to.not.have.property("appium:deviceName");
+    });
+  });
+
   describe("launch()", function() {
     function makeFakeChildExitingZero() {
       const child = new EventEmitter();

--- a/build-tests/unit/AppiumLauncher_spec.js
+++ b/build-tests/unit/AppiumLauncher_spec.js
@@ -6,6 +6,8 @@ import AppiumLauncher from "../../build-utils/AppiumLauncher.js";
 describe("AppiumLauncher", function() {
   let fakeDriver;
   let fakeStartAppium;
+  let originalSimUdid;
+  let originalIosDeviceUdid;
   const originalMaxListeners = process.getMaxListeners();
 
   before(function() { process.setMaxListeners(20); });
@@ -19,6 +21,21 @@ describe("AppiumLauncher", function() {
       getLogs: sinon.stub().resolves([])
     };
     fakeStartAppium = sinon.stub().resolves(fakeDriver);
+    // Stub iOS UDID env vars so tests that construct an iOS launcher
+    // for command-dispatch assertions (launch/terminate) don't hit the
+    // device-path or sim-path UDID throws. Tests that exercise the
+    // "env unset" contract delete these in-body.
+    originalSimUdid = process.env.SIM_UDID;
+    originalIosDeviceUdid = process.env.IOS_DEVICE_UDID;
+    process.env.SIM_UDID = "test-sim-udid";
+    process.env.IOS_DEVICE_UDID = "test-device-udid";
+  });
+
+  afterEach(function() {
+    if (originalSimUdid === undefined) delete process.env.SIM_UDID;
+    else process.env.SIM_UDID = originalSimUdid;
+    if (originalIosDeviceUdid === undefined) delete process.env.IOS_DEVICE_UDID;
+    else process.env.IOS_DEVICE_UDID = originalIosDeviceUdid;
   });
 
   describe("connect()", function() {

--- a/build-utils/AppiumLauncher.js
+++ b/build-utils/AppiumLauncher.js
@@ -153,10 +153,11 @@ class AppiumLauncher {
           "appium:udid": process.env.SIM_UDID,
         });
       } else {
+        if (!process.env.IOS_DEVICE_UDID) {
+          throw new Error("IOS_DEVICE_UDID must be set for iOS device runs (`idevice_id -l`)");
+        }
         Object.assign(caps, {
-          "appium:platformVersion": "12.4",
-          "appium:deviceName": "The Code Sharman Test iPhone",
-          "appium:udid": "auto",
+          "appium:udid": process.env.IOS_DEVICE_UDID,
           "appium:xcodeOrgId": "6RRED3LUUV",
           "appium:xcodeSigningId": "Apple Development",
         });

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -207,7 +207,7 @@ export DEVELOPER="Your Name (TEAMID)"       # Common Name from your signing cert
 export PROFILE_DIST="<app-store-profile-uuid>"
 export PROFILE_ADHOC="<adhoc-profile-uuid>"
 export PROFILE_DEV="<dev-profile-uuid>"
-export DEVICE_UDID="<device-udid>"          # Run: idevice_id -l
+export IOS_DEVICE_UDID="<device-udid>"      # Run: idevice_id -l
 ```
 
 Profile UUIDs are visible in the developer portal. To find your device UDID:
@@ -265,7 +265,7 @@ npx grunt --platform=ios debug
 | `PROFILE_DIST` | iOS App Store builds | UUID |
 | `PROFILE_ADHOC` | iOS ad-hoc builds | UUID |
 | `PROFILE_DEV` | iOS dev/debug builds | UUID |
-| `DEVICE_UDID` | iOS ad-hoc builds | from `idevice_id -l` |
+| `IOS_DEVICE_UDID` | iOS device builds + acceptance | from `idevice_id -l` |
 | `NODE_PATH` | Node.js unit tests | `./walta-app/app/lib/` |
 
 ---


### PR DESCRIPTION
## Summary
- iOS device-acceptance hit a session-start error against any iPhone other than a long-retired test device — the Appium caps hardcoded `platformVersion: "12.4"`, a specific `deviceName`, and `udid: "auto"` (which Appium doesn't actually accept). Drop all three; require `IOS_DEVICE_UDID` env var and throw a clear error pointing devs at `idevice_id -l` if unset.
- Add two unit tests in `build-tests/unit/AppiumLauncher_spec.js`: throws when env unset, wires UDID through to `appium:udid`.
- Drive-by: rename `DEVICE_UDID` → `IOS_DEVICE_UDID` in [docs/installation.md](docs/installation.md) — the docs had drifted from `Gruntfile.js`, which already used the prefixed name.

[Trello WB-83](https://trello.com/c/owpAz6G2/83-appiumlauncher-drop-hardcoded-ios-device-name-platformversion-require-iosdeviceudid) — scoped to the launcher caps; the related developer.apple.com provisioning-profile work (registering the iPhone UDID on `PROFILE_DEV`) is independent and not in this PR.

CI doesn't exercise iOS device acceptance — only simulator + macOS runners — so this is dev-only scope.

## Test plan
- [x] `mocha build-tests/unit/AppiumLauncher_spec.js` — 24 passing (existing 22 + 2 new)
- [ ] `npx grunt build-test` — passes
- [ ] iOS-device acceptance run unblocked (gated on provisioning profile, out of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)