### PR TITLE
WB-101: retry photo downloads that failed on an earlier sync

### DIFF
--- a/walta-app/app/lib/logic/SampleDownloader.js
+++ b/walta-app/app/lib/logic/SampleDownloader.js
@@ -83,29 +83,34 @@ function createSampleDownloader(delay) {
                 function retrieveUnknownCreatures() {
                     return delayedPromise( Promise.resolve().then( () => Alloy.Globals.CerdiApi.retrieveUnknownCreatures(serverSample.id) ), delay )
                 }
-                return sample.loadByServerId(serverSample.id) 
+                return sample.loadByServerId(serverSample.id)
                     .then( () => {
                         if ( needsUpdate(serverSample,sample) ) {
                             info(`Updating serverSampleId = ${serverSample.id}`);
-                            // must set the serverSyncTime here so that if updatedAt
-                            // is set to be a few milliseconds later - this can happen if
-                            // habitat blanks are filled in, and we need to signal a re-upload.
+                            // serverSyncTime is set right after persistSample so that an
+                            // updatedAt bumped a few ms later (e.g. habitat blanks being
+                            // filled in) lands after it and signals a re-upload.
                             return Promise.resolve()
                                 .then( retrieveUnknownCreatures )
                                 .then( processUnknownCreatures )
                                 .then( persistSample )
-                                .then( () => [sample,serverSample] )
-                                .then( downloadSitePhoto )
-                                .then( downloadCreaturePhotos )
-                                
                                 .then( setTimestamp );
-                        } 
+                        }
                     })
