### PR TITLE
WB-106: trim essay comments out of merged acceptance test-infra

### DIFF
--- a/features/step_definitions/registration.js
+++ b/features/step_definitions/registration.js
@@ -1,30 +1,15 @@
 'use strict';
 const { Given, When, Then } = require('@cucumber/cucumber');
 Given('I am not logged in', function() {
-/*     @current_page = page(MenuScreen).await
-    if @current_page.loggedIn?
-        @current_page.log_out
-    end
-    expect( @current_page.loggedIn? ).to eq(false) */
 });
 
-// Logs in via the `walta://login` deeplink — the app's UrlActions
-// dispatcher calls CerdiApi.loginUser then fires Topics.LOGGEDIN, which
-// the menu controller observes. Password is fixed to match the mock
-// CERDI server's /token/create stub.
-//
-// `driver.url` on Android UiAutomator2 routes the URL via Chrome,
-// which won't deliver custom schemes reliably. `mobile: deepLink` /
-// `mobile: deepLink` (iOS) sends the intent directly to the app.
+// Password is fixed to match the mock CERDI server's /token/create stub.
+// `mobile: deepLink` (not driver.url, which Android routes via Chrome and
+// drops custom schemes) sends the walta://login intent straight to the app.
 Given('I am logged in as {string}', {timeout: 120000}, async function(emailAddress) {
-    // Wait for the app to be fully booted FIRST. The launcher intent
-    // (mobile: startActivity) carries cerdiServerUrl/cerdiApiSecret as
-    // extras; alloy.js reads those and builds CerdiApi against the mock
-    // server. If we fire the deeplink before that boot completes, the
-    // OS treats the deeplink as a cold-launch intent (no extras) and
-    // CerdiApi is built against the production sandbox URL — login then
-    // never reaches the mock and the test silently passes the menu wait
-    // but is never actually authenticated.
+    // Wait for boot first: a deeplink fired before boot is treated as a
+    // cold-launch intent without the cerdiServerUrl/Secret extras, so CerdiApi
+    // builds against prod and login silently never reaches the mock.
     await this.menu.waitFor();
     const url = `walta://login?email=${encodeURIComponent(emailAddress)}&password=password`;
     if (this.platform === 'android') {
@@ -39,58 +24,31 @@ Given('I am logged in as {string}', {timeout: 120000}, async function(emailAddre
             bundleId: 'net.thewaterbug.waterbug',
         });
     }
-    // Wait for the "You are Logged in" label to appear in the Menu —
-    // this is the deterministic UI signal that LOGGEDIN fired and the
-    // menu re-rendered with logged-in state. Replaces a fixed sleep
-    // that was sometimes too short on iOS post-reinstall.
     await this.menu.waitForLabel("You are Logged in");
-    // On iOS, LOGGEDIN → HOME → Navigation.openController("Menu") tears
-    // down the existing Menu and opens a new one; the label appears on
-    // the new instance, but immediate clicks can race against the
-    // tear-down. A brief settle avoids stale-element clicks.
+    // iOS re-opens the Menu on LOGGEDIN; let it settle to avoid a stale click.
     if (this.platform === 'ios') {
         await new Promise(r => setTimeout(r, 1500));
     }
 });
 
 Given('the user "([^"]*)" does not exist', function(emailAddress) {
-/*     MockServer.create_user_does_not_exist() */
 });
 
 Then('I am registered on the server', function() {
-/*    serverReq = JSON.parse( Mirage::Client.new.requests(2).body )
-   expect( serverReq["email"] ).to eq(@emailAddress)
-   expect( serverReq["name"] ).to eq("Test User")
-   expect( serverReq["password"] ).to eq("t3stPassw0rd")
-   expect( serverReq["group"] ).to eq(false)
-   expect( serverReq["survey_consent"] ).to eq(false)
-   expect( serverReq["share_name_consent"] ).to eq(false) */
 });
 
 Then('I am logged in', {timeout: 60000}, async function() {
     await this.menu.waitForLabel("You are Logged in");
 });
 
