### PR TITLE
WB-12: Investigate: Syncing download everything updates after a day

### DIFF
--- a/contract-tests/CerdiApi_spec.js
+++ b/contract-tests/CerdiApi_spec.js
@@ -428,6 +428,24 @@ describe('CerdiApi', function() {
             expect(res4[0].creature_id).to.be.null;
         });
 
+        // WB-12: verify the unknown-creature round-trip exposes a photo id we
+        // can use to populate `serverCreaturePhotoId` locally on download.
+        // SampleDownloader.js:66 relies on `u.photos[0].id` from this endpoint.
+        it("should round-trip unknown creature photo id", async function() {
+            await cerdi.loginUser('testlogin@example.com', 'tstPassw0rd!');
+            const sampleRes = await submitTestSample(moment().format());
+            const submitRes = await cerdi.submitUnknownCreature(sampleRes.id, 6, creaturePhotoPath);
+            const uploadedPhotoId = submitRes.photos[0].id;
+            console.log('submitUnknownCreature response:', JSON.stringify(submitRes, null, 2));
+
+            const fetched = await cerdi.retrieveUnknownCreatures(sampleRes.id);
+            console.log('retrieveUnknownCreatures response:', JSON.stringify(fetched, null, 2));
+
+            expect(fetched).to.have.lengthOf(1);
+            expect(fetched[0].photos, 'photos array on GET').to.have.lengthOf(1);
+            expect(fetched[0].photos[0].id, 'photo id on GET matches upload response').to.equal(uploadedPhotoId);
+        });
+
         it("should delete unknown creatures", async function() {
             let serverSampleId;
             await cerdi.loginUser( 'testlogin@example.com', 'tstPassw0rd!' );
@@ -619,6 +637,38 @@ describe('CerdiApi', function() {
                 })
         });
         