+                    // Photo downloads run on every sync, independent of the metadata
+                    // needsUpdate gate, so a photo that failed to download earlier (e.g.
+                    // marginal network) is retried without re-persisting sample metadata
+                    // (WB-101). Both steps are no-ops once nothing is outstanding.
+                    .then( () => [sample,serverSample] )
+                    .then( downloadSitePhoto )
+                    .then( downloadCreaturePhotos )
                     .then( () => [sample,serverSample]);
             }
 
             function downloadSitePhoto([sample,serverSample]) {
-                if ( serverSample.photos.length > 0  ) {
+                // Skip when we already have it — photos are immutable on the server,
+                // so a present serverSitePhotoId means there's nothing to re-fetch.
+                if ( serverSample.photos.length > 0 && ! sample.get("serverSitePhotoId") ) {
                     let sitePhotoPath = `site_download_${serverSample.id}`;
                     info(`Downloading site photo for ${serverSample.id}`);
                     return delayedPromise( Alloy.Globals.CerdiApi.retrieveSitePhoto(serverSample.id, sitePhotoPath), delay )
@@ -177,7 +182,10 @@ function createSampleDownloader(delay) {
                 // this means photos are only ever downloaded from the server when they
                 // do not exist on the client - this is a fair assumption since the photo
                 // can not be changed on the server.
-                let pendingTaxaPhotos = taxa.filter( t => _.isNull(t.get("taxonPhotoPath")));
+                // serverCreaturePhotoId === 0 marks "no photo on the server" (set by
+                // downloadCreaturePhoto), so it's excluded — only fresh or previously
+                // failed photos remain pending and get (re)tried (WB-101).
+                let pendingTaxaPhotos = taxa.filter( t => _.isNull(t.get("taxonPhotoPath")) && t.get("serverCreaturePhotoId") !== 0 );
                 return _.reduce( pendingTaxaPhotos,  
                     (queue,t) => queue.then( () => delayedPromise( downloadCreaturePhoto(t,serverSample),delay)),
                     Promise.resolve())

--- a/walta-app/app/spec/SampleSync_spec.js
+++ b/walta-app/app/spec/SampleSync_spec.js
@@ -754,7 +754,50 @@ describe("SampleSync", function () {
             verifyTaxon(1);
 
         });
-        
+
+        it('should retry a creature photo that failed to download on an earlier sync', async function() {
+            // WB-101: a transient photo-download failure (e.g. marginal network)
+            // must not strand the photo. The sample stays pending so a later
+            // sync re-fetches it, rather than being marked fully synced with a
+            // null taxonPhotoPath that is never retried.
+            let creatureMock = {
+                id: 1948,
+                photo: Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "/spec/resources/simpleKey1/media/amphipoda_01.jpg"),
+            };
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveUnknownCreatures")
+                .resolveWith([]);
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveSamples")
+                .resolveWith([makeCerdiSampleData({
+                    sampled_creatures: [{
+                        "id": 2390,
+                        "sample_id": 473,
+                        "creature_id": 1,
+                        "count": 2,
+                        "photos_count": 0
+                    }]
+                })]);
+
+            let networkUp = false;
+            Alloy.Globals.CerdiApi.retrieveCreaturePhoto = function(serverSampleId, creatureId, photoPath) {
+                if ( !networkUp ) return Promise.reject({ message: "HTTP error" });
+                creatureMock.photo.copy(Ti.Filesystem.applicationDataDirectory + Ti.Filesystem.separator + photoPath);
+                return Promise.resolve(creatureMock);
+            };
+
+            // First sync: the photo fetch fails, so the photo stays pending.
+            await createSampleDownloader().downloadSamples();
+            let sample = Alloy.Models.instance("sample");
+            sample.loadByServerId(473);
+            expect(sample.loadTaxa().at(0).get("taxonPhotoPath"), "photo pending after failed fetch").to.be.null;
+
+            // Second sync once the network recovers: the photo must be retried.
+            networkUp = true;
+            await createSampleDownloader().downloadSamples();
+            sample = Alloy.Models.instance("sample");
+            sample.loadByServerId(473);
+            expect(sample.loadTaxa().at(0).get("serverCreaturePhotoId"), "photo recovered on retry").to.equal(creatureMock.id);
+        });
+
 
         // Due to protocol error early on it is possible for habitat data to be incorrectly blank
         // on the server, if somehow we download corrupt habitat data, make sure any correct data


### PR DESCRIPTION
## Summary
- A transient photo-download failure (marginal network, token expiry mid-sync) used to **strand the photo permanently**: `setTimestamp` stamped `serverSyncTime` even when the fetch failed, so `needsUpdate` returned false on every later sync and the photo was never re-attempted — the creature showed the bluebug silhouette forever. This is the download-side cause of the "photos missing / sample stuck at a percentage" symptom (sibling of WB-88, which fixed the upload/stale-path side).
- **Fix:** decouple photo retrieval from the metadata `needsUpdate` gate. Photo downloads now run on every sync (no-ops once nothing is outstanding), so a previously failed photo is retried **without** re-persisting sample metadata (which avoids overwriting local edits and avoids perpetual re-persist if a photo permanently fails).
  - `setTimestamp` stays inside the `needsUpdate` branch (metadata only).
  - `downloadSitePhoto` skips when `serverSitePhotoId` is already set (photos are immutable on the server — existing assumption).
  - The creature-photo pending filter now excludes the "no photo on server" marker (`serverCreaturePhotoId === 0`), so only fresh or previously-failed photos remain pending.

This was discovered when an iOS-acceptance "flake" on main turned out to be a real, reproducible instance of the bug; the user confirmed it's been happening in the field and was suspected to relate to marginal network.

## Test plan
- [x] New device spec `should retry a creature photo that failed to download on an earlier sync` — RED before the fix (`expected null to equal 1948`), GREEN after
- [x] Full `SampleSync` device suite — 34 passing, 0 failing (no download/upload regressions)
- [ ] CI green (iOS + Android unit + acceptance)

First slice of [Trello WB-101](https://trello.com/c/D8Vu0oCA). The acceptance-harness race that surfaced this (SampleSync auto-running on relaunch vs the `walta://login` deeplink) is noted on the card as separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)