### PR TITLE
ci(release): flip workflow default environment from production to test

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -22,7 +22,7 @@ Local builds for testing on a device or simulator are fine. *Release builds* —
 
 ## Trigger the workflow
 
-**Default to `environment=test`.** Always pass `-f environment=test` unless the user has *explicitly* asked for a production release ("ship to prod", "production release", "real users", or similar). The workflow's own default is `production` for historical reasons; do not rely on it. A wrong-environment release wastes a build number, surprises the tester pool, and (production → real CERDI) can pollute live data.
+**Default to `environment=test`.** Always pass `-f environment=test` unless the user has *explicitly* asked for a production release ("ship to prod", "production release", "real users", or similar). The workflow's own default is also `test` (defence in depth), but pass it explicitly anyway — it makes the intent unambiguous in the workflow-run log. A wrong-environment release wastes a build number, surprises the tester pool, and (production → real CERDI) can pollute live data.
 
 ```bash
 # Default — test environment, both platforms, auto-incremented version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,15 +6,15 @@ on:
       environment:
         description: >
           Build environment.
-          'production' = real CERDI API + clean tag (v2.1.0.4).
           'test' = sandbox CERDI API + version suffix (-test) in TestFlight /
-          Play Console + tag (v2.1.0.4-test). Default is production —
-          accidental triggers are safe.
+          Play Console + tag (v2.1.0.4-test).
+          'production' = real CERDI API + clean tag (v2.1.0.4) — must be
+          explicitly selected to avoid accidental prod releases.
         type: choice
         options:
-          - production
           - test
-        default: production
+          - production
+        default: test
       version:
         description: >
           Version (e.g. 2.0.5.1). Leave empty to auto-increment the build


### PR DESCRIPTION
## Summary

- Flips the release workflow's `environment` input default from `production` → `test`, and reorders options so `test` is the first dropdown item. Belt-and-braces against accidental prod releases — the skill is already configured to always pass `-f environment=test` explicitly, but the YAML default catches anything that bypasses the skill (e.g. a UI-triggered run from the Actions tab, a future caller that forgets the flag).
- Updates the input description and the release skill text to match. The skill still mandates passing the flag explicitly for clarity in workflow-run logs; the YAML default is now the safety net rather than the contract.

Side-quest split out of WB-85 (so that PR stays focused). Motivated by the 2026-05-15 incident captured in [1a39af6e](https://github.com/TheWaterBugCompany/WALTA/commit/1a39af6e) — that commit fixed the *skill* to default to test; this commit fixes the *workflow* the same way.

## Test plan

- [x] N/A — config-only change, no code paths affected
- [ ] Manual: after merge, trigger a release from the Actions tab UI without selecting an environment → confirm the run goes through the test path (sandbox CERDI, `-test` tag suffix, TestFlight beta lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)