### PR TITLE
WB-94: CI acceptance smart retry — distinguish infra failure from test failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -696,18 +696,24 @@ jobs:
       - name: Run iOS acceptance tests
         env:
           SIM_UDID: ${{ steps.sim.outputs.udid }}
-        # Retry once (WB-54). Cucumber suite takes ~15 min so a retry
-        # roughly doubles the cost on a deterministic failure — but
-        # acceptance flakes are common enough on macOS-15 runners that
-        # the trade-off favours green over fast-fail.
+        # WB-94: smart retry. The CucumberLauncher returns 75 (EX_TEMPFAIL
+        # from BSD sysexits.h) when cucumber-js exited non-zero without
+        # ever reaching scenario execution — Appium connect refused,
+        # BeforeAll crash, sim/WDA not ready, etc. — meaning the
+        # infrastructure was the problem and the run is retry-eligible.
+        # A real test failure surfaces as cucumber-js's own exit code
+        # (1, 2, ...) and is NOT retried — doubling the cost on a
+        # deterministic test failure was the cost we paid under the
+        # previous WB-54 retry-on-anything loop.
         run: |
           for attempt in 1 2; do
-            if npx grunt --platform=ios --simulator --skip-build acceptance-test; then
-              exit 0
-            fi
-            echo "::warning ::iOS acceptance attempt $attempt failed; retrying once (WB-54)"
+            npx grunt --platform=ios --simulator --skip-build acceptance-test
+            rc=$?
+            [ $rc -eq 0 ] && exit 0
+            [ $rc -ne 75 ] && exit $rc
+            echo "::warning ::iOS acceptance attempt $attempt returned EX_TEMPFAIL (75); retrying once (WB-94)"
           done
-          exit 1
+          exit 75
 
       - name: Upload per-scenario failure artifacts
         if: failure()

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -595,9 +595,14 @@ const KobitonAPI = require("./features/support/kobiton");
         .then(({ default: CucumberLauncher }) => new CucumberLauncher({ tags, name, appiumOptions }).run())
         .then((code) => {
           if (code !== 0) {
+            // WB-94: propagate the launcher's specific exit code so the
+            // CI shell can distinguish a real test failure (cucumber-js's
+            // own 1/2 codes) from an infrastructure failure that never
+            // reached tests (EX_TEMPFAIL = 75). `done(false)` would
+            // collapse everything to grunt's generic non-zero, losing
+            // the signal CI needs to decide whether to retry.
             grunt.log.error(`cucumber-js exited with code ${code}`);
-            done(false);
-            return;
+            process.exit(code);
           }
           done();
         })

--- a/build-tests/unit/CucumberLauncher_spec.js
+++ b/build-tests/unit/CucumberLauncher_spec.js
@@ -4,7 +4,19 @@ import { EventEmitter } from "events";
 import CucumberLauncher from "../../build-utils/CucumberLauncher.js";
 
 function makeFakeChild() {
-  return Object.assign(new EventEmitter(), { unref: sinon.stub() });
+  const child = Object.assign(new EventEmitter(), { unref: sinon.stub() });
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  return child;
+}
+
+// Trigger the lifecycle the launcher's stdout-watcher expects:
+// emit some stdout chunks, then exit. Used to simulate cucumber-js
+// runs that did/didn't reach the "N scenarios (...)" summary.
+function emitThenExit(child, { stdoutChunks = [], stderrChunks = [], code = 0 } = {}) {
+  for (const chunk of stdoutChunks) child.stdout.emit("data", Buffer.from(chunk));
+  for (const chunk of stderrChunks) child.stderr.emit("data", Buffer.from(chunk));
+  child.emit("exit", code);
 }
 
 // Helper: wait for the spawn stub to be called, then emit exit on the
@@ -167,8 +179,83 @@ describe("CucumberLauncher", function() {
         isAppiumRunning: fakeIsRunning,
       });
       const promise = launcher.run();
-      await exitAfterSpawn(fakeSpawn, 0, 1);
+      // Include the scenarios-summary marker so "tests-ran-and-failed" is
+      // distinguished from "tests-never-started" (covered below).
+      const wait = exitAfterSpawnEmit(fakeSpawn, 0, {
+        stdoutChunks: ["7 scenarios (5 failed, 2 passed)\n"],
+        code: 1,
+      });
+      await wait;
       expect(await promise).to.equal(1);
