### PR TITLE
WB-105: target a specific Android device via ANDROID_SERIAL

### DIFF
--- a/build-tests/unit/AppiumLauncher_spec.js
+++ b/build-tests/unit/AppiumLauncher_spec.js
@@ -198,6 +198,33 @@ describe("AppiumLauncher", function() {
     });
   });
 
+  describe("Android device targeting (appium:udid)", function() {
+    let originalSerial;
+    beforeEach(function() {
+      originalSerial = process.env.ANDROID_SERIAL;
+      delete process.env.ANDROID_SERIAL;
+    });
+    afterEach(function() {
+      if (originalSerial === undefined) delete process.env.ANDROID_SERIAL;
+      else process.env.ANDROID_SERIAL = originalSerial;
+    });
+
+    it("passes ANDROID_SERIAL through as appium:udid so the session targets that device", async function() {
+      process.env.ANDROID_SERIAL = "emulator-5554";
+      const launcher = new AppiumLauncher("android", { isSimulator: true, startAppium: fakeStartAppium, isAppiumRunning: fakeIsAppiumRunning });
+      await launcher.connect();
+      const caps = fakeStartAppium.firstCall.args[0];
+      expect(caps["appium:udid"]).to.equal("emulator-5554");
+    });
+
+    it("omits appium:udid when ANDROID_SERIAL is unset (single-device default)", async function() {
+      const launcher = new AppiumLauncher("android", { isSimulator: true, startAppium: fakeStartAppium, isAppiumRunning: fakeIsAppiumRunning });
+      await launcher.connect();
+      const caps = fakeStartAppium.firstCall.args[0];
+      expect(caps).to.not.have.property("appium:udid");
+    });
+  });
+
   describe("launch()", function() {
     function makeFakeChildExitingZero() {
       const child = new EventEmitter();

--- a/build-utils/AppiumLauncher.js
+++ b/build-utils/AppiumLauncher.js
@@ -183,6 +183,14 @@ class AppiumLauncher {
       if (optionalIntentArguments) {
         caps["appium:optionalIntentArguments"] = optionalIntentArguments;
       }
+      // Pin the session to a specific device when ANDROID_SERIAL is set —
+      // without it, uiautomator2 can't disambiguate between multiple attached
+      // devices (e.g. a dev box with both an emulator and a physical phone)
+      // and attaches to the wrong one or stalls. Symmetric with iOS reading
+      // SIM_UDID / IOS_DEVICE_UDID. CI is single-device so this is a no-op there.
+      if (process.env.ANDROID_SERIAL) {
+        caps["appium:udid"] = process.env.ANDROID_SERIAL;
+      }
       if (this.isSimulator) {
         Object.assign(caps, { "appium:avdName": "Medium_Phone_API_36.1" });
       }

--- a/features/support/appium-world.js
+++ b/features/support/appium-world.js
@@ -17,6 +17,13 @@ function adb() {
         : 'adb';
 }
 
+// Scope adb to a specific device when ANDROID_SERIAL is set, so `pm clear`
+// etc. don't fail with "more than one device/emulator" on a dev box that
+// has both an emulator and a physical phone attached (WB-105).
+function adbDeviceArgs() {
+    return process.env.ANDROID_SERIAL ? ['-s', process.env.ANDROID_SERIAL] : [];
+}
+
 function mockCerdiUrl() {
     if (process.env.MOCK_CERDI_URL) return process.env.MOCK_CERDI_URL;
     // Android emulator reaches the host loopback only via 10.0.2.2.
@@ -50,9 +57,10 @@ async function connectAndPrepareApp({ platform, isSimulator }) {
     // don't propagate to a relaunch (a pm clear afterwards would negate it).
     if (platform === 'android' && isSimulator) {
         try {
-            execFileSync(adb(), ['shell', 'pm', 'clear', APP_ID]);
-            execFileSync(adb(), ['shell', 'pm', 'grant', APP_ID, 'android.permission.ACCESS_FINE_LOCATION']);
-            execFileSync(adb(), ['shell', 'pm', 'grant', APP_ID, 'android.permission.ACCESS_COARSE_LOCATION']);
+            const dev = adbDeviceArgs();
+            execFileSync(adb(), [...dev, 'shell', 'pm', 'clear', APP_ID]);
+            execFileSync(adb(), [...dev, 'shell', 'pm', 'grant', APP_ID, 'android.permission.ACCESS_FINE_LOCATION']);
+            execFileSync(adb(), [...dev, 'shell', 'pm', 'grant', APP_ID, 'android.permission.ACCESS_COARSE_LOCATION']);
         } catch (e) {
             console.warn(`[appium-world] adb pm clear/grant failed: ${e.message}`);
         }


### PR DESCRIPTION
## Summary
- **Why:** the Appium uiautomator2 session set **no `appium:udid`** (unlike iOS, which sets `SIM_UDID`/`IOS_DEVICE_UDID`), so on a dev box with both an emulator *and* a physical phone attached the session couldn't disambiguate — it attached to the wrong device or stalled, **even with `ANDROID_SERIAL` set**. Discovered running the WB-104 Android e2e smoke locally.
- `AppiumLauncher` android caps now set `appium:udid` from `ANDROID_SERIAL` when present (symmetric with the iOS udid caps). CI is single-device → no-op there.
- `appium-world.js` `pm clear`/`pm grant` adb calls scoped with `-s <serial>` when `ANDROID_SERIAL` is set (otherwise `more than one device/emulator` → caught & warned, so app state wasn't actually cleared).
- The grunt launch path already targeted the emulator (`AndroidEmulatorLauncher` pins the adb serial); this fixes the two spots that didn't — the Appium session and the unscoped adb calls.

[Trello WB-105](https://trello.com/c/VQ4TsVtC).

## Test plan
- [x] `npx grunt build-test` — 163 passing, incl. new "passes ANDROID_SERIAL through as appium:udid" + "omits when unset" (TDD: confirmed RED first)
- [x] WB-104 Android e2e smoke, which **hung** on a two-device box, now binds to `-s emulator-5554` and passes (1 passing, 24s)
- [ ] CI green (single-device — verifies the change is a no-op there)

## Note
Stacked on **WB-104** (`task/wb-104-revive-e2e`) because the `appium-world.js` fix lives in that not-yet-merged branch. Base is the WB-104 branch; rebase to `main` once WB-104 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)