### PR TITLE
WB-88: Inconsistent Sync — heal stale-container photo paths

### DIFF
--- a/docs/patterns/photo-paths.md
+++ b/docs/patterns/photo-paths.md
@@ -1,6 +1,15 @@
 # Photo paths
 
-- **User-taken photos** live in `Ti.Filesystem.applicationDataDirectory` and are stored as **relative paths** (no leading `/`).
+- **User-taken & downloaded photos** (site photos, creature/taxon photos) live in `Ti.Filesystem.applicationDataDirectory` and are stored as **relative names** (no leading `/`), e.g. `taxon_12_171_1758403516.jpg`.
 - **Taxonomy reference images** live in `Ti.Filesystem.resourcesDirectory` and are stored as **absolute paths** (leading `/`).
 
-`PhotoUtils.absolutePath()` handles both conventions — call it whenever you need the resolved filesystem path for either kind.
+`PhotoUtils.absolutePath()` resolves both conventions — call it whenever you need the resolved filesystem path, and never assign a stored path straight to `ImageView.image`.
+
+## Never store an absolute container path (WB-88)
+
+On iOS the app's data-container path includes a UUID (`…/Application/<UUID>/Documents/`) that **changes across app updates/reinstalls**. A stored absolute `file:///…/<UUID>/…` path therefore goes stale — the file still exists, but under a *different* container, so the old path resolves to nothing and the image renders blank.
+
+Two safeguards keep this from biting:
+
+1. **Write relative.** `taxa.setPhoto` / `sample.setSitePhoto` persist the bare filename, not `nativePath`.
+2. **Heal on read.** `absolutePath()` collapses any `file:///…` value to its basename and re-resolves it against the *current* `applicationDataDirectory`, so legacy rows that already hold a stale absolute path self-heal the next time they're read. The pure decision lives in `resolvePhotoLocation()` (unit-tested in `test/util/PhotoUtils_spec.js`).

--- a/test/util/PhotoUtils_spec.js
+++ b/test/util/PhotoUtils_spec.js
@@ -1,0 +1,47 @@
+require("mocha");
+const { expect } = require("chai");
+
+// see docs/patterns/photo-paths.md
+describe("PhotoUtils.absolutePath", function () {
+    let PhotoUtils;
+
+    beforeEach(function () {
+        // Minimal Ti.Filesystem fake. getFile mimics Titanium's join of a base
+        // directory + a relative segment so we can assert on the resolved
+        // nativePath an outside caller would actually open.
+        global.Ti = {
+            Filesystem: {
+                applicationDataDirectory: "file:///CURRENT/Documents/",
+                resourcesDirectory: "file:///APP/",
+                getFile(...parts) {
+                    const joined = parts.length === 1
+                        ? parts[0]
+                        : parts[0].replace(/\/?$/, "/") + parts[1].replace(/^\//, "");
+                    return { nativePath: joined };
+                },
+            },
+        };
+        delete require.cache[require.resolve("../../walta-app/app/lib/util/PhotoUtils")];
+        PhotoUtils = require("../../walta-app/app/lib/util/PhotoUtils");
+    });
+
+    afterEach(function () {
+        delete global.Ti;
+    });
+
+    it("heals a stale-container absolute path by resolving its basename under the current data directory", function () {
+        const stale = "file:///var/mobile/Containers/Data/Application/A9DE96B2-CF38-43A8-B4B6-8004E476D1D7/Documents/taxon_11_72_1758403455.jpg";
+        expect(PhotoUtils.absolutePath(stale).nativePath)
+            .to.equal("file:///CURRENT/Documents/taxon_11_72_1758403455.jpg");
+    });
+
+    it("resolves a relative photo name under the current data directory", function () {
+        expect(PhotoUtils.absolutePath("taxon_11_72_1758403455.jpg").nativePath)
+            .to.equal("file:///CURRENT/Documents/taxon_11_72_1758403455.jpg");
+    });
+
+    it("resolves a taxonomy reference image under the resources directory", function () {
+        expect(PhotoUtils.absolutePath("/images/silhouette.png").nativePath)
+            .to.equal("file:///APP/images/silhouette.png");
+    });
+});

--- a/walta-app/app/controllers/PhotoSelect.js
+++ b/walta-app/app/controllers/PhotoSelect.js
@@ -4,7 +4,7 @@ var debug = (m, tag = "media") => Logger.debug(m, tag);
 var error = (m, tag = "media") => Logger.error(m, tag);
 var moment = require('lib/moment');
 var { removeFilesBeginningWith } = require('logic/FileUtils');
-var { optimisePhoto, savePhoto, loadPhoto } = require('util/PhotoUtils');
+var { optimisePhoto, savePhoto, loadPhoto, absolutePath } = require('util/PhotoUtils');
 var Topics = require("ui/Topics");
 
 var readOnlyMode = false;
@@ -151,8 +151,12 @@ function setImage( fileOrBlob ) {
             $.photoUrls = [photo];
         } else {
             debug(`not calling generateThumbnail fileOrBlob = ${fileOrBlob}`)
-            $.photo.image = fileOrBlob;
-            $.photoUrls = [fileOrBlob];
+            // Resolve to the current container's absolute path: stored paths may
+            // be relative names or legacy absolute paths with a stale container
+            // UUID, neither of which ImageView.image can load directly (WB-88).
+            var resolved = absolutePath(fileOrBlob).nativePath;
+            $.photo.image = resolved;
+            $.photoUrls = [resolved];
         }
         
     }

