### PR TITLE
WB-110: real-fraction sync progress bar + activity-aware logging

### DIFF
--- a/test/models/SyncStore_spec.js
+++ b/test/models/SyncStore_spec.js
@@ -107,17 +107,34 @@ describe("SyncStore", function () {
       expect(store.logLines).to.deep.equal(["Uploading site photo"]);
     });
 
-    it("increments percent monotonically, capped below 100", function () {
-      const percents = [];
-      for (let i = 0; i < 10; i++) {
-        store.recordProgress("step " + i);
-        percents.push(store.percent);
-      }
-      for (let i = 1; i < percents.length; i++) {
-        expect(percents[i]).to.be.at.least(percents[i - 1]);
-      }
-      expect(percents[percents.length - 1]).to.be.below(100);
-      expect(percents[0]).to.be.greaterThan(0);
+    it("sets percent from the current/total work fraction", function () {
+      store.recordProgress("downloading", { current: 1, total: 4 });
+      expect(store.percent).to.equal(25);
+      store.recordProgress("downloading", { current: 2, total: 4 });
+      expect(store.percent).to.equal(50);
+      store.recordProgress("downloading", { current: 3, total: 4 });
+      expect(store.percent).to.equal(75);
+    });
+
+    it("caps percent below 100 until recordSuccess, even when all work is done", function () {
+      store.recordProgress("last item", { current: 4, total: 4 });
+      expect(store.percent).to.be.below(100);
+      store.recordSuccess();
+      expect(store.percent).to.equal(100);
+    });
+
+    it("leaves percent unchanged for a message-only progress event (no fraction)", function () {
+      store.recordProgress("starting", { current: 2, total: 4 });
+      store.recordProgress("a note with no fraction");
+      expect(store.percent).to.equal(50);
+    });
+
+    it("advances percent without disturbing statusText for a percent-only tick", function () {
+      store.recordProgress("Downloading samples", { current: 1, total: 4 });
+      store.recordProgress(undefined, { current: 2, total: 4 });
+      expect(store.percent).to.equal(50);
+      expect(store.statusText).to.equal("Downloading samples");
+      expect(store.logLines).to.deep.equal(["Downloading samples"]);
     });
 
     it("is ignored when not in the 'syncing' state", function () {

--- a/test/viewmodels/SyncFeedback_spec.js
+++ b/test/viewmodels/SyncFeedback_spec.js
@@ -197,8 +197,8 @@ describe("SyncFeedbackViewModel", function () {
 
     it("includes the statusText when syncing with a message", function () {
       store.recordStart();
-      store.recordProgress("Uploading taxa 141 photo");
-      expect(vm.progressText).to.equal("15% Uploading taxa 141 photo");
+      store.recordProgress("Uploading taxa 141 photo", { current: 1, total: 4 });
+      expect(vm.progressText).to.equal("25% Uploading taxa 141 photo");
     });
 
     it("renders the seeded statusText after recordStart", function () {
@@ -215,16 +215,16 @@ describe("SyncFeedbackViewModel", function () {
 
     it("shows the error message on error", function () {
       store.recordStart();
-      store.recordProgress("Uploading");
+      store.recordProgress("Uploading", { current: 1, total: 4 });
       store.recordError(new Error("upload failed"));
-      expect(vm.progressText).to.equal("15% upload failed");
+      expect(vm.progressText).to.equal("25% upload failed");
     });
 
     it("falls back to 'Server Error' when the error has no message", function () {
       store.recordStart();
-      store.recordProgress("Uploading");
+      store.recordProgress("Uploading", { current: 1, total: 4 });
       store.recordError(new Error(""));
-      expect(vm.progressText).to.equal("15% Server Error");
+      expect(vm.progressText).to.equal("25% Server Error");
     });
   });
 
@@ -283,8 +283,8 @@ describe("SyncFeedbackViewModel", function () {
     it("formats the percent as a CSS-style width string", function () {
       expect(vm.progressWidth).to.equal("0%");
       store.recordStart();
-      store.recordProgress("Uploading");
-      expect(vm.progressWidth).to.equal("15%");
+      store.recordProgress("Uploading", { current: 1, total: 4 });
+      expect(vm.progressWidth).to.equal("25%");
     });
   });
 

--- a/walta-app/app/lib/logic/SampleDownloader.js
+++ b/walta-app/app/lib/logic/SampleDownloader.js
@@ -7,10 +7,12 @@ var debug = (m, tag = "sync") => Logger.debug(m, tag);
 var info = (m, tag = "sync") => Logger.info(m, tag);
 var warn = (m, tag = "sync") => Logger.warn(m, tag);
 var error = (m, tag = "sync") => Logger.error(m, tag);
-function createSampleDownloader(delay) {
+function createSampleDownloader(delay, progress) {
+    progress = progress || { plan() {}, tick() {} };
     return {
         downloadSamples() {
             debug(`Queuing sample retrieval from server... `);
+            let updatedCount = 0;
             
             // only update if updated after it was last uploaded - this allows user changes
             // to not be overwritten.
@@ -87,6 +89,7 @@ function createSampleDownloader(delay) {
                     .then( () => {
                         if ( needsUpdate(serverSample,sample) ) {
                             info(`Updating serverSampleId = ${serverSample.id}`);
+                            updatedCount++;
                             // serverSyncTime is set right after persistSample so that an
                             // updatedAt bumped a few ms later (e.g. habitat blanks being
                             // filled in) lands after it and signals a re-upload.
@@ -193,11 +196,14 @@ function createSampleDownloader(delay) {
                 
             }
 
-            function saveNewSamples( samples ) {     
-                return _.reduce( samples, 
+            function saveNewSamples( samples ) {
+                progress.plan( samples.length );
+                return _.reduce( samples,
                     (updateAllSamples, serverSample ) => updateAllSamples
                             .then( () => serverSample )
-                            .then( updateIncomingSample ),Promise.resolve() );
+                            .then( updateIncomingSample )
+                            .then( () => progress.tick() ),Promise.resolve() )
+                    .then( () => updatedCount );
             }
             return delayedPromise( Alloy.Globals.CerdiApi.retrieveSamples(), delay )
                 .then( saveNewSamples );

--- a/walta-app/app/lib/logic/SampleSync.js
+++ b/walta-app/app/lib/logic/SampleSync.js
@@ -46,11 +46,15 @@ function setFullSyncPending(value) {
     Ti.App.Properties.setBool(FULL_SYNC_PENDING_KEY, value);
 }
 
-function hasPendingUploads() {
+function countPendingUploads() {
     let userId = Alloy.Globals.CerdiApi.retrieveUserId();
     let samples = Alloy.createCollection("sample");
     samples.loadUploadQueue(userId);
-    return samples.length > 0;
+    return samples.length;
+}
+
+function hasPendingUploads() {
+    return countPendingUploads() > 0;
 }
 
 function clearUploadTimer() {
@@ -135,8 +139,21 @@ function resumeInterruptedWork(options) {
 
 function runSync({ download, options }) {
     let delay = (options && !_.isUndefined(options.delay)?options.delay:2500);
-    let sampleUploader = createSampleUploader(delay);
-    let sampleDownloader = createSampleDownloader(delay);
+
+    // Combined-pool progress: one running fraction across the download and
+    // upload phases. Upload work is countable up front, so seed it before
+    // the download phase plans its own count — that keeps the bar from
+    // jumping backwards when uploads begin after a download.
+    let progressDone = 0, progressTotal = countPendingUploads();
+    function tick(message) {
+        progressDone++;
+        syncStore.recordProgress(message, { current: progressDone, total: progressTotal });
+    }
+    let downloadProgress = { plan: (n) => { progressTotal += n; }, tick };
+    let uploadProgress = { plan() {}, tick };
+
+    let sampleUploader = createSampleUploader(delay, uploadProgress);
+    let sampleDownloader = createSampleDownloader(delay, downloadProgress);
     debug(`Starting ${download?"full sync":"upload"} process... (delay=${delay})`);
 
     cancelled = false;
@@ -182,15 +199,15 @@ function runSync({ download, options }) {
 
     isSyncing = true;
     syncStore.recordStart();
-    info(`Starting ${download?"sync":"upload"}`);
     Topics.fireTopicEvent( Topics.SYNC_STARTED );
     let didDownload = download;
+    let downloadedCount = 0, uploadedCount = 0;
     function syncPass( withDownload ) {
         return Promise.resolve()
-            .then(() => withDownload ? sampleDownloader.downloadSamples() : undefined )
-            .then(checkCancelled)
+            .then(() => withDownload ? sampleDownloader.downloadSamples() : 0 )
+            .then((n) => { downloadedCount += (n || 0); checkCancelled(); })
             .then(() => sampleUploader.uploadSamples() )
-            .then(checkCancelled);
+            .then((n) => { uploadedCount += (n || 0); checkCancelled(); });
     }
     return syncPass( download )
         .then(() => {
@@ -207,7 +224,14 @@ function runSync({ download, options }) {
         .then(() => {
             if ( didDownload ) setFullSyncPending(false);
             syncStore.recordSuccess();
-            info(`${didDownload?"Sync":"Upload"} finished successfully`);
+            // Only narrate a sync that actually moved data; an idle check
+            // leaves just a debug breadcrumb so the log isn't dominated by
+            // empty-sync brackets.
+            if ( downloadedCount + uploadedCount > 0 ) {
+                info(`Sync finished: downloaded ${downloadedCount}, uploaded ${uploadedCount}`);
+            } else {
+                debug(`Sync check complete — nothing to ${didDownload?"sync":"upload"}`);
+            }
             Topics.fireTopicEvent( Topics.SYNC_FINISHED, { success: true } );
         })
         .catch( err => {

--- a/walta-app/app/lib/logic/SampleUploader.js
+++ b/walta-app/app/lib/logic/SampleUploader.js
@@ -212,18 +212,24 @@ function loadSamples() {
     return samples;
 }
 
-function createSampleUploader(delay) {
+function createSampleUploader(delay, progress) {
+    progress = progress || { plan() {}, tick() {} };
     return {
         uploadSamples() {
             debug(`Queuing uploading samples to server...`);
             return Promise.resolve()
                 .then(loadSamples)
-                .then((samples) => this.uploadRemainingSamples(samples) );
+                .then((samples) => {
+                    const planned = samples.length;
+                    progress.plan( planned );
+                    return this.uploadRemainingSamples(samples).then( () => planned );
+                });
         },
 
          uploadRemainingSamples(samples) {
             if ( samples.length > 0 ) {
                 return this.uploadNextSample(samples)
+                    .then( () => progress.tick() )
                     .then( () => this.uploadRemainingSamples(samples) )
                     .catch( (err) => {
                         if ( err.message === "The given data was invalid.") {

--- a/walta-app/app/lib/logic/SampleUploader.js
+++ b/walta-app/app/lib/logic/SampleUploader.js
@@ -220,17 +220,18 @@ function createSampleUploader(delay, progress) {
             return Promise.resolve()
                 .then(loadSamples)
                 .then((samples) => {
-                    const planned = samples.length;
-                    progress.plan( planned );
-                    return this.uploadRemainingSamples(samples).then( () => planned );
+                    progress.plan( samples.length );
+                    return this.uploadRemainingSamples(samples);
                 });
         },
 
          uploadRemainingSamples(samples) {
             if ( samples.length > 0 ) {
                 return this.uploadNextSample(samples)
-                    .then( () => progress.tick() )
-                    .then( () => this.uploadRemainingSamples(samples) )
+                    .then( (uploaded) => {
+                        progress.tick();
+                        return this.uploadRemainingSamples(samples).then( (rest) => uploaded + rest );
+                    })
                     .catch( (err) => {
                         if ( err.message === "The given data was invalid.") {
                             return this.uploadRemainingSamples(samples);
@@ -239,7 +240,7 @@ function createSampleUploader(delay, progress) {
                         }
                     })
             } else {
-                return Promise.resolve();
+                return Promise.resolve(0);
             }
         },
 
@@ -308,9 +309,10 @@ function createSampleUploader(delay, progress) {
                         .then( (sample) => uploadUnknownCreatures(sample,delay))
                         .then( (sample) => deletePendingUnknownCreatures(sample,delay))
                         .then( (sample) => markSampleComplete(sample,delay) )
-                        .catch( Logger.recordException );
+                        .then( () => 1 )
+                        .catch( (err) => { Logger.recordException(err); return 0; } );
             } else {
-                return Promise.resolve(sample);
+                return Promise.resolve(0);
             }
         
                      

--- a/walta-app/app/lib/models/SyncStore.js
+++ b/walta-app/app/lib/models/SyncStore.js
@@ -1,8 +1,9 @@
 const ChangeNotifier = require("../util/ChangeNotifier");
 const Logger = require("../util/Logger");
 
-const PROGRESS_STEP = 15;
-const PROGRESS_CAP = 95;
+// Hold just below 100 until recordSuccess() owns the final 100%, so the
+// bar never reports complete while work is still settling.
+const PROGRESS_CAP = 99;
 const LOG_CAP = 200;
 
 const INITIAL_STATE = {
@@ -44,12 +45,19 @@ class SyncStore extends ChangeNotifier {
     this._setState({ ...INITIAL_STATE, status: "syncing", statusText: "Starting sync" });
   }
 
-  recordProgress(message) {
+  recordProgress(message, progress) {
     if (this._state.status !== "syncing") return;
-    const safe = message || "";
-    const nextPercent = Math.min(PROGRESS_CAP, this._state.percent + PROGRESS_STEP);
-    const nextLog = safe ? this._appendLog(safe) : this._state.logLines;
-    this._setState({ percent: nextPercent, statusText: safe, logLines: nextLog });
+    const patch = {};
+    // Omit message entirely (a percent-only tick) to advance the bar
+    // without disturbing the phase label currently shown.
+    if (message !== undefined) {
+      patch.statusText = message || "";
+      if (message) patch.logLines = this._appendLog(message);
+    }
+    if (progress && progress.total > 0) {
+      patch.percent = Math.min(PROGRESS_CAP, Math.round((progress.current / progress.total) * 100));
+    }
+    this._setState(patch);
   }
 
   recordSuccess() {

--- a/walta-app/app/spec/SampleSync_spec.js
+++ b/walta-app/app/spec/SampleSync_spec.js
@@ -1566,5 +1566,32 @@ describe("SampleSync", function () {
             expect(Alloy.Globals.CerdiApi.retrieveSamples.callCount, "download ran before success").to.equal(1);
             expect(Ti.App.Properties.getBool(FULL_SYNC_PENDING_KEY), "flag cleared once the full sync ran").to.equal(false);
         });
+
+        it("emits no info-level log line for an idle sync with nothing to do", async function () {
+            mockLoggedIn();
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveSamples").resolveWith([]);
+            const Logger = require("util/Logger");
+            const captured = [];
+            const unsubscribe = Logger.subscribe({ facility: "sync", minLevel: "info" }, (e) => captured.push(e.message));
+
+            await SampleSync.forceSync({ delay: 0, noschedule: true });
+            unsubscribe();
+
+            expect(captured, "info-level sync log").to.deep.equal([]);
+        });
+
+        it("logs a one-line summary when a sync actually moves data", async function () {
+            mockLoggedIn();
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveUnknownCreatures").resolveWith([]);
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveSamples").resolveWith([makeCerdiSampleData({ user_id: 38 })]);
+            const Logger = require("util/Logger");
+            const captured = [];
+            const unsubscribe = Logger.subscribe({ facility: "sync", minLevel: "info" }, (e) => captured.push(e.message));
+
+            await SampleSync.forceSync({ delay: 0, noschedule: true });
+            unsubscribe();
+
+            expect(captured, "summary line").to.include("Sync finished: downloaded 1, uploaded 0");
+        });
     })
 });

--- a/walta-app/app/spec/SampleSync_spec.js
+++ b/walta-app/app/spec/SampleSync_spec.js
@@ -221,6 +221,19 @@ describe("SampleSync", function () {
             expect(Alloy.Globals.CerdiApi.submitSample.calls[0].args[0].waterbody_name).to.equal("test water body name");
             expect(sample.get("serverSyncTime")).to.be.a('number');
         });
+        it('returns the count of uploaded samples and reports progress per sample', async function() {
+            simple.mock(Alloy.Globals.CerdiApi,"retrieveUserId").returnWith(38);
+            simple.mock(Alloy.Globals.CerdiApi,"submitSample").resolveWith({id:123, user_id:38});
+            simple.mock(Alloy.Globals.CerdiApi,"submitSitePhoto").resolveWith({id:1});
+            let sample = makeSampleData();
+            sample.save();
+            const planned = [], ticks = [];
+            const progress = { plan: (n) => planned.push(n), tick: () => ticks.push(1) };
+            const count = await createSampleUploader(undefined, progress).uploadSamples();
+            expect(count, "uploaded count").to.equal(1);
+            expect(planned, "planned total").to.deep.equal([1]);
+            expect(ticks.length, "ticks").to.equal(1);
+        });
         it('should upload modified samples to the server', async function() {
             simple.mock(Alloy.Globals.CerdiApi,"retrieveUserId")
                 .returnWith(38);
@@ -514,6 +527,18 @@ describe("SampleSync", function () {
             expect(taxa.at(1).get("taxonId")).to.equal(2);
             expect(taxa.at(1).get("abundance")).to.equal("6-10");
             expect(sample.get("serverUserId")).to.equal(38);
+        });
+        it('returns the count of updated samples and reports progress per sample', async function () {
+            simple.mock(Alloy.Globals.CerdiApi,"retrieveUnknownCreatures")
+                .resolveWith([]);
+            simple.mock(Alloy.Globals.CerdiApi,"retrieveSamples")
+                .resolveWith([makeCerdiSampleData({user_id:38})]);
+            const planned = [], ticks = [];
+            const progress = { plan: (n) => planned.push(n), tick: () => ticks.push(1) };
+            const count = await createSampleDownloader(undefined, progress).downloadSamples();
+            expect(count, "updated count").to.equal(1);
+            expect(planned, "planned total").to.deep.equal([1]);
+            expect(ticks.length, "ticks").to.equal(1);
         });
         it('should update existing samples if they have been updated on the server', async function () {
             simple.mock(Alloy.Globals.CerdiApi,"retrieveUnknownCreatures")

--- a/walta-app/app/spec/SyncFeedback_spec.js
+++ b/walta-app/app/spec/SyncFeedback_spec.js
@@ -166,19 +166,16 @@ describe("SyncFeedback controller", function () {
         beforeEach(async () => {
             var { syncController, store } = createSyncController(SyncStore);
             store.recordStart();
-            store.recordProgress("Downloading samples");
-            store.recordProgress("Uploading site photo");
-            store.recordProgress("Uploading taxa 141 photo");
-            // PROGRESS_STEP=15 → 3 increments puts percent at 45, status
-            // text at the last message. Gives a clear mid-sync render.
+            // 3 of 4 work units done → 75%, status text at the last message.
+            store.recordProgress("Uploading taxa 141 photo", { current: 3, total: 4 });
             ctl = Alloy.createController("SyncFeedback", { syncController });
             win = wrapViewInWindow(ctl.getView());
             await windowOpenTest(win);
         });
 
         it("shows the bar partially filled with the latest status text", () => {
-            expect(ctl.progressText.text).to.equal("45% Uploading taxa 141 photo");
-            expect(ctl.progressFill.width).to.equal("45%");
+            expect(ctl.progressText.text).to.equal("75% Uploading taxa 141 photo");
+            expect(ctl.progressFill.width).to.equal("75%");
         });
     });
 
@@ -186,8 +183,7 @@ describe("SyncFeedback controller", function () {
         beforeEach(async () => {
             var { syncController, store } = createSyncController(SyncStore);
             store.recordStart();
-            store.recordProgress("Downloading samples");
-            store.recordProgress("Uploading site photo");
+            store.recordProgress("Uploading site photo", { current: 1, total: 4 });
             store.recordError(new Error("Server Error"));
             ctl = Alloy.createController("SyncFeedback", { syncController });
             win = wrapViewInWindow(ctl.getView());
@@ -195,7 +191,7 @@ describe("SyncFeedback controller", function () {
         });
 
         it("renders the error message in the progress text with the error colour", () => {
-            expect(ctl.progressText.text).to.equal("30% Server Error");
+            expect(ctl.progressText.text).to.equal("25% Server Error");
             expect(ctl.progressFill.backgroundColor).to.equal(Alloy.CFG.colors.error);
         });
     });


### PR DESCRIPTION
## Summary
- **Progress bar reflects real work, not a fixed step.** `SyncStore.recordProgress` took a fixed +15%/event capped at 95%, so a large download saturated the bar after ~7 events while most samples were still pending (the reported bug). It now computes a true `current/total` fraction, held at 99 until `recordSuccess()` owns 100.
- **Combined-pool model across phases.** `SampleSync` owns one running counter: it seeds the up-front upload count, lets the download phase grow the total once its sample list arrives, and ticks per sample — so the bar climbs proportionally through download then upload without jumping backwards.
- **Activity-aware logging.** The unconditional "Starting sync" / "Sync finished successfully" brackets are gone. A sync that moves data logs one `Sync finished: downloaded N, uploaded M`; an idle check leaves only a debug breadcrumb, so the Show Logs pane (info+) stays quiet when there's nothing to do.
- **Shared mechanism:** `SampleDownloader`/`SampleUploader` take an optional `{ plan, tick }` reporter and return the count of samples actually processed. `uploadSamples` returns *actual* uploads (not queue length), so a downloaded sample that surfaces in the queue but needs no upload isn't miscounted. `Topics.UPLOAD_PROGRESS` is untouched — it still drives the SampleHistory list refresh.

Combines [Trello WB-110](https://trello.com/c/fsBgtdSd/110-sync-progress-bar-saturates-at-95-during-full-history-download) (progress bar) with the idle-sync log-noise cleanup, since both build on the same work-quantity reporting (agreed in-session rather than splitting an artificial dependency).

### Known minor limitations (noted on the card)
- A freshly downloaded sample can surface in the upload queue and be examined (ticked) without uploading; with the upload count pre-seeded the internal counter can pass the total — capped at 99, no backward motion, summary counts stay accurate.
- Photo-only retries don't flip the activity flag (a sync that only re-fetched a photo logs "nothing to sync").

## Test plan
- [x] `npx grunt unit-test-node` — 176 passing (SyncStore fraction + SyncFeedback presentation)
- [x] `npx grunt --platform=ios --simulator unit-test --grep=SampleSync` (LiveView) — 47 passing
- [ ] Full iOS device unit-test run **without** `--liveview` (clean bundle) before ready
- [ ] Visual check: large-account full sync shows the bar climbing proportionally, not pinned at 95%
- [ ] Confirm an idle Sync leaves no info lines in Show Logs; diagnostics shows the debug breadcrumb (needs WB-111 / #271 for debug persistence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)