+    });
+
+    // WB-94: distinguish startup-infra failure from real test failure so
+    // CI can retry the former but not the latter. Marker = the
+    // "N scenarios (...)" summary cucumber-js prints once it has run at
+    // least one scenario through to its end-of-run summary. If cucumber-js
+    // exits non-zero *without* ever printing that summary, it never
+    // reached scenarios (Appium connect refused, BeforeAll crash, etc.) —
+    // a transient infrastructure problem — and we surface `75` (BSD
+    // sysexits.h `EX_TEMPFAIL`) so the CI shell knows it's retry-eligible.
+    it("resolves with EX_TEMPFAIL (75) when cucumber-js exits non-zero without the scenarios-summary marker", async function() {
+      const launcher = new CucumberLauncher({
+        spawn: fakeSpawn,
+        isAppiumRunning: fakeIsRunning,
+      });
+      const promise = launcher.run();
+      const wait = exitAfterSpawnEmit(fakeSpawn, 0, {
+        stderrChunks: ["Error: connect ECONNREFUSED 127.0.0.1:4723\n"],
+        code: 1,
+      });
+      await wait;
+      expect(await promise).to.equal(75);
+    });
+
+    it("propagates cucumber-js's exit code unchanged when the scenarios-summary marker is present", async function() {
+      const launcher = new CucumberLauncher({
+        spawn: fakeSpawn,
+        isAppiumRunning: fakeIsRunning,
+      });
+      const promise = launcher.run();
+      // Cucumber-js exit 2 is config error — but if it emitted the
+      // summary line, scenarios ran. Don't rewrite to EX_TEMPFAIL.
+      const wait = exitAfterSpawnEmit(fakeSpawn, 0, {
+        stdoutChunks: ["1 scenario (1 failed)\n"],
+        code: 2,
+      });
+      await wait;
+      expect(await promise).to.equal(2);
+    });
+
+    it("resolves with 0 (not 75) when cucumber-js succeeds even if no summary was captured", async function() {
+      // Defensive: success is success; the EX_TEMPFAIL rewrite only
+      // applies when the exit code was already non-zero.
+      const launcher = new CucumberLauncher({
+        spawn: fakeSpawn,
+        isAppiumRunning: fakeIsRunning,
+      });
+      const promise = launcher.run();
+      const wait = exitAfterSpawnEmit(fakeSpawn, 0, { code: 0 });
+      await wait;
+      expect(await promise).to.equal(0);
     });
   });
 });
+
+// Helper: wait for the spawn at childIndex, emit any stdout/stderr chunks,
+// then exit with the given code. Generalises exitAfterSpawn for tests that
+// need to assert behaviour against specific output content.
+function exitAfterSpawnEmit(spawnStub, childIndex, opts) {
+  return new Promise(resolve => {
+    const check = () => {
+      if (spawnStub.callCount > childIndex) {
+        const child = spawnStub.getCall(childIndex).returnValue;
+        emitThenExit(child, opts);
+        resolve();
+      } else {
+        setTimeout(check, 5);
+      }
+    };
+    check();
+  });
+}

--- a/build-utils/CucumberLauncher.js
+++ b/build-utils/CucumberLauncher.js
@@ -1,6 +1,20 @@
 import { spawn as defaultSpawn } from "child_process";
 import { isAppiumRunning as defaultIsAppiumRunning } from "./AppiumLauncher.js";
 
