### PR TITLE
WB-111: fix inverted trace/debug level ranking + persist debug to diagnostics

### DIFF
--- a/test/Logger_spec.js
+++ b/test/Logger_spec.js
@@ -151,7 +151,7 @@ describe("Logger.subscribe", function () {
         expect(captured).to.have.length(0);
     });
 
-    it("filters out entries below minLevel (debug < trace < info < warn < error)", function () {
+    it("filters out entries below minLevel (trace < debug < info < warn < error)", function () {
         const captured = [];
         Logger.subscribe({ facility: "sync", minLevel: "info" }, e => captured.push(e));
         Logger.debug("noise", "sync");
@@ -160,6 +160,15 @@ describe("Logger.subscribe", function () {
         Logger.warn("slow", "sync");
         Logger.error("boom", "sync");
         expect(captured.map(e => e.level)).to.deep.equal(["info", "warn", "error"]);
+    });
+
+    it("ranks trace below debug — minLevel 'debug' excludes trace but keeps debug", function () {
+        const captured = [];
+        Logger.subscribe({ facility: "sync", minLevel: "debug" }, e => captured.push(e));
+        Logger.log("trace bit", "sync");
+        Logger.debug("debug bit", "sync");
+        Logger.info("milestone", "sync");
+        expect(captured.map(e => e.level)).to.deep.equal(["debug", "info"]);
     });
 
     it("returns an unsubscribe function that stops further notifications", function () {

--- a/test/util/sinks/SqlSink_spec.js
+++ b/test/util/sinks/SqlSink_spec.js
@@ -14,9 +14,9 @@ describe("SqlSink", function () {
         return { appended, append(entry) { appended.push(entry); } };
     }
 
-    it("create() returns a sink with levels [trace, info, warn, error] (skips debug)", function () {
+    it("create() returns a sink that persists debug too (only ever read back in diagnostics)", function () {
         const sink = SqlSink.create(fakeRepo());
-        expect(sink.levels).to.deep.equal(["trace", "info", "warn", "error"]);
+        expect(sink.levels).to.deep.equal(["trace", "debug", "info", "warn", "error"]);
     });
 
     it("write() forwards the entry to repo.append and returns a Promise", async function () {

--- a/walta-app/app/lib/repository/LogRepository.js
+++ b/walta-app/app/lib/repository/LogRepository.js
@@ -8,7 +8,7 @@
 // `LogRepository.open()` happens. Tests use
 // `Migrator.migrate(testDbName)` against their test-named db.
 
-const LEVEL_RANK = { debug: 0, trace: 1, info: 2, warn: 3, error: 4 };
+const { LEVEL_RANK } = require("../util/LogLevels");
 
 exports.open = function (dbName) {
     const db = Ti.Database.open(dbName);

--- a/walta-app/app/lib/util/LogLevels.js
+++ b/walta-app/app/lib/util/LogLevels.js
@@ -1,0 +1,5 @@
+// Single source of truth for log-level ordering, shared by Logger
+// (subscriber minLevel filtering) and LogRepository (query minLevel).
+// Conventional verbosity order: trace is the most verbose, error the
+// most severe. See docs/patterns/logger-sinks.md.
+exports.LEVEL_RANK = { trace: 0, debug: 1, info: 2, warn: 3, error: 4 };

--- a/walta-app/app/lib/util/Logger.js
+++ b/walta-app/app/lib/util/Logger.js
@@ -13,7 +13,7 @@ function getBugfender() {
 // see docs/patterns/logger-sinks.md
 const _sinks = [];
 const _subscribers = [];
-const LEVEL_RANK = { debug: 0, trace: 1, info: 2, warn: 3, error: 4 };
+const { LEVEL_RANK } = require("./LogLevels");
 
 exports.addSink = function (sink) {
     _sinks.push(sink);

--- a/walta-app/app/lib/util/sinks/SqlSink.js
+++ b/walta-app/app/lib/util/sinks/SqlSink.js
@@ -3,11 +3,13 @@
 // LogRepository. This module's only job is to satisfy the sink
 // contract and forward entries to repo.append.
 //
-// Levels: skip "debug" — dev-only noise that doesn't need persisting.
+// Persists every level including "debug": debug is filtered out of the
+// in-app Show Logs pane (minLevel: info) but is wanted in the exported
+// diagnostics report, which is the only place it's ever read back.
 
 exports.create = function (repo) {
     return {
-        levels: ["trace", "info", "warn", "error"],
+        levels: ["trace", "debug", "info", "warn", "error"],
         write: async function (entry) {
             repo.append(entry);
         }


### PR DESCRIPTION
## Summary
- **Reorder `LEVEL_RANK` to convention** (`trace < debug < info < warn < error`). It previously ranked `trace` *above* `debug`, so a `minLevel: "trace"` filter dropped `debug` while keeping the noisier per-request `network` traces — backwards from what's useful for diagnosis.
- **Consolidate the rank table into a new `LogLevels` module.** It was duplicated verbatim in `Logger.js` and `LogRepository.js` and had to be kept in sync by hand; a single source of truth removes the drift risk. (Dedup explicitly approved during the session.)
- **Persist `debug` via `SqlSink`.** The in-app Show Logs pane still filters at `minLevel: info`, but the exported diagnostics report now includes `Logger.debug()` lines (e.g. `SampleDownloader.needsUpdate` reasons) — the only place they're read back. The remote `BugfenderSink` deliberately still excludes `debug`.

First slice of [Trello WB-111](https://trello.com/c/tyKX3u7C/111-logger-fix-inverted-trace-debug-level-ranking-persist-debug-to-diagnostics) — the whole card. Found while reading the WB-8 smoke-test diagnostics .eml, where the absent `debug` lines were exactly what was needed to confirm "Updating serverSampleId" was correct first-time-download behaviour.

## Test plan
- [x] `npx grunt unit-test-node` — passes (174)
- [ ] `npx grunt build-test` — passes
- [ ] Generate a diagnostics report on device and confirm `debug` lines appear in `waterbug-log.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)