--- a/walta-app/app/lib/util/PhotoUtils.js
+++ b/walta-app/app/lib/util/PhotoUtils.js
@@ -1,17 +1,29 @@
 var Logger = require('util/Logger');
 var info = (m, tag = "media") => Logger.debug(m, tag);
 var log = (m, tag = "media") => Logger.log(m, tag);
-function absolutePath(path) {
+// Pure decision: which base directory a stored photo path belongs to, and the
+// segment to join onto it. Kept Ti-free so it's unit-testable.
+//
+// `file:///` values are legacy absolute paths that embed the iOS data-container
+// UUID, which changes across app updates/reinstalls — so the stored prefix can
+// point at a dead container. We collapse them to their basename and re-resolve
+// against the *current* data directory, healing stale rows on read (WB-88).
+function resolvePhotoLocation(path) {
     if ( path.startsWith("file:///") ) {
-        //info(`${path} starts with file:///`);
-        return Ti.Filesystem.getFile(path);
+        return { dir: "data", name: path.slice(path.lastIndexOf("/") + 1) };
     } else if ( path.startsWith("/") ) {
-        //info(`${path} starts with /`)
-        return Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory,path);
+        return { dir: "resources", name: path };
     } else {
-       // info(`${path} doesn't start with /`)
-        return Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, path);
+        return { dir: "data", name: path };
     }
+}
+
+function absolutePath(path) {
+    const { dir, name } = resolvePhotoLocation(path);
+    const baseDir = dir === "resources"
+        ? Ti.Filesystem.resourcesDirectory
+        : Ti.Filesystem.applicationDataDirectory;
+    return Ti.Filesystem.getFile(baseDir, name);
 }
 
 function loadPhoto(path) {
@@ -91,6 +103,7 @@ function optimisePhoto( fullPhoto ) {
     return fullPhoto;
 }
 
+exports.absolutePath = absolutePath;
 exports.optimisePhoto = optimisePhoto;
 exports.savePhoto = savePhoto;
 exports.loadPhoto = loadPhoto;

--- a/walta-app/app/models/sample.js
+++ b/walta-app/app/models/sample.js
@@ -119,7 +119,9 @@ exports.definition = {
 				removeFilesBeginningWith(`sitePhoto_${this.get("sampleId")}_`);
 				var sitePhotoPath = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, newPhotoName);
 				Ti.Filesystem.getFile(...file).move(sitePhotoPath.nativePath);
-				this.set( "sitePhotoPath", sitePhotoPath.nativePath );
+				// Store the relative name, not the absolute nativePath (see WB-88
+				// / taxa.setPhoto): absolute container paths go stale on update.
+				this.set( "sitePhotoPath", newPhotoName );
 				this.set( "serverSitePhotoId", null); // indicates this photo hasn't been uploaded yet
 			},
 

--- a/walta-app/app/models/taxa.js
+++ b/walta-app/app/models/taxa.js
@@ -84,8 +84,11 @@ exports.definition = {
 				log(`updating photo from ${file} to ${newPhotoName}`);
 				var taxonPhotoPath = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, newPhotoName);
 				photoFile.move(taxonPhotoPath.nativePath);
