### PR TITLE
WB-87: bump form-login step timeout to 5min for cold-start CI runners

### DIFF
--- a/features/step_definitions/registration.js
+++ b/features/step_definitions/registration.js
@@ -71,7 +71,13 @@ Then('I am logged in', {timeout: 60000}, async function() {
     await this.menu.waitForLabel("You are Logged in");
 });
 
-When('I log in with {string} and password {string}', {timeout: 60000}, async function(emailAddress, password) {
+// 5-min step timeout: form-fill (~3-5s) + LoginScreen.dismissSavePasswordSheet's
+// own 60s wait for the iOS Save Password sheet sum to more than the previous
+// 60s cucumber budget on cold-start CI runners. With both clocks set to 60s,
+// the step kept self-killing before the dismiss could actually see + tap
+// "Not Now". Locally on a warm sim the sheet pops in a few seconds and 60s
+// was enough; on shared macOS-15 runners it isn't.
+When('I log in with {string} and password {string}', {timeout: 300000}, async function(emailAddress, password) {
     await this.menu.waitFor();
     await this.menu.login(emailAddress, password);
 });


### PR DESCRIPTION
## Summary

Follow-up to [#253](https://github.com/TheWaterBugCompany/WALTA/pull/253). On the WB-87 branch's CI run, attempt 1 was failing — the form-login `When I log in with {string} and password {string}` step timed out at 60s, then 3 subsequent deeplink-login scenarios cascaded because Save Password leaked from the unfinished form-login dismiss. Attempt 2 saved it (warm sim), but relying on retry isn't ideal.

Root cause: the cucumber step timeout was `{timeout: 60000}` (60s) and inside it `LoginScreen.dismissSavePasswordSheet()` also waits up to 60s for the iOS "Not Now" button. On cold-start macOS-15 CI runners, form-fill (~3-5s) plus dismiss-wait (up to 60s) exceeds the step's 60s budget; the step kills itself before the dismiss can see and click the button.

Bumping the step timeout to 300s gives the existing 60s dismiss its full budget plus generous slack for form-fill + animation. No change to [login-screen.js](features/support/login-screen.js) — the dismiss is fine, it just needed room to actually run.

Cherry-pick of `1b6e5c59` from `task/wb-87-savepassword-retry` (pushed after #253 auto-merged, so it didn't make the original PR).

## Test plan

- [x] Cherry-picked cleanly onto current `main`.
- [ ] CI iOS acceptance passes on **attempt 1** (no retry warning).
- [ ] CI Android acceptance still green.
- [ ] Full Node unit + build + sim checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)