### PR TITLE
docs: always invoke tests via grunt wrappers, never raw npx mocha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,10 @@ npx grunt --platform=ios --simulator --reset debug
 ### Test
 
 ```bash
-npx grunt unit-test-node   # Node-only unit tests, fastest feedback
-npx grunt build-test       # Build-utils / hooks / launcher unit tests
+npx grunt unit-test-node                   # Node-only unit tests, fastest feedback
+npx grunt build-test                       # Build-utils / hooks / launcher unit tests
+npx grunt --platform=ios unit-test         # Device / simulator unit specs
+npx grunt --platform=ios acceptance-test   # Cucumber acceptance scenarios
 ```
 
 **Always invoke tests via the grunt wrappers** — never `npx mocha` directly. The wrappers set the right `NODE_PATH`, `NODE_OPTIONS`, and test-file globs; raw mocha runs can hang silently (no test output) when those aren't configured.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,10 +78,12 @@ npx grunt --platform=ios --simulator --reset debug
 ### Test
 
 ```bash
-npx grunt unit-test-node                   # Node-only unit tests, fastest feedback
-npx grunt build-test                       # Build-utils / hooks / launcher unit tests
-npx grunt --platform=ios unit-test         # Device / simulator unit specs
-npx grunt --platform=ios acceptance-test   # Cucumber acceptance scenarios
+npx grunt unit-test-node                       # Node-only unit tests, fastest feedback
+npx grunt build-test                           # Build-utils / hooks / launcher unit tests
+npx grunt --platform=ios unit-test             # iOS device / simulator unit specs
+npx grunt --platform=android unit-test         # Android device / emulator unit specs
+npx grunt --platform=ios acceptance-test       # iOS cucumber acceptance scenarios
+npx grunt --platform=android acceptance-test   # Android cucumber acceptance scenarios
 ```
 
 **Always invoke tests via the grunt wrappers** — never `npx mocha` directly. The wrappers set the right `NODE_PATH`, `NODE_OPTIONS`, and test-file globs; raw mocha runs can hang silently (no test output) when those aren't configured.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,10 @@ npx grunt --platform=ios --simulator --reset debug
 
 ```bash
 npx grunt unit-test-node   # Node-only unit tests, fastest feedback
+npx grunt build-test       # Build-utils / hooks / launcher unit tests
 ```
+
+**Always invoke tests via the grunt wrappers** — never `npx mocha` directly. The wrappers set the right `NODE_PATH`, `NODE_OPTIONS`, and test-file globs; raw mocha runs can hang silently (no test output) when those aren't configured.
 
 See the [tdd](.claude/skills/tdd/SKILL.md) and [fast-iteration](.claude/skills/fast-iteration/SKILL.md) skills.
 


### PR DESCRIPTION
## Summary
Document the existing rule that test invocations must go through the grunt wrappers (`npx grunt unit-test-node`, `npx grunt build-test`) rather than direct `npx mocha`. Raw mocha hangs silently in this repo because `NODE_PATH` (set in Gruntfile.js for Titanium-style module resolution) and `NODE_OPTIONS=--experimental-vm-modules` (build-test) are only applied through the grunt tasks.

Surfaced this session while running build-utils tests directly — output stayed empty for minutes with no failure or progress. Capturing the rule in `CLAUDE.md` so future sessions reach for the right command first.

## Test plan
- [x] `CLAUDE.md` renders cleanly with the new bold call-out and code block

🤖 Generated with [Claude Code](https://claude.com/claude-code)