### PR TITLE
WB-113: tolerate deleteSession failing in AppiumLauncher.stop()

### DIFF
--- a/build-tests/unit/AppiumLauncher_spec.js
+++ b/build-tests/unit/AppiumLauncher_spec.js
@@ -343,6 +343,19 @@ describe("AppiumLauncher", function() {
       await launcher.stop(); // should not throw
     });
 
+    it("tolerates deleteSession rejecting when the session is already gone", async function() {
+      // On a contended CI runner the Appium/WDA session connection can drop
+      // (UND_ERR_CLOSED) before teardown; deleting a session we're discarding
+      // anyway must not fail the run (WB-113).
+      fakeDriver.deleteSession = sinon.stub().rejects(new Error("Request failed with error code UND_ERR_CLOSED"));
+      const launcher = new AppiumLauncher("android", { startAppium: fakeStartAppium, isAppiumRunning: fakeIsAppiumRunning });
+      await launcher.connect();
+      await launcher.stop(); // should not throw
+      // the dead driver is cleared, so a fresh connect() starts a new session
+      await launcher.connect();
+      expect(fakeStartAppium.calledTwice).to.be.true;
+    });
+
     it("kills the appium server if we started it", async function() {
       fakeDriver.deleteSession = sinon.stub().resolves();
       const fakeChild = Object.assign(new EventEmitter(), { unref: sinon.stub(), pid: 12345 });

--- a/build-utils/AppiumLauncher.js
+++ b/build-utils/AppiumLauncher.js
@@ -260,7 +260,15 @@ class AppiumLauncher {
 
   async stop() {
     if (this._driver) {
-      await this._driver.deleteSession();
+      // The session may already be gone (e.g. UND_ERR_CLOSED when a contended
+      // CI runner drops the WDA/Appium connection mid-run). Deleting a session
+      // we're discarding anyway must not fail teardown — mirror the SIGINT
+      // handler's tolerant cleanup (WB-113).
+      try {
+        await this._driver.deleteSession();
+      } catch (e) {
+        console.warn("AppiumLauncher.stop: deleteSession failed, session likely already gone:", e && e.message);
+      }
       this._driver = null;
     }
     if (this._serverPid) {


### PR DESCRIPTION
## Summary
- **`AppiumLauncher.stop()` no longer crashes the run when the session is already gone.** It awaited `deleteSession()` with no guard, so a dropped WDA/Appium connection (`UND_ERR_CLOSED`) on a contended CI runner propagated out of cucumber's `AfterAll` hook and failed the whole run with exit 75 — *before the passing scenarios were even reported*. The WB-94 in-job retry re-ran on the same wedged runner, so both attempts died identically.
- Wrapped `deleteSession()` in a try/catch (logging + continuing to kill the server), mirroring the `SIGINT` handler in `connect()` that already guards this exact call. Tearing down a session we're discarding anyway is now a no-op.

Diagnosed from #270's red run (26269097711): the failure artifacts for "Creature photos remain visible after sync" show the scenario ran cleanly end-to-end (login → sync → photos `200` → "Sync finished successfully"); the only error anywhere was the teardown `deleteSession`. So this turns #270 green, and as a bonus a session that genuinely dies mid-scenario will now surface as the real scenario failure instead of being masked by a teardown crash.

[Trello WB-113](https://trello.com/c/MDunVVj5) — CI-infra reliability, sibling of WB-93/WB-94/WB-95.

## Test plan
- [x] `npx grunt build-test` — 164 passing (new unit test: `stop()` tolerates `deleteSession` rejecting and still clears the driver)
- [ ] iOS acceptance green on CI (the real-world confirmation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)