### PR TITLE
WB-97: poll for sample-tray tiles instead of single-shot isDisplayed

### DIFF
--- a/features/step_definitions/sample_a_site_steps.js
+++ b/features/step_definitions/sample_a_site_steps.js
@@ -56,9 +56,10 @@ Then('the sample tray is filled with each identification', async function () {
             ? `-ios predicate string:label CONTAINS '${expected}'`
             : `android=new UiSelector().descriptionContains("${expected}")`;
         var el = await this.driver.$(selector);
-        if (!(await el.isDisplayed())) {
-            throw new Error(`Sample tray is missing tile for "${expected}"`);
-        }
+        await el.waitForDisplayed({
+            timeout: 10000,
+            timeoutMsg: `Sample tray is missing tile for "${expected}"`,
+        });
     }
 });
 

--- a/features/step_definitions/view_samples_steps.js
+++ b/features/step_definitions/view_samples_steps.js
@@ -26,9 +26,10 @@ Then('I can see each creature with its abundance', async function () {
             ? `-ios predicate string:label BEGINSWITH '${fragment}'`
             : `android=new UiSelector().descriptionStartsWith("${fragment}")`;
         const el = await this.driver.$(selector);
-        if (!(await el.isDisplayed())) {
-            throw new Error(`Sample tray is missing tile starting with "${fragment}"`);
-        }
+        await el.waitForDisplayed({
+            timeout: 10000,
+            timeoutMsg: `Sample tray is missing tile starting with "${fragment}"`,
+        });
     }
 });
 


### PR DESCRIPTION
## Summary
- The two cucumber probes that asserted sample-tray tile visibility with a single-shot `await el.isDisplayed()`-then-throw raced the iOS-simulator screen transition — the element wasn't rendered yet at probe time, so the step threw even though the UI was correct ms later. This is what flaked the `Creature photos remain visible after sync` scenario on WB-88 PR #261 ([run 26147515221](https://github.com/TheWaterBugCompany/WALTA/actions/runs/26147515221)) while Android passed the same shared scenario.
- Both probes ([view_samples_steps.js](features/step_definitions/view_samples_steps.js) and [sample_a_site_steps.js](features/step_definitions/sample_a_site_steps.js)) now use `waitForDisplayed({ timeout: 10000, timeoutMsg })`, matching the existing convention in [base-screen.js](features/support/base-screen.js) / [summary-screen.js](features/support/summary-screen.js). The `timeoutMsg` preserves the original clear failure message.
- Audited `features/step_definitions/` — these were the only two single-shot `isDisplayed()`-then-throw probes; none remain.

Fixes [Trello WB-97](https://trello.com/c/4RMSU9PV/97-acceptance-steps-probe-elements-with-single-shot-isdisplayed-flaky-on-ios-sim-use-waitfor-polling). Cucumber-layer analogue of the unit-spec rule "no hardcoded delays — poll for the actual state".

## Test plan
- [x] iOS acceptance CI green (the flaky scenario passes consistently)
- [x] Android acceptance CI green (no regression to the shared scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)