### PR TITLE
WB-85: Diagnostics button: email with log + per-table CSVs + photo manifest

### DIFF
--- a/test/util/DiagnosticsBundle_spec.js
+++ b/test/util/DiagnosticsBundle_spec.js
@@ -1,0 +1,24 @@
+require("mocha");
+const { expect } = require("chai");
+const { buildBody } = require("../../walta-app/app/lib/util/DiagnosticsBundle");
+
+describe("DiagnosticsBundle.buildBody", function () {
+  it("formats app + device + free-disk into a labelled block", function () {
+    const body = buildBody({
+      appVersion: "4.1.0",
+      osname: "ios",
+      osVersion: "17.4",
+      model: "iPhone15,3",
+      locale: "en-AU",
+      freeBytes: 13_421_772_800, // exactly 12.5 GiB
+    });
+
+    expect(body).to.equal(
+      "App version:  4.1.0\n" +
+      "OS:           ios 17.4\n" +
+      "Phone model:  iPhone15,3\n" +
+      "Locale:       en-AU\n" +
+      "Free disk:    12.5 GB"
+    );
+  });
+});

--- a/test/util/DiagnosticsBundle_spec.js
+++ b/test/util/DiagnosticsBundle_spec.js
@@ -1,10 +1,12 @@
 require("mocha");
 const { expect } = require("chai");
