### PR TITLE
WB-102: fix iOS acceptance smart-retry defeated by errexit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -707,8 +707,11 @@ jobs:
         # previous WB-54 retry-on-anything loop.
         run: |
           for attempt in 1 2; do
-            npx grunt --platform=ios --simulator --skip-build acceptance-test
-            rc=$?
+            # `|| rc=$?` keeps the grunt failure inside a list so bash's
+            # default `set -e` doesn't abort the step before we can inspect
+            # the code and decide whether to retry (WB-102).
+            rc=0
+            npx grunt --platform=ios --simulator --skip-build acceptance-test || rc=$?
             [ $rc -eq 0 ] && exit 0
             [ $rc -ne 75 ] && exit $rc
             echo "::warning ::iOS acceptance attempt $attempt returned EX_TEMPFAIL (75); retrying once (WB-94)"


### PR DESCRIPTION
## Summary
- The WB-94 "smart retry" for iOS acceptance has been **dead since it landed**: it never retried an EX_TEMPFAIL (exit 75). GitHub runs `run:` blocks with `bash -e`, and because `npx grunt` was a standalone command, errexit aborted the step the instant grunt exited non-zero — before `rc=$?`, the retry check, or attempt 2 could run. An Appium/sim infra flake therefore failed the job on the first attempt.
- **Fix:** capture the code with `npx grunt ... || rc=$?`, which keeps the failure inside a list so errexit doesn't fire and the retry logic runs as intended.

## Evidence this was happening
Main run [26154128517](https://github.com/TheWaterBugCompany/WALTA/actions/runs/26154128517) (re-run): the iOS acceptance step ran ~10 min (one attempt), exited 75 on an Appium session dying in the cucumber `BeforeAll` hook, and **never emitted the "retrying once (WB-94)" warning** — confirming the retry branch was never reached.

## Test plan
- [x] YAML parses (ruby `YAML.load_file`)
- [x] Bash logic simulated under `bash -eo pipefail`: `75→0` recovers (exit 0); `75→75` fails after one retry (exit 75); real test failure `exit 1` fails fast with no retry; `0` passes first try
- [ ] CI green on this PR (and the retry warning appears if an infra flake is hit)

Fixes [Trello WB-102](https://trello.com/c/Q2YuEWN4). The Android acceptance step (WB-54) already uses `|| { ... }`, so only the iOS path was affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)