### PR TITLE
docs: remind future sessions to load the fast-iteration skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ This project follows test-driven development (Kent Beck style): each behavioural
 
 Before any development work, load the [tdd](.claude/skills/tdd/SKILL.md) skill — every behavioural change starts with a failing test, including small ones. Skip only for non-behavioural edits (typos, formatting, comment-only changes).
 
+When iterating on `Ti.*` / Alloy code (controllers, view specs, cucumber scenarios), load the [fast-iteration](.claude/skills/fast-iteration/SKILL.md) skill — narrow with `--grep` and use `--liveview --reuse-server` so each iteration is seconds, not minutes. Skip this skill when the change is pure JS — `npx grunt unit-test-node` is faster.
+
 When a code smell surfaces mid-session — tangled deps, hidden state, a function doing two things, a workaround stacking on a workaround — pause and flag it for review rather than silently restructuring or pressing on. Code happens fast in these sessions; the human reviewer is the project's refactor-detector, and surfacing smells gives them a checkpoint to decide refactor-now vs. carry-on.
 
 ## Workflow


### PR DESCRIPTION
## Summary
- The Methodology section already names `tdd` as load-before-dev; add a parallel reminder for `fast-iteration` so future sessions iterating on `Ti.*` / Alloy code default to `--liveview --reuse-server` + `--grep` rather than full clean-build cycles.
- Caveat included: skip the skill for pure-JS work where `npx grunt unit-test-node` is faster.

Methodology side-quest split off WB-85 (Diagnostics button) so the WB-85 PR stays focused. Once this lands, the WB-85 branch rebases on top.

## Test plan
- [x] N/A — docs-only change, no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)