+        // WB-12: the patch-broken-records block at sample.js:455-476 assumes
+        // the server stores habitat 0s as NULL for two-word fields, and bumps
+        // `updatedAt` to force a re-upload — driving the observed upload loop.
+        // Verify whether the assumption still holds by round-tripping zeros
+        // for all 8 fields and asserting each individually.
+        it("should round-trip habitat zero values", async function() {
+            await cerdi.loginUser('testlogin@example.com', 'tstPassw0rd!');
+            const sampleData = makeTestSample(moment().format());
+            sampleData.habitat = {
+                boulder: 0,
+                gravel: 0,
+                sand_or_silt: 0,
+                leaf_packs: 0,
+                wood: 0,
+                aquatic_plants: 0,
+                open_water: 0,
+                edge_plants: 0
+            };
+            const submitted = await cerdi.submitSample(sampleData);
+            const fetched = await cerdi.retrieveSampleById(submitted.id);
+            expect(fetched.habitat).to.deep.include({
+                boulder: 0,
+                gravel: 0,
+                sand_or_silt: 0,
+                leaf_packs: 0,
+                wood: 0,
+                aquatic_plants: 0,
+                open_water: 0,
+                edge_plants: 0
+            });
+        });
+
         it("should retrieve samples", function() {
             let createdAt = null, updatedAt = null, sampleDate = moment().format();
             return cerdi

--- a/walta-app/app/models/taxa.js
+++ b/walta-app/app/models/taxa.js
@@ -128,7 +128,13 @@ exports.definition = {
 					abundance: this.convertCountToAbundance(creature.count)
 				};
 				
-				fields.serverCreaturePhotoId = parseIntOrNull(creature._serverCreaturePhotoId);
+				// Only populated by SampleDownloader.processUnknownCreatures for
+				// unknown creatures; for known creatures the server doesn't echo
+				// this field. Guard the read so re-syncs don't wipe the local
+				// id that downloadCreaturePhoto set on first download.
+				if ( !_.isUndefined(creature._serverCreaturePhotoId) ) {
+					fields.serverCreaturePhotoId = parseIntOrNull(creature._serverCreaturePhotoId);
+				}
 				fields.serverCreatureId = parseIntOrNull(creature.id);
 				fields.taxonId = parseIntOrNull(creature.creature_id);
 

--- a/walta-app/app/spec/Sample_spec.js
+++ b/walta-app/app/spec/Sample_spec.js
@@ -212,6 +212,40 @@ describe("Taxa collection", function() {
     
   });
 
+  // WB-12: re-syncing a sample from the server must not wipe the
+  // locally-stored serverCreaturePhotoId. The server doesn't echo
+  // `_serverCreaturePhotoId` for known creatures, so reading it back as
+  // null on every download makes findPendingUploads() flag every taxon
+  // as pending — triggering an upload loop.
+  it('should preserve serverCreaturePhotoId when re-syncing a known creature whose photo was already uploaded', function() {
+    clearDatabase();
+    let taxon = Alloy.createModel("taxa");
+    taxon.set("sampleId", 666);
+    taxon.set("abundance", "> 20");
+    taxon.set("taxonId", 1);
+    taxon.set("serverCreatureId", 9067);
+    taxon.set("serverCreaturePhotoId", 12345);
+    taxon.set("taxonPhotoPath", makeTestPhoto("test-photo.jpg"));
+    taxon.set("updatedAt", 0);
+    taxon.save();
+
+    let taxa = Alloy.createCollection("taxa");
+    taxa.load(666);
+
+    // simulate a real server response — `_serverCreaturePhotoId` is absent
+    // because the server treats `_`-prefixed fields as private to the client.
+    taxa.fromCerdiApiJson([{
+      id: 9067,
+      creature_id: 1,
+      count: 25,
+      photos_count: 1
+    }], 666);
+
+    taxa.load(666);
+    expect(taxa.size(), "size of taxa collection").to.equal(1);
+    expect(taxa.at(0).get("serverCreaturePhotoId"), "serverCreaturePhotoId should be preserved across re-sync").to.equal(12345);
+  });
+
   it('should return taxons pending upload', function() {
     clearDatabase();
     let taxon1, taxon2,taxon3;


### PR DESCRIPTION
## Summary
- Root-cause the "after-a-day re-sync" loop: `taxa.fromCerdiApiJson` was wiping the locally-stored `serverCreaturePhotoId` on every re-download, because it read `creature._serverCreaturePhotoId` unconditionally — a field the server only echoes for unknown creatures. With the id wiped, `taxa.findPendingUploads()` flagged every taxon as pending, triggering an upload which bumped server `updated_at` which forced another re-sync. Fix is a one-line guard matching the pattern already used for `_taxonPhotoPath` / `_updatedAt` on the lines below.
- Add two contract tests (Node-level) documenting the actual sandbox response shapes — habitat zeros round-trip correctly (refutes the original hypothesis that patch-broken-records was load-bearing), and unknown-creature `photos[0].id` round-trips (confirms `SampleDownloader.processUnknownCreatures` is correct).
- RED test in `Sample_spec.js` covers the precise invariant: `serverCreaturePhotoId` survives a `fromCerdiApiJson` call whose payload doesn't include `_serverCreaturePhotoId`.

First slice of [Trello WB-12](https://trello.com/c/AHRyVNlF/12-investigate-syncing-download-everything-updates-after-a-day) — the loop fix only. Deferred for separate cards (already noted in conversation): vestigial patch-broken-records code at `sample.js:455-476`, dead `_` round-trip fields, Bugfender SDK unreliability on TestFlight v2.0.4.24.

## Test plan
- [x] `Taxa collection` device specs on iOS sim — 10/10 passing
- [x] `contract-test` — habitat zero + unknown creature round-trip tests pass
- [x] Full `unit-test-node` suite
- [x] Full iOS device-unit suite (no `--liveview`) before marking ready
- [ ] Sanity-check on iPhone 17e — install rebuild, trigger sync, confirm "Updating existing sample" log doesn't fire on samples with no local changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)