-				this.set( "taxonPhotoPath", taxonPhotoPath.nativePath );
-				return this.get("taxonPhotoPath");	
+				// Store the relative name, not the absolute nativePath: the iOS
+				// data-container UUID changes across updates, so an absolute path
+				// goes stale (WB-88). PhotoUtils.absolutePath resolves the name.
+				this.set( "taxonPhotoPath", newPhotoName );
+				return this.get("taxonPhotoPath");
 			},
 
 			getPhoto() {

--- a/walta-app/app/spec/PhotoPaths_spec.js
+++ b/walta-app/app/spec/PhotoPaths_spec.js
@@ -1,0 +1,40 @@
+require("spec/lib/ti-mocha");
+var { expect } = require("spec/lib/chai");
+var { makeTestPhoto, clearDatabase } = require("spec/util/TestUtils");
+var PhotoUtils = require("util/PhotoUtils");
+
+// Regression guard for WB-88: photos stored an absolute path embedding the iOS
+// data-container UUID, which changes across app updates — so the stored path
+// went stale and the image rendered blank even though the file survived under
+// the new container. Exercised against the real taxa model + Ti.Filesystem.
+describe("Photo path healing (WB-88)", function () {
+    beforeEach(function () {
+        clearDatabase();
+    });
+
+    function makeTaxonWithPhoto() {
+        var taxon = Alloy.createModel("taxa");
+        taxon.set("sampleId", 666);
+        taxon.set("taxonId", 1);
+        taxon.setPhoto(makeTestPhoto("wb88_source.jpg"));
+        return taxon;
+    }
+
+    it("stores a creature photo as a relative name, not an absolute container path", function () {
+        var stored = makeTaxonWithPhoto().getPhoto();
+        expect(stored).to.match(/^taxon_666_1_\d+\.jpg$/);
+        expect(stored).to.not.contain("file://");
+    });
+
+    it("resolves a creature photo whose stored path has a stale container UUID", function () {
+        var name = makeTaxonWithPhoto().getPhoto();
+        // Simulate a legacy row written under a now-dead container.
+        var stalePath = `file:///var/mobile/Containers/Data/Application/`
+            + `DEADBEEF-0000-0000-0000-000000000000/Documents/${name}`;
+
+        var resolved = PhotoUtils.absolutePath(stalePath);
+
+        expect(resolved.exists(), "healed file should exist under current container").to.be.true;
+        expect(resolved.read(), "healed file should be readable").to.be.ok;
+    });
+});

--- a/walta-app/app/spec/SampleSync_spec.js
+++ b/walta-app/app/spec/SampleSync_spec.js
@@ -654,10 +654,11 @@ describe("SampleSync", function () {
             sample.loadByServerId(473);
             // checking the site photo id proves the code was run
             expect(sample.get("serverSitePhotoId")).to.equal(1948);
-            // check the photo path contans the correct photo - we compare file sizes 
-            let sampleSitePhoto = Ti.Filesystem.getFile(sample.getSitePhoto());
+            // resolve the stored path the same way production does (loadPhoto →
+            // absolutePath) and compare content; getSitePhoto now returns a
+            // relative name, not an absolute path.
             let siteMockBlob = siteMock.read();
-            let photoBlob = sampleSitePhoto.read();
+            let photoBlob = loadPhoto(sample.getSitePhoto());
             expect(siteMockBlob.length).to.equal(photoBlob.length);
 
         });
@@ -744,9 +745,8 @@ describe("SampleSync", function () {
             function verifyTaxon(i) {
                 let taxon = taxa.at(i);
                 expect(taxon.get("serverCreaturePhotoId")).to.equal(creatureMocks[i].id);
-                let creaturePhoto = Ti.Filesystem.getFile(taxon.getPhoto());
                 let expectedBlob = creatureMocks[i].photo.read();
-                let actualBlob = creaturePhoto.read();
+                let actualBlob = loadPhoto(taxon.getPhoto());
                 expect(expectedBlob.length).to.equal(actualBlob.length);
             }
             // checking the site photo id proves the code was run

--- a/walta-app/app/spec/index.js
+++ b/walta-app/app/spec/index.js
@@ -67,6 +67,7 @@ var SPEC_FILES = [
   "SampleHistory",
   "Gallery",
   "PhotoSelect",
+  "PhotoPaths",
   "EditTaxon",
   "NavButton",
   "GoBackButton",


### PR DESCRIPTION
## Summary
- **Root cause:** creature/site photos render blank on iOS after an app update because the DB stored absolute paths embedding the iOS data-container UUID (`…/Application/<UUID>/Documents/…`). That UUID changes across updates/reinstalls, so the file survives under a new container but the stored path resolves to nothing. A mix of old/new UUIDs across rows is exactly why *some* photos show and some don't — the "Inconsistent Sync" symptom.
- **Heal on read:** `PhotoUtils.absolutePath()` now collapses any `file:///…` value to its basename and re-resolves against the current `applicationDataDirectory`, so legacy rows self-heal the next time they're read. Pure decision extracted to `resolvePhotoLocation()` and unit-tested.
- **Write relative:** `taxa.setPhoto` / `sample.setSitePhoto` persist the relative name, not the absolute `nativePath`.
- **Display resolve:** `PhotoSelect.setImage` resolves the stored path before assigning to `ImageView.image` (the SiteDetails display path passed it raw).
- Updated [docs/patterns/photo-paths.md](docs/patterns/photo-paths.md).

Addresses [Trello WB-88](https://trello.com/c/2RZVGoQq/88-inconsistent-sync) — and the underlying real-device bug behind WB-89 (the merged #256 guardrail test couldn't reproduce it on the sim because the container never changes mid-session).

**Evidence:** an on-device diagnostics DB dump showed two distinct container UUIDs across rows while every referenced file was present in the *current* container's Documents — confirming the files exist and only the stored path prefix is stale.

## Test plan
- [x] `npx grunt unit-test-node` — passes (incl. new `test/util/PhotoUtils_spec.js`)
- [ ] CI green (iOS + Android)
- [ ] On-device verification: install over a prior build (or change container), open a synced sample, confirm previously-blank creature/site photos now render

🤖 Generated with [Claude Code](https://claude.com/claude-code)