-const { buildBody } = require("../../walta-app/app/lib/util/DiagnosticsBundle");
+const { buildBody, formatLogEntries, formatCsv, filterLogsByFacility } = require("../../walta-app/app/lib/util/DiagnosticsBundle");
 
 describe("DiagnosticsBundle.buildBody", function () {
-  it("formats app + device + free-disk into a labelled block", function () {
+  it("formats user + app + device + free-disk into a labelled block", function () {
     const body = buildBody({
+      userEmail: "user@example.com",
+      userId: 1734,
       appVersion: "4.1.0",
       osname: "ios",
       osVersion: "17.4",
@@ -14,11 +16,104 @@ describe("DiagnosticsBundle.buildBody", function () {
     });
 
     expect(body).to.equal(
+      "User email:   user@example.com\n" +
+      "User ID:      1734\n" +
       "App version:  4.1.0\n" +
       "OS:           ios 17.4\n" +
       "Phone model:  iPhone15,3\n" +
       "Locale:       en-AU\n" +
       "Free disk:    12.5 GB"
     );
+  });
+
+  it("renders 'unknown' for free disk when Ti.Filesystem.spaceAvailable returns a non-number", function () {
+    const body = buildBody({
+      userEmail: "u@x.com", userId: 1,
+      appVersion: "4.1.0", osname: "ios", osVersion: "18.0",
+      model: "iPhone17,3", locale: "en-AU",
+      freeBytes: NaN,
+    });
+    expect(body).to.contain("Free disk:    unknown");
+  });
+
+  it("renders '(not logged in)' when the user identity is absent", function () {
+    const body = buildBody({
+      userEmail: null,
+      userId: null,
+      appVersion: "4.1.0", osname: "ios", osVersion: "17.4",
+      model: "iPhone15,3", locale: "en-AU", freeBytes: 1_073_741_824,
+    });
+    expect(body).to.contain("User email:   (not logged in)");
+    expect(body).to.contain("User ID:      (not logged in)");
+  });
+});
+
+describe("DiagnosticsBundle.formatLogEntries", function () {
+  it("renders one row per entry with ISO timestamp + padded level + padded facility + message", function () {
+    const text = formatLogEntries([
+      { ts: Date.UTC(2026, 4, 15, 7, 32, 25, 0),   level: "info",  facility: "sync",    message: "Sync finished successfully" },
+      { ts: Date.UTC(2026, 4, 15, 7, 32, 30, 123), level: "error", facility: "network", message: "GET /samples failed: 500" },
+    ]);
+
+    expect(text).to.equal(
+      "2026-05-15T07:32:25.000Z info  sync       Sync finished successfully\n" +
+      "2026-05-15T07:32:30.123Z error network    GET /samples failed: 500"
+    );
+  });
+
+  it("returns the empty string for no entries", function () {
+    expect(formatLogEntries([])).to.equal("");
+  });
+});
+
+describe("DiagnosticsBundle.filterLogsByFacility", function () {
+  it("keeps entries whose facility appears in the allow-list and drops the rest", function () {
+    const entries = [
+      { ts: 1, level: "info",  facility: "sync",       message: "kept-sync" },
+      { ts: 2, level: "debug", facility: "navigation", message: "dropped-nav" },
+      { ts: 3, level: "info",  facility: "network",    message: "kept-network" },
+      { ts: 4, level: "info",  facility: "auth",       message: "dropped-auth" },
+    ];
+    expect(filterLogsByFacility(entries, ["sync", "network"]))
+      .to.deep.equal([
+        { ts: 1, level: "info", facility: "sync",    message: "kept-sync" },
+        { ts: 3, level: "info", facility: "network", message: "kept-network" },
+      ]);
+  });
+});
+
+describe("DiagnosticsBundle.formatCsv", function () {
+  it("emits an RFC-4180 CSV with header row + value rows", function () {
+    const csv = formatCsv([
+      { sampleId: 42, waterbodyName: "Yarra River", lat: -37.78, complete: 1 },
+      { sampleId: 43, waterbodyName: null,          lat: -38.10, complete: 0 },
+    ]);
+    expect(csv).to.equal(
+      "sampleId,waterbodyName,lat,complete\n" +
+      "42,Yarra River,-37.78,1\n" +
+      "43,,-38.1,0"
+    );
+  });
+
+  it("quotes fields containing commas, double-quotes or newlines, with quotes doubled", function () {
+    const csv = formatCsv([
+      { name: "Plain" },
+      { name: "Has, comma" },
+      { name: "She said \"hi\"" },
+      { name: "Line1\nLine2" },
+    ]);
+    expect(csv).to.equal(
+      "name\n" +
+      "Plain\n" +
+      "\"Has, comma\"\n" +
+      "\"She said \"\"hi\"\"\"\n" +
+      "\"Line1\nLine2\""
+    );
+  });
+
+  it("emits a '(no rows)' marker for no rows so the attachment is non-empty", function () {
+    // Android Intent.ACTION_SEND_MULTIPLE / TiFileProvider silently drops 0-byte
+    // attachments; emit a sentinel so empty tables still arrive in the email.
+    expect(formatCsv([])).to.equal("(no rows)");
   });
 });

--- a/walta-app/app/controllers/index-app.js
+++ b/walta-app/app/controllers/index-app.js
@@ -13,7 +13,9 @@ var { View } = require("logic/View");
 var { Survey } = require("logic/Survey");
 var { Navigation } = require('logic/Navigation');
 var { checkForErrors } = require('util/PromiseUtils');
+var DiagnosticsBundle = require('util/DiagnosticsBundle');
 Topics.init();
+DiagnosticsBundle.subscribe();
 
 // FIXME: deprecate using globals
 Alloy.Globals.CerdiApi = CerdiApi.createCerdiApi( Alloy.CFG.cerdiServerUrl, Alloy.CFG.cerdiApiSecret );

--- a/walta-app/app/controllers/index-app.js
+++ b/walta-app/app/controllers/index-app.js
@@ -66,8 +66,8 @@ if (OS_IOS) {
 SampleSync.init();
 
 // Report user name to Logger when logged in
-function setUserId() { 
-  Logger.setUserId( Ti.App.Properties.getObject('userAccessUsername') ); 
+function setUserId() {
+  Logger.setUserId( Alloy.Globals.CerdiApi.retrieveUsername() );
 }
 Topics.subscribe( Topics.LOGGEDIN, (data) => setUserId() );
 if ( Alloy.Globals.CerdiApi.retrieveUserToken() ) {

--- a/walta-app/app/lib/logic/CerdiApi.js
+++ b/walta-app/app/lib/logic/CerdiApi.js
@@ -153,7 +153,11 @@ function createCerdiApi( serverUrl, client_secret  ) {
                     return token.id;
                 }
             },
-        
+
+            retrieveUsername() {
+                return Ti.App.Properties.getObject("userAccessUsername");
+            },
+
             storeUserToken( email, accessToken ) {
                 //Ti.API.info(`accessToken = ${JSON.stringify(accessToken)}`)
                 Ti.App.Properties.setObject("userAccessUsername", email );

--- a/walta-app/app/lib/util/DiagnosticsBundle.js
+++ b/walta-app/app/lib/util/DiagnosticsBundle.js
@@ -1,0 +1,77 @@
+const RECIPIENT = "waterbug-diagnostics@thecodesharman.com.au";
+const SUBJECT_PREFIX = "Waterbug diagnostics";
+const ATTACHMENT_FILENAME = "waterbug-diagnostics.txt";
+
+function buildBody(platform) {
+    const gb = (platform.freeBytes / (1024 ** 3)).toFixed(1);
+    const rows = [
+        ["App version:", platform.appVersion],
+        ["OS:", `${platform.osname} ${platform.osVersion}`],
+        ["Phone model:", platform.model],
+        ["Locale:", platform.locale],
+        ["Free disk:", `${gb} GB`],
+    ];
+    return rows.map(([label, value]) => label.padEnd(14) + value).join("\n");
+}
+
+function readPlatform() {
+    return {
+        appVersion: Ti.App.version,
+        osname: Ti.Platform.osname,
+        osVersion: Ti.Platform.version,
+        model: Ti.Platform.model,
+        locale: Ti.Platform.locale,
+        freeBytes: Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory).spaceAvailable,
+    };
+}
+
+function writeStubAttachment(body) {
+    const file = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, ATTACHMENT_FILENAME);
+    file.write(body);
+    return file;
+}
+
+function openDiagnosticsEmail(deps) {
+    deps = deps || {};
+    const createEmailDialog = deps.createEmailDialog || ((cfg) => Ti.UI.createEmailDialog(cfg));
+    const createAlertDialog = deps.createAlertDialog || ((cfg) => Ti.UI.createAlertDialog(cfg));
+    const setClipboardText  = deps.setClipboardText  || ((text) => Ti.UI.Clipboard.setText(text));
+    const platform          = deps.platform          || readPlatform();
+    const writeAttachment   = deps.writeAttachment   || writeStubAttachment;
+
+    const body    = buildBody(platform);
+    const subject = `${SUBJECT_PREFIX} — ${platform.appVersion} on ${platform.model}`;
+    const dialog  = createEmailDialog({
+        toRecipients: [RECIPIENT],
+        subject,
+        messageBody: body,
+    });
+
+    if (!dialog.isSupported()) {
+        // iOS Ti.UI.EmailDialog wraps MFMailComposeViewController, which insists on Apple Mail
+        // even when other email apps are installed; many users will never see the composer.
+        // Falling back to clipboard means everyone can still send diagnostics manually.
+        setClipboardText(body);
+        createAlertDialog({
+            title: "Diagnostics copied",
+            message: "Diagnostics have been copied to the clipboard.",
+        }).show();
+        return;
+    }
+
+    const file = writeAttachment(body);
+    dialog.addAttachment(file);
+    dialog.open();
+}
+
+function subscribe(deps) {
+    // lazy-require so the Node unit test for buildBody doesn't pull in Ti.* via Topics
+    const Topics = require("ui/Topics");
+    const handler = () => openDiagnosticsEmail(deps);
+    Topics.subscribe(Topics.DIAGNOSTICS, handler);
+    return () => Topics.unsubscribe(Topics.DIAGNOSTICS, handler);
+}
+
+exports.buildBody = buildBody;
+exports.openDiagnosticsEmail = openDiagnosticsEmail;
+exports.subscribe = subscribe;

--- a/walta-app/app/lib/util/DiagnosticsBundle.js
+++ b/walta-app/app/lib/util/DiagnosticsBundle.js
@@ -1,33 +1,131 @@
 const RECIPIENT = "waterbug-diagnostics@thecodesharman.com.au";
 const SUBJECT_PREFIX = "Waterbug diagnostics";
-const ATTACHMENT_FILENAME = "waterbug-diagnostics.txt";
+const LOG_LIMIT = 5000;
+const LOG_FILENAME = "waterbug-log.txt";
+// Diagnostics is incident-triage focused; drop UI/key/media chatter, keep
+// the network + sync narrative that explains why a sample didn't upload.
+const LOG_FACILITIES = ["sync", "network"];
+const DB_TABLES = ["sample", "taxa", "migrations"];
 
 function buildBody(platform) {
-    const gb = (platform.freeBytes / (1024 ** 3)).toFixed(1);
+    // Ti.Filesystem.spaceAvailable has been observed returning non-finite values on iOS;
+    // fall back to "unknown" rather than emitting "NaN GB" in the body.
+    const freeDisk = Number.isFinite(platform.freeBytes)
+        ? (platform.freeBytes / (1024 ** 3)).toFixed(1) + " GB"
+        : "unknown";
+    const orNotLoggedIn = (v) => (v === null || v === undefined ? "(not logged in)" : v);
     const rows = [
+        ["User email:", orNotLoggedIn(platform.userEmail)],
+        ["User ID:", orNotLoggedIn(platform.userId)],
         ["App version:", platform.appVersion],
         ["OS:", `${platform.osname} ${platform.osVersion}`],
         ["Phone model:", platform.model],
         ["Locale:", platform.locale],
-        ["Free disk:", `${gb} GB`],
+        ["Free disk:", freeDisk],
     ];
     return rows.map(([label, value]) => label.padEnd(14) + value).join("\n");
 }
 
+function formatLogEntries(entries) {
+    return entries.map((e) =>
+        new Date(e.ts).toISOString()
+            + " " + String(e.level).padEnd(5)
+            + " " + String(e.facility).padEnd(10)
+            + " " + e.message
+    ).join("\n");
+}
+
+function filterLogsByFacility(entries, facilities) {
+    return entries.filter((e) => facilities.indexOf(e.facility) !== -1);
+}
+
+function csvEscape(value) {
+    if (value === null || value === undefined) return "";
+    const s = String(value);
+    if (/[",\n\r]/.test(s)) {
+        return `"${s.replace(/"/g, '""')}"`;
+    }
+    return s;
+}
+
+function formatCsv(rows) {
+    // Android Intent.ACTION_SEND_MULTIPLE / TiFileProvider silently drops 0-byte
+    // attachments; emit a sentinel so empty tables still arrive in the email.
+    if (rows.length === 0) return "(no rows)";
+    const columns = Object.keys(rows[0]);
+    const header = columns.join(",");
+    const values = rows.map((row) => columns.map((c) => csvEscape(row[c])).join(","));
+    return [header, ...values].join("\n");
+}
+
 function readPlatform() {
+    const cerdiApi = Alloy.Globals.CerdiApi;
     return {
+        userEmail: (cerdiApi && cerdiApi.retrieveUsername && cerdiApi.retrieveUsername()) || null,
+        userId: (cerdiApi && cerdiApi.retrieveUserId && cerdiApi.retrieveUserId()) || null,
         appVersion: Ti.App.version,
         osname: Ti.Platform.osname,
         osVersion: Ti.Platform.version,
         model: Ti.Platform.model,
         locale: Ti.Platform.locale,
-        freeBytes: Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory).spaceAvailable,
+        // Ti.Filesystem.File.spaceAvailable is a method in Titanium 13.x (not the documented
+        // Number property) — reading as a property returns the function reference, which
+        // produces NaN when divided. The isFinite guard in buildBody is a belt-and-braces.
+        freeBytes: Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory).spaceAvailable(),
     };
 }
 
-function writeStubAttachment(body) {
-    const file = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, ATTACHMENT_FILENAME);
-    file.write(body);
+function readLogsFromRepository() {
+    const LogRepository = require("repository/LogRepository");
+    const repo = LogRepository.open("waterbug_data");
+    // query() returns newest-first; filter to relevant facilities then reverse
+    // for chronological reading order.
+    return filterLogsByFacility(
+        repo.query({ limit: LOG_LIMIT }),
+        LOG_FACILITIES
+    ).reverse();
+}
+
+function selectAll(db, table) {
+    const rs = db.execute(`SELECT * FROM ${table}`);
+    const rows = [];
+    while (rs.isValidRow()) {
+        const row = {};
+        for (let i = 0; i < rs.fieldCount; i++) {
+            row[rs.fieldName(i)] = rs.field(i);
+        }
+        rows.push(row);
+        rs.next();
+    }
+    rs.close();
+    return rows;
+}
+
+function readDbTablesFromTiDatabase() {
+    const db = Ti.Database.open("samples");
+    try {
+        return {
+            sample: selectAll(db, "sample"),
+            taxa: selectAll(db, "taxa"),
+            migrations: selectAll(db, "migrations"),
+        };
+    } finally {
+        db.close();
+    }
+}
+
+function readPhotoManifestFromFilesystem() {
+    const dir = Ti.Filesystem.applicationDataDirectory;
+    const listing = (Ti.Filesystem.getFile(dir).getDirectoryListing() || []);
+    return listing
+        .filter((name) => /\.(jpe?g|png)$/i.test(name))
+        .map((name) => ({ name, sizeBytes: Ti.Filesystem.getFile(dir, name).size }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function writeFileAttachment(name, content) {
+    const file = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, name);
+    file.write(content);
     return file;
 }
 
@@ -35,9 +133,11 @@ function openDiagnosticsEmail(deps) {
     deps = deps || {};
     const createEmailDialog = deps.createEmailDialog || ((cfg) => Ti.UI.createEmailDialog(cfg));
     const createAlertDialog = deps.createAlertDialog || ((cfg) => Ti.UI.createAlertDialog(cfg));
-    const setClipboardText  = deps.setClipboardText  || ((text) => Ti.UI.Clipboard.setText(text));
     const platform          = deps.platform          || readPlatform();
-    const writeAttachment   = deps.writeAttachment   || writeStubAttachment;
+    const readLogs          = deps.readLogs          || readLogsFromRepository;
+    const readDbTables      = deps.readDbTables      || readDbTablesFromTiDatabase;
+    const readPhotoManifest = deps.readPhotoManifest || readPhotoManifestFromFilesystem;
+    const writeAttachment   = deps.writeAttachment   || writeFileAttachment;
 
     const body    = buildBody(platform);
     const subject = `${SUBJECT_PREFIX} — ${platform.appVersion} on ${platform.model}`;
@@ -48,19 +148,26 @@ function openDiagnosticsEmail(deps) {
     });
 
     if (!dialog.isSupported()) {
-        // iOS Ti.UI.EmailDialog wraps MFMailComposeViewController, which insists on Apple Mail
-        // even when other email apps are installed; many users will never see the composer.
-        // Falling back to clipboard means everyone can still send diagnostics manually.
-        setClipboardText(body);
         createAlertDialog({
-            title: "Diagnostics copied",
-            message: "Diagnostics have been copied to the clipboard.",
+            title: "Email not set up",
+            message: "Please configure Apple Mail in Settings, then try again.",
         }).show();
         return;
     }
 
-    const file = writeAttachment(body);
-    dialog.addAttachment(file);
+    const logFile = writeAttachment(LOG_FILENAME, formatLogEntries(readLogs(LOG_LIMIT)));
+    dialog.addAttachment(logFile);
+
+    const tables = readDbTables();
+    for (const name of DB_TABLES) {
+        const csv = formatCsv(tables[name] || []);
+        const file = writeAttachment(`${name}.csv`, csv);
+        dialog.addAttachment(file);
+    }
+
+    const photosFile = writeAttachment("photos.csv", formatCsv(readPhotoManifest()));
+    dialog.addAttachment(photosFile);
+
     dialog.open();
 }
 
@@ -73,5 +180,8 @@ function subscribe(deps) {
 }
 
 exports.buildBody = buildBody;
+exports.formatLogEntries = formatLogEntries;
+exports.filterLogsByFacility = filterLogsByFacility;
+exports.formatCsv = formatCsv;
 exports.openDiagnosticsEmail = openDiagnosticsEmail;
 exports.subscribe = subscribe;

--- a/walta-app/app/spec/DiagnosticsBundle_spec.js
+++ b/walta-app/app/spec/DiagnosticsBundle_spec.js
@@ -7,7 +7,7 @@ const DiagnosticsBundle = require("util/DiagnosticsBundle");
 describe("DiagnosticsBundle subscriber", function () {
     let createdDialog;
     let createdAlert;
-    let clipboardText;
+    let writtenFiles;
     let unsubscribe;
 
     const fakePlatform = {
@@ -19,14 +19,33 @@ describe("DiagnosticsBundle subscriber", function () {
         freeBytes: 1_073_741_824, // 1.0 GB
     };
 
+    const fakeLogs = [
+        { ts: 0, level: "info", facility: "sync", message: "Sync finished successfully" },
+    ];
+    const fakeDb = {
+        sample: [{ sampleId: 1, waterbodyName: "Yarra River" }],
+        taxa: [],
+        migrations: [{ latest: "202504280000000", model: "sample" }],
+    };
+    const fakePhotos = [
+        { name: "sitePhoto_42_123.jpg", sizeBytes: 12345 },
+        { name: "taxon_42_Bug_456.png", sizeBytes: 23456 },
+    ];
+
     function setup({ isSupported }) {
         createdDialog = null;
         createdAlert = null;
-        clipboardText = null;
+        writtenFiles = [];
         unsubscribe = DiagnosticsBundle.subscribe({
             platform: fakePlatform,
-            writeAttachment: (body) => ({ name: "waterbug-diagnostics.txt", body }),
-            setClipboardText: (text) => { clipboardText = text; },
+            readLogs: () => fakeLogs,
+            readDbTables: () => fakeDb,
+            readPhotoManifest: () => fakePhotos,
+            writeAttachment: (name, content) => {
+                const file = { name, content };
+                writtenFiles.push(file);
+                return file;
+            },
             createEmailDialog: (cfg) => {
                 createdDialog = {
                     cfg,
@@ -55,7 +74,7 @@ describe("DiagnosticsBundle subscriber", function () {
         unsubscribe = null;
     });
 
-    it("opens the email dialog with body, subject, recipient and attachment when Mail is supported", function () {
+    it("opens the email dialog with body + log + DB attachments when Mail is supported", function () {
         setup({ isSupported: true });
         Topics.fireTopicEvent(Topics.DIAGNOSTICS);
 
@@ -63,24 +82,33 @@ describe("DiagnosticsBundle subscriber", function () {
         expect(createdDialog.cfg.toRecipients).to.deep.equal(["waterbug-diagnostics@thecodesharman.com.au"]);
         expect(createdDialog.cfg.subject).to.contain("Waterbug diagnostics");
         expect(createdDialog.cfg.messageBody).to.contain("App version:");
-        expect(createdDialog.attachments).to.have.lengthOf(1);
-        expect(createdDialog.attachments[0].name).to.equal("waterbug-diagnostics.txt");
+        expect(createdDialog.attachments).to.have.lengthOf(5);
+        expect(createdDialog.attachments[0].name).to.equal("waterbug-log.txt");
+        expect(createdDialog.attachments[0].content).to.contain("Sync finished successfully");
+        expect(createdDialog.attachments[1].name).to.equal("sample.csv");
+        expect(createdDialog.attachments[1].content).to.contain("waterbodyName");
+        expect(createdDialog.attachments[1].content).to.contain("Yarra River");
+        expect(createdDialog.attachments[2].name).to.equal("taxa.csv");
+        expect(createdDialog.attachments[3].name).to.equal("migrations.csv");
+        expect(createdDialog.attachments[3].content).to.contain("latest,model");
+        expect(createdDialog.attachments[4].name).to.equal("photos.csv");
+        expect(createdDialog.attachments[4].content).to.contain("name,sizeBytes");
+        expect(createdDialog.attachments[4].content).to.contain("sitePhoto_42_123.jpg");
+        expect(createdDialog.attachments[4].content).to.contain("12345");
         expect(createdDialog.opened).to.be.true;
         expect(createdAlert).to.be.null;
     });
 
-    it("copies the body to the clipboard and shows a copied alert when Mail is not supported", function () {
+    it("shows an alert and does not open the dialog when Mail is not supported", function () {
         setup({ isSupported: false });
         Topics.fireTopicEvent(Topics.DIAGNOSTICS);
 
         expect(createdDialog).to.not.be.null;
         expect(createdDialog.opened).to.be.false;
         expect(createdDialog.attachments).to.have.lengthOf(0);
-        expect(clipboardText).to.contain("App version:");
-        expect(clipboardText).to.contain("Free disk:");
+        expect(writtenFiles).to.have.lengthOf(0);
         expect(createdAlert).to.not.be.null;
-        expect(createdAlert.cfg.title).to.equal("Diagnostics copied");
-        expect(createdAlert.cfg.message).to.equal("Diagnostics have been copied to the clipboard.");
+        expect(createdAlert.cfg.title).to.equal("Email not set up");
         expect(createdAlert.shown).to.be.true;
     });
 

--- a/walta-app/app/spec/DiagnosticsBundle_spec.js
+++ b/walta-app/app/spec/DiagnosticsBundle_spec.js
@@ -1,0 +1,91 @@
+require("spec/lib/ti-mocha");
+const { expect } = require("spec/lib/chai");
+const { isManualTests } = require("spec/util/TestUtils");
+const Topics = require("ui/Topics");
+const DiagnosticsBundle = require("util/DiagnosticsBundle");
+
+describe("DiagnosticsBundle subscriber", function () {
+    let createdDialog;
+    let createdAlert;
+    let clipboardText;
+    let unsubscribe;
+
+    const fakePlatform = {
+        appVersion: "9.9.9",
+        osname: "ios",
+        osVersion: "17.4",
+        model: "iPhone-test",
+        locale: "en-AU",
+        freeBytes: 1_073_741_824, // 1.0 GB
+    };
+
+    function setup({ isSupported }) {
+        createdDialog = null;
+        createdAlert = null;
+        clipboardText = null;
+        unsubscribe = DiagnosticsBundle.subscribe({
+            platform: fakePlatform,
+            writeAttachment: (body) => ({ name: "waterbug-diagnostics.txt", body }),
+            setClipboardText: (text) => { clipboardText = text; },
+            createEmailDialog: (cfg) => {
+                createdDialog = {
+                    cfg,
+                    attachments: [],
+                    opened: false,
+                    isSupported: function () { return isSupported; },
+                    addAttachment: function (file) { this.attachments.push(file); },
+                    addEventListener: function () {},
+                    open: function () { this.opened = true; },
+                };
+                return createdDialog;
+            },
+            createAlertDialog: (cfg) => {
+                createdAlert = {
+                    cfg,
+                    shown: false,
+                    show: function () { this.shown = true; },
+                };
+                return createdAlert;
+            },
+        });
+    }
+
+    afterEach(function () {
+        if (unsubscribe) unsubscribe();
+        unsubscribe = null;
+    });
+
+    it("opens the email dialog with body, subject, recipient and attachment when Mail is supported", function () {
+        setup({ isSupported: true });
+        Topics.fireTopicEvent(Topics.DIAGNOSTICS);
+
+        expect(createdDialog).to.not.be.null;
+        expect(createdDialog.cfg.toRecipients).to.deep.equal(["waterbug-diagnostics@thecodesharman.com.au"]);
+        expect(createdDialog.cfg.subject).to.contain("Waterbug diagnostics");
+        expect(createdDialog.cfg.messageBody).to.contain("App version:");
+        expect(createdDialog.attachments).to.have.lengthOf(1);
+        expect(createdDialog.attachments[0].name).to.equal("waterbug-diagnostics.txt");
+        expect(createdDialog.opened).to.be.true;
+        expect(createdAlert).to.be.null;
+    });
+
+    it("copies the body to the clipboard and shows a copied alert when Mail is not supported", function () {
+        setup({ isSupported: false });
+        Topics.fireTopicEvent(Topics.DIAGNOSTICS);
+
+        expect(createdDialog).to.not.be.null;
+        expect(createdDialog.opened).to.be.false;
+        expect(createdDialog.attachments).to.have.lengthOf(0);
+        expect(clipboardText).to.contain("App version:");
+        expect(clipboardText).to.contain("Free disk:");
+        expect(createdAlert).to.not.be.null;
+        expect(createdAlert.cfg.title).to.equal("Diagnostics copied");
+        expect(createdAlert.cfg.message).to.equal("Diagnostics have been copied to the clipboard.");
+        expect(createdAlert.shown).to.be.true;
+    });
+
+    it("[manual] opens the real Ti.UI.EmailDialog for visual inspection", function () {
+        if (!isManualTests()) { this.skip(); return; }
+        DiagnosticsBundle.openDiagnosticsEmail();
+    });
+});

--- a/walta-app/app/spec/index.js
+++ b/walta-app/app/spec/index.js
@@ -75,6 +75,7 @@ var SPEC_FILES = [
   "Main",
   "Navigation",
   "util/repository/LogRepository",
+  "DiagnosticsBundle",
   //"Database"  - needs to run last, migrations are run in all database using test anyway
 ];
 


### PR DESCRIPTION
## Summary

The Diagnostics button in SyncFeedback was firing `Topics.DIAGNOSTICS` into the void — no subscriber. This PR wires it to an `Ti.UI.EmailDialog` that ships a useful incident-triage payload:

**Body** leads with the CERDI user identity (email + ID via a new `CerdiApi.retrieveUsername()` accessor) so operators can attribute the report without cross-referencing. Plus the usual app version / OS / device / locale / free disk.

**Five attachments:**
- `waterbug-log.txt` — last 5 000 log entries, filtered to the **sync + network** facilities (drops UI/key/media chatter that isn't load-bearing for incident triage).
- `sample.csv` / `taxa.csv` / `migrations.csv` — RFC-4180 CSV per table so ops can open them directly in Numbers / Excel / Sheets and join by `sampleId`.
- `photos.csv` — filesystem walk of `applicationDataDirectory` filtered to JPEG/PNG, with `sizeBytes` per file.

Single email path (no clipboard fallback): log + DB files don't fit clipboard reliably, and Apple Mail config is acceptable once the operator has set it up. iOS users without Apple Mail will hit the "Email not set up" alert — addressed in a follow-up architectural ticket (potential AWS Lambda / API Gateway endpoint to replace email entirely).

## Two cross-platform bugs surfaced + fixed

- **`Ti.Filesystem.File.spaceAvailable` is a method in Titanium 13.x** (not the documented `Number` property). Reading as a property returned the function reference → NaN when divided. Now called as a method; the `isFinite` guard in `buildBody` stays as belt-and-braces.
- **Android `Intent.ACTION_SEND_MULTIPLE` silently drops 0-byte attachments.** `formatCsv` now emits a `(no rows)` sentinel for empty tables so `taxa.csv` / `photos.csv` still arrive when those sources are empty.

## Drive-by

`index-app.js` was reaching past CerdiApi's auth-storage encapsulation in `Logger.setUserId`. Same shape as the breach this PR introduces and fixes for the diagnostics body; cleaning both up together keeps the surface coherent.

## Test plan

- [x] `npx grunt unit-test-node` — green (167 passing, includes new `formatLogEntries` / `formatCsv` / `filterLogsByFacility` / `buildBody` edge cases)
- [x] `npx grunt --platform=ios --simulator --liveview --reuse-server --grep=DiagnosticsBundle unit-test` — green
- [x] **iOS device (iPhone)** — Apple Mail composer with body + 5 attachments
- [x] **Android device** — Gmail composer (via Intent chooser) with body + 5 attachments
- [ ] Acceptance suite (full cucumber regression — runs in CI)

## Follow-ups (separate cards, to be filed)

- iOS native module for share-sheet via `UIActivityViewController` — eliminates the Apple-Mail dependency on iOS, letting Gmail / Outlook / Drive / etc. handle the attachment too.
- POST-to-CERDI or AWS-Lambda diagnostics endpoint — eliminates client-side email plumbing entirely, queryable triage backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)