+// BSD sysexits.h — "temporary failure, indicating something that is not
+// really an error... the request should be reattempted later." Used to
+// signal CI that this run never reached test execution (Appium connect
+// refused, BeforeAll crash, sim/WDA not ready, etc.) and is retry-eligible,
+// distinct from a real test or config failure.
+const EX_TEMPFAIL = 75;
+
+// Cucumber-js prints a summary line like "1 scenario (1 passed)" or
+// "7 scenarios (5 failed, 2 passed)" once at least one scenario has
+// completed (formatter-independent — appears in both progress and pretty
+// output). If cucumber-js exits without ever emitting this line, no
+// scenarios ran.
+const SCENARIOS_SUMMARY = /\d+ scenarios? \(/;
+
 class CucumberLauncher {
   constructor({
     tags = "not @skip", name = null, appiumOptions = {}, spawn = defaultSpawn,
@@ -52,7 +66,10 @@ class CucumberLauncher {
           "--force-exit",
         ],
         {
-          stdio: "inherit",
+          // Piped (not 'inherit') so we can watch stdout/stderr for the
+          // scenarios-summary marker. Output is still streamed live to
+          // the parent below — no log capture, just a tee with a regex test.
+          stdio: ['ignore', 'pipe', 'pipe'],
           env: {
             ...process.env,
             PATH: `./node_modules/.bin/:${process.env.PATH}`,
@@ -60,7 +77,29 @@ class CucumberLauncher {
           },
         }
       );
-      child.on("exit", (code) => resolve(code));
+
+      let sawSummary = false;
+      const watch = (source, sink) => {
+        source.on('data', (chunk) => {
+          sink.write(chunk);
+          if (!sawSummary && SCENARIOS_SUMMARY.test(chunk.toString())) {
+            sawSummary = true;
+          }
+        });
+      };
+      watch(child.stdout, process.stdout);
+      watch(child.stderr, process.stderr);
+
+      child.on("exit", (exitCode) => {
+        if (exitCode !== 0 && !sawSummary) {
+          // Non-zero exit before any scenario completed — infrastructure
+          // problem, not a test failure. Surface as EX_TEMPFAIL so the
+          // CI shell can retry exactly this kind of failure.
+          resolve(EX_TEMPFAIL);
+          return;
+        }
+        resolve(exitCode);
+      });
     });
 
     this._stopServer();


### PR DESCRIPTION
## Summary

Implements [Trello WB-94](https://trello.com/c/tJYgPoZ9/94-ci-iOS-acceptance-detect-hung-startup-via-log-line-probe-not-blunt-timeout). Replaces the blunt \"retry on any non-zero exit\" loop (WB-54) with a launcher-level decision so CI only retries when the failure is actually retry-eligible.

### The problem

Today's iOS acceptance retry re-runs the whole ~15-min suite on any non-zero exit from grunt. That doubles the CI cost even on deterministic test failures, hiding real signal in noise. The retry's actual purpose was always to recover from transient infrastructure failures — Appium connect refused, BeforeAll crash, sim/WDA not ready — not test failures.

### The change

Push the \"test ran vs didn't run\" decision into the layer that knows: `CucumberLauncher`. Use the standard Unix convention for retry-eligible failures — `EX_TEMPFAIL` (75) from BSD `sysexits.h`, defined as *\"temporary failure ... the request should be reattempted later\"*.

1. **[build-utils/CucumberLauncher.js](build-utils/CucumberLauncher.js)** — switch cucumber-js spawn stdio from `\"inherit\"` to piped, tee both streams live to the parent (no log capture), and watch for the `N scenarios (...)` summary line cucumber-js prints once at least one scenario completed. If cucumber-js exits non-zero **without** the marker, return `75`. Otherwise propagate the actual exit code.
2. **[Gruntfile.js](Gruntfile.js)** — cucumber task uses `process.exit(code)` instead of `done(false)` so the launcher's specific code reaches the shell.
3. **[.github/workflows/ci.yml](.github/workflows/ci.yml)** — iOS acceptance step retries **only** when `rc === 75`. Cucumber's own 1 / 2 codes (test failure, config error) exit immediately.

### Tests

[`build-tests/unit/CucumberLauncher_spec.js`](build-tests/unit/CucumberLauncher_spec.js) — four new cases:
- Returns `75` when cucumber-js exits non-zero without the summary marker.
- Propagates the actual exit code (1, 2, ...) when the summary marker is present.
- Returns `0` on success even if no summary was captured (defensive).
- Existing \"resolves with non-zero exit code when cucumber-js fails\" updated to include the summary marker (the previous assertion was passing only because the rewrite didn't exist yet).

### Caveat / out of scope

This only catches failures that propagate up through cucumber-js's exit. If grunt or npx **itself** deadlocks before reaching the launcher (the WB-94 card's \"32m of zero output\" worst case), no launcher logic can help — that needs a CI-shell-level hard timeout. Filed as a separate concern; not blocking this change.

## Test plan

- [x] \`npx grunt build-test\` — 161 passing locally.
- [ ] CI green on all 8 jobs.
- [ ] Manual verification of EX_TEMPFAIL path on a real CI failure (will happen organically when something flakes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)