### PR TITLE
WB-104: document acceptance-vs-E2E test layer split

### DIFF
--- a/.claude/skills/fast-iteration/SKILL.md
+++ b/.claude/skills/fast-iteration/SKILL.md
@@ -29,6 +29,10 @@ Skip when:
 - the code under test is pure JS with no `Ti.*` / Alloy dependency → `npx grunt unit-test-node`
 - you need the full acceptance suite to pass/fail in CI — run the regular
   `acceptance-test` task without `--liveview` for the final pre-merge check
+- the test is an extensive, mechanism-heavy full-stack flow (e.g. sync
+  interrupt/resume) — that belongs in the Mocha+Appium E2E layer
+  (`end-to-end-testing/`), not a cucumber feature. See docs/testing.md;
+  revival tracked in WB-104.
 
 ## The command
 

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -86,8 +86,8 @@ Cheapest layer that meaningfully exercises the change:
 
 - **Node unit** (`test/**/*_spec.js`, `npx grunt unit-test-node`) — pure JS, no `Ti.*`. Sub-second feedback. Most defects belong here.
 - **Device unit** (`walta-app/app/spec/*_spec.js`) — needs Alloy / `Ti.*`. Drive with [fast-iteration](../fast-iteration/SKILL.md).
-- **Cucumber** (`features/`) — cross-screen user flows. Slow; use sparingly.
-- **Appium** (`end-to-end-testing/`) — full-stack smoke. Reserve for golden-path checks.
+- **Cucumber acceptance** (`features/`) — cross-screen flows that map to a *business requirement*; keep them business-readable. Slow; use sparingly.
+- **Appium E2E** (`end-to-end-testing/`, Mocha+Appium) — extensive, mechanism-heavy full-stack integration that doesn't belong in business language (e.g. sync interrupt/resume across restart/network/foreground). Currently dormant + not in CI — revival tracked in WB-104.
 
 When in doubt, lowest layer that can observe the bug.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Technical docs live in `docs/` (only `README.md`, `CLAUDE.md`, and `CONTRIBUTORS
 - [docs/installation.md](docs/installation.md) — setup guide: prerequisites, Titanium SDK, signing, env vars
 - [docs/coding-style.md](docs/coding-style.md) — JS conventions and comment policy
 - [docs/architecture-vision.md](docs/architecture-vision.md) — long-term architectural direction
-- [docs/testing.md](docs/testing.md) — five test layers and what to use when
+- [docs/testing.md](docs/testing.md) — five test layers and what to use when. Note the deliberate split between the two top layers: `features/` (Cucumber) is business-readable BDD tied to product requirements; `end-to-end-testing/` (Mocha+Appium) is for extensive, mechanism-heavy integration (e.g. sync interrupt/resume) that would clutter a business scenario. The E2E layer is dormant pending WB-104 — don't push low-level integration mechanics into `features/`.
 - [docs/device-specs.md](docs/device-specs.md) — device-spec idioms and gotchas
 - [docs/pull-requests.md](docs/pull-requests.md) — PR template
 - [docs/patterns/](docs/patterns/) — pattern/module summaries; see [docs/patterns/README.md](docs/patterns/README.md) for the index

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -11,8 +11,8 @@ Five layers, ordered fastest to slowest:
 | Node.js unit tests | `test/*_spec.js` | Mocha (Node) | Logic in `lib/logic/` and `lib/util/` that doesn't use `Ti.*` APIs |
 | Build utility tests | `build-tests/unit/*.js` | Mocha (Node, ESM) | Build tools, launchers, hooks |
 | Device unit tests | `walta-app/app/spec/*_spec.js` | ti-mocha (on-device) | Code that depends on `Ti.*` APIs or Alloy controllers |
-| End-to-end tests | `end-to-end-testing/*.js` | Mocha + Appium | Full user interaction flows |
-| Acceptance tests | `features/*.feature` | Cucumber + WebdriverIO | BDD scenarios against product requirements |
+| End-to-end tests | `end-to-end-testing/*.js` | Mocha + Appium | Extensive, mechanism-heavy full-stack integration — developer-oriented flows that would clutter a business-readable scenario |
+| Acceptance tests | `features/*.feature` | Cucumber + WebdriverIO | Business-readable BDD tied to a product requirement; kept high-level |
 
 ## When to write what
 
@@ -20,7 +20,11 @@ Five layers, ordered fastest to slowest:
 
 **Default to a device spec** for screen-level features. Every screen feature must have a device spec under `walta-app/app/spec/`, even if an acceptance test covers the same path. Rationale: acceptance tests are slow integration tests — a single run takes minutes — so they're unsuitable for the tight TDD loop. Device specs run quickly with `--liveview --reuse-server` (see the `fast-iteration` skill), give per-screen test checklists for future work, and pinpoint failures at the controller level rather than at the end of an end-to-end flow.
 
-**Add an acceptance scenario** only for cross-screen flows.
+**Add an acceptance scenario** (`features/`, Cucumber) for a cross-screen flow that maps to a *business requirement* — it should read like a spec a non-developer could follow. Keep the mechanism out: no "kill the app mid-sync, toggle the network, assert N rows" plumbing.
+
+**Drop to an end-to-end test** (`end-to-end-testing/`, Mocha + Appium) for extensive, mechanism-heavy full-stack integration that doesn't belong in business language — e.g. interrupting a sync mid-flight and asserting it resumes after app restart / network restore / foreground. The two layers are deliberately split: `features/` answers "does the product meet the requirement?", `end-to-end-testing/` answers "does this mechanism hold up under real-stack conditions?".
+
+> **Note (2026-05):** the end-to-end layer is currently dormant — only a back-button smoke test, and no CI job runs the `end-to-end-test` grunt task (it appears in `ci.yml` only as a `changes` path-filter). Reviving the harness, wiring it into CI, and adding the sync interrupt/resume suite is tracked in **WB-104**. Until then, prefer device specs for mechanism coverage and don't add low-level integration mechanics to `features/`.
 
 ## Quick reference
 


### PR DESCRIPTION
## Summary
- **Why:** while verifying WB-8, we noticed the cucumber "Diagnostic logs persist across app restart" scenario only asserts the log pane survives — it never interrupts a sync mid-flight. That surfaced a missing rule about *where* mechanism-heavy integration tests belong.
- Documents the deliberate split between the two top test layers: `features/` (Cucumber) = business-readable BDD tied to product requirements; `end-to-end-testing/` (Mocha+Appium) = extensive, mechanism-heavy full-stack integration (e.g. sync interrupt/resume) that would clutter a business scenario.
- Notes the E2E layer is currently **dormant** — only a back-button smoke test, and no CI job runs the `end-to-end-test` grunt task (`ci.yml` references `end-to-end-testing/**` only as a `changes` path-filter).
- Updates `docs/testing.md` (layer table + "When to write what"), `CLAUDE.md` (docs pointer), and the `tdd` + `fast-iteration` skills so the AI guidance matches.

Docs-only slice of [Trello WB-104](https://trello.com/c/qa11D9CP) — the actual E2E harness revival, CI wiring, and sync resilience suite are the rest of that card and land separately.

## Test plan
- [x] Docs-only change — no code touched; nothing to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)