-// 5-min step timeout: form-fill (~3-5s) + LoginScreen.dismissSavePasswordSheet's
-// own 60s wait for the iOS Save Password sheet sum to more than the previous
-// 60s cucumber budget on cold-start CI runners. With both clocks set to 60s,
-// the step kept self-killing before the dismiss could actually see + tap
-// "Not Now". Locally on a warm sim the sheet pops in a few seconds and 60s
-// was enough; on shared macOS-15 runners it isn't.
+// 5-min timeout: form-fill + dismissSavePasswordSheet's own 60s sheet wait
+// exceed the 60s budget on cold-start CI runners (warm local sims are fine).
 When('I log in with {string} and password {string}', {timeout: 300000}, async function(emailAddress, password) {
     await this.menu.waitFor();
     await this.menu.login(emailAddress, password);
 });
 
 When('I register as "([^"]*)"', function(emailAddress) {
-/*     @emailAddress = emailAddress
-    @current_page = page(MenuScreen).await
-    @current_page = @current_page.select("Log In")
-    @current_page = page(LoginScreen).await
-    @current_page = @current_page.select("Register")
-    @current_page = page(RegisterScreen).await
-    sleep 0.5
-    @current_page = @current_page.register_via_email( emailAddress, "Test User", "t3stPassw0rd") */
 });
 
 Given('The {string} account exists with password {string}', function(emailAddress, password) {

--- a/features/step_definitions/server_sample_steps.js
+++ b/features/step_definitions/server_sample_steps.js
@@ -5,8 +5,7 @@ const { expect } = require("chai");
 
 Given('I have existing samples stored on the server', {timeout: 60000}, async function () {
     global.mockCerdiServer.makeMockSample();
-    // The user is pre-logged-in via launchArgs (cucumber.js) — bypassing
-    // the login flow avoids the iOS save-password sheet race entirely.
+    // Pre-logged-in via launchArgs (cucumber.js) — skips the save-password race.
     await this.menu.waitFor();
 });
 
@@ -88,5 +87,5 @@ Then('the new samples are downloaded to the phone', {timeout: 60000}, async func
 });
 
 When('the server becomes reachable', function() {
-/* # its always reachable */
+    // no-op: the mock server is always reachable
 });

--- a/features/support/base-screen.js
+++ b/features/support/base-screen.js
@@ -4,7 +4,7 @@ class BaseScreen {
         this.driver = world.driver;
         this.platform = world.platform;
         this.world = world;
-        this.presenceSelector=this.selector("unknown_base_screen"); // casues waitFor to fail
+        this.presenceSelector=this.selector("unknown_base_screen"); // causes waitFor to fail until a subclass overrides it
     }
 
     isIos() { return this.platform === "ios"; }
@@ -37,17 +37,14 @@ class BaseScreen {
 
     async waitForText(text, timeout = 90000) {
         if ( this.isIos() ) {
-            // visible == 1 filters out off-screen / overlay duplicates —
-            // multiple Titanium widgets can share the same text (e.g. the
-            // light/dark labels stacked on a progress bar) and `$()`
-            // returns the first match, which may be the hidden one.
+            // visible == 1 filters out off-screen/overlay duplicates that share
+            // the same text (e.g. stacked light/dark progress-bar labels).
             await this.waitForRaw(
                 `-ios predicate string:visible == 1 AND (label CONTAINS '${text}' OR name CONTAINS '${text}' OR value CONTAINS '${text}')`,
                 `text "${text}" not present`,
                 timeout);
         } else {
-            // TextView covers Label / Button text; EditText covers TextField /
-            // TextArea (e.g. the SyncFeedback log pane).
+            // TextView covers Label/Button text; EditText covers TextField/TextArea.
             await this.waitForRaw(
                 `//*[(self::android.widget.TextView or self::android.widget.EditText) and contains(@text,"${text}")]`,
                 `text "${text}" not present`, timeout);
@@ -70,10 +67,9 @@ class BaseScreen {
         var location = await el.getLocation();
         var dist = Math.round(size.width * percent / 100);
         var cy = Math.round(location.y + size.height / 2);
-        // iOS slider value at min sits at the left edge; start a few px in
-        // to land on the thumb, then drag to the target offset. Use W3C
-        // actions with an explicit pause — `mobile: dragFromToForDuration`
-        // doesn't reliably fire the Titanium slider's change event on sim.
+        // iOS: start a few px in to land on the thumb. W3C actions with an
+        // explicit pause — dragFromToForDuration doesn't reliably fire the
+        // Titanium slider's change event on sim.
         var fromX = this.isIos() ? location.x + 10 : location.x;
         await this.driver.performActions([{
             type: 'pointer', id: 'finger1', parameters: { pointerType: 'touch' },
@@ -94,9 +90,8 @@ class BaseScreen {
         }
         await el.setValue(text);
         if ( this.isIos() ) {
-            // Titanium text fields don't expose a standard keyboard dismiss
-            // button, so hideKeyboard() fails. Tap above the keyboard to
-            // blur the text field and dismiss it.
+            // hideKeyboard() fails on Titanium text fields; tap above the
+            // keyboard to blur the field and dismiss it.
             var size = await this.driver.getWindowSize();
             await this.driver.performActions([{
                 type: 'pointer', id: 'finger1', parameters: { pointerType: 'touch' },

--- a/features/support/login-screen.js
+++ b/features/support/login-screen.js
@@ -13,13 +13,9 @@ class LoginScreen extends BaseScreen {
         if (this.isIos()) await this.dismissSavePasswordSheet();
     }
 
-    // iOS pops a system-level "Save Password?" sheet after the login form
-    // submits. It persists across walta://reset because it's a system
-    // overlay, not a UIAlertController. Each cucumber run gets a fresh
-    // simulator, so we assume the sheet will appear once per run — wait
-    // for it and dismiss it deterministically. If it doesn't appear in
-    // the window, throw — silent return is what previously let the sheet
-    // leak into later scenarios and block their first screen-wait.
+    // iOS's system "Save Password?" sheet persists across walta://reset (it's
+    // a system overlay, not a UIAlertController). Dismiss it deterministically;
+    // throw if it never appears — a silent return leaked it into later scenarios.
     async dismissSavePasswordSheet() {
         const btn = await this.driver.$("-ios predicate string:label == 'Not Now'");
         await btn.waitForDisplayed({
@@ -29,27 +25,5 @@ class LoginScreen extends BaseScreen {
         await btn.click();
         await btn.waitForDisplayed({ timeout: 5000, reverse: true });
     }
-} 
+}
 module.exports = LoginScreen
-/*     def trait
-      "* marked:'Log in with your existing account:'"
-    end
-
-    def log_in( email, password )
-      wait_for_elements_exist( [email_field,password_field] )
-     
-      enter_text(email_field, email)
-      hide_keyboard_and_wait
-      enter_text(password_field, password)
-      hide_keyboard_and_wait
-      select('Log In')
-      return page(MenuScreen).await
-    end
-
-    def email_field
-      field("Email.")
-    end
-
-    def password_field
-      field("Password.")
-    end */


### PR DESCRIPTION
## Summary
- **Why:** the merged acceptance support/step files had accumulated multi-line essay comments and dead commented-out code that the comment policy (single-line *why* only; narrative → docs/) says shouldn't live in source.
- Removed the dead commented-out Ruby blocks left over from the old Calabash suite (`registration.js`, `login-screen.js`) — git history retains them.
- Cut multi-line essay comments down to single-line why-notes across `registration.js`, `login-screen.js`, `base-screen.js`, and `server_sample_steps.js`.
- Fixed a typo (`casues` → `causes`) in the base-screen presence-selector note.

[Trello WB-106](https://trello.com/c/1ajpq0ru/106-trim-essay-comments-out-of-merged-acceptance-test-infra-files) — comment-policy cleanup of merged-main acceptance test-infra. Scoped to files **not** rewritten by #268/WB-104 to avoid rebase conflicts; sibling cleanup to the comment trim in #268.

## Test plan
- [x] Comment-only / dead-code removal — all four files pass `node --check`
- [ ] `npx grunt --platform=ios --simulator acceptance-test` — green (behaviour unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)