### PR TITLE
WB-116: quiesce in-flight sync on reset to de-flake app-badge scenarios

### DIFF
--- a/features/support/appium-world.js
+++ b/features/support/appium-world.js
@@ -133,8 +133,15 @@ async function resetApp() {
     } else {
         await global.driver.execute('mobile: deepLink', { url, bundleId: appId });
     }
-    // Topics.HOME → openController("Menu") is async; let the window land.
-    await new Promise(r => setTimeout(r, 500));
+    // Reset announces the logout (menu shows "Log In") only *after* it has
+    // quiesced any in-flight sync and cleared the token — so the Log In button
+    // is a reliable "reset complete" signal. Polling for it (rather than a
+    // fixed sleep) avoids the race where the next scenario logs in before
+    // reset finishes and reset then nulls the freshly-set token.
+    await global.driver.waitUntil(async () => {
+        const el = await global.driver.$('~Log In.');
+        return el.isDisplayed().catch(() => false);
+    }, { timeout: 15000, interval: 200, timeoutMsg: 'app did not return to the logged-out menu after reset' });
 }
 
 async function teardown() {

--- a/features/sync_samples.feature
+++ b/features/sync_samples.feature
@@ -27,8 +27,15 @@ Scenario: Diagnostic logs persist across app restart
     And I tap Show Logs in the sync popup
    Then the log pane still contains the remembered lines
 
+  # The app-icon badge / notification-dot nudge (WB-10) scenarios run last, on
+  # purpose: they assert global app state (the springboard badge / notification
+  # shade) that a sync left in flight by an earlier scenario could perturb, so
+  # running them here surfaces any accidental cross-scenario coupling rather
+  # than hiding it. resetApp quiesces in-flight sync between scenarios so each
+  # still starts clean.
+
   # iOS-only: the app-icon badge is an iOS-springboard artifact. The Android
-  # notification-dot equivalent is WB-10b, hence @skip-android.
+  # notification-dot equivalent is below, hence @skip-android.
   @skip-android
   Scenario: A logged-in user is nudged to sync via the app-icon badge
     Given I am logged in as "test@example.com"

--- a/walta-app/app/lib/logic/SampleSync.js
+++ b/walta-app/app/lib/logic/SampleSync.js
@@ -18,6 +18,19 @@ function areWeSyncing() {
     return isSyncing;
 }
 
+// Resolve once no sync is in flight (or after timeoutMs as a safety net, so a
+// wedged HTTP can't hang the caller forever). Used by AppReset to let a
+// cancelled sync stop cleanly before the session token is dropped.
+function whenQuiesced(timeoutMs = 10000) {
+    return new Promise(function (resolve) {
+        var start = Date.now();
+        (function poll() {
+            if (!isSyncing || Date.now() - start > timeoutMs) return resolve();
+            setTimeout(poll, 50);
+        })();
+    });
+}
+
 function addListener(cb) {
     syncStore.addListener(cb);
 }
@@ -112,11 +125,19 @@ function init() {
     }
 }
 
-function onLoggedOut() {
-    info("Logged out — cancelling any in-flight sync and stopping the schedule.");
+// Signal any in-flight sync to stop and drop the schedule. Doesn't touch the
+// session — callers that also log out fire LOGGEDOUT separately. AppReset uses
+// this directly so it can quiesce the sync before clearing the token, without
+// flipping the UI to logged-out until reset has finished (see AppReset.js).
+function cancel() {
     cancelled = true;
     clearUploadTimer();
     setFullSyncPending(false);
+}
+
+function onLoggedOut() {
+    info("Logged out — cancelling any in-flight sync and stopping the schedule.");
+    cancel();
 }
 
 // User tapped Sync: a full history sync (download + upload), resumable across interruption.
@@ -266,6 +287,8 @@ exports.countSamplesNeedingUpload = countSamplesNeedingUpload;
 exports.resumeInterruptedWork = resumeInterruptedWork;
 exports.networkChanged = networkChanged;
 exports.areWeSyncing = areWeSyncing;
+exports.whenQuiesced = whenQuiesced;
+exports.cancel = cancel;
 exports.addListener = addListener;
 exports.removeListener = removeListener;
 exports.init = init;

--- a/walta-app/app/lib/util/AppReset.js
+++ b/walta-app/app/lib/util/AppReset.js
@@ -6,19 +6,24 @@
 // (WB-67).
 
 const Topics = require('ui/Topics');
+const SampleSync = require('logic/SampleSync');
 
-function reset() {
-  // Logout — drop the persistent user/app tokens so the next scenario
-  // starts unauthenticated. CerdiApi.storeUserToken handles
-  // userAccessUsername + userAccessTokenLive; appAccessTokenLive is a
-  // separate key.
+async function reset() {
+  // Cancel any in-flight sync and wait for it to actually stop *before*
+  // dropping the token: otherwise a straddling sync's next API call fails
+  // with "Not logged in", stranding a half-downloaded sample that leaks into
+  // the next scenario. We cancel directly rather than via LOGGEDOUT so the
+  // menu doesn't flip to its logged-out state until reset has finished —
+  // that lets the harness poll the logged-out menu as a reliable
+  // "reset complete" signal (features/support/appium-world.js).
+  SampleSync.cancel();
+  await SampleSync.whenQuiesced();
+
+  // Drop the persistent user/app tokens so the next scenario starts
+  // unauthenticated. CerdiApi.storeUserToken handles userAccessUsername +
+  // userAccessTokenLive; appAccessTokenLive is a separate key.
   Alloy.Globals.CerdiApi.storeUserToken(null, null);
   Ti.App.Properties.removeProperty('appAccessTokenLive');
-
-  // Reset is a logout, so announce it — SampleSync cancels any in-flight
-  // sync started against the now-cleared token (WB-103), mirroring the
-  // real logout path in Menu.js.
-  Topics.fireTopicEvent(Topics.LOGGEDOUT, null);
 
   // Wipe the local sample/taxa tables. Same DELETE pattern as
   // walta-app/app/spec/util/TestUtils.clearDatabase.
@@ -38,9 +43,12 @@ function reset() {
   Alloy.Models.instance('sample');
   Alloy.Models.instance('taxa');
 
-  // Topics.HOME → Navigation.openController("Menu") (see Main.js). The
-  // navigation logic truncates the history and fires PAGES_UNLOADED so
-  // intermediate controllers clean themselves up.
+  // Announce the logout last — now that the token is cleared, this flips the
+  // menu to its logged-out state (the harness's reset-complete signal) and
+  // clears the sync-recommended badge. Topics.HOME → openController("Menu")
+  // (see Main.js) truncates history and fires PAGES_UNLOADED so intermediate
+  // controllers clean themselves up.
+  Topics.fireTopicEvent(Topics.LOGGEDOUT, null);
   Topics.fireTopicEvent(Topics.HOME);
 }
 

--- a/walta-app/app/spec/AppReset_spec.js
+++ b/walta-app/app/spec/AppReset_spec.js
@@ -18,12 +18,15 @@ describe("AppReset", function () {
         Alloy.Globals.CerdiApi = savedApi;
     });
 
-    it("fires LOGGEDOUT so subscribers can cancel work tied to the session", function () {
+    // reset() quiesces any in-flight sync before announcing the logout, so it
+    // is async now (WB-116) — LOGGEDOUT fires after the returned promise's
+    // await, hence we await reset() before asserting and unsubscribing.
+    it("fires LOGGEDOUT so subscribers can cancel work tied to the session", async function () {
         var fired = false;
         function onLoggedOut() { fired = true; }
         Topics.subscribe(Topics.LOGGEDOUT, onLoggedOut);
         try {
-            AppReset.reset();
+            await AppReset.reset();
         } finally {
             Topics.unsubscribe(Topics.LOGGEDOUT, onLoggedOut);
         }


### PR DESCRIPTION
## Summary
- The per-scenario `walta://reset` cleared the session token **before** an in-flight sync from the previous scenario had stopped. The straddling sync's next photo download then hit the cleared token (`_requireAccessToken` → "Not logged in") and stranded a half-downloaded sample (serverSyncTime set, photos missing). That stranded sample counts as needing-upload, so the next scenario's app-icon badge read **2** (pending 1 + recommended 1) instead of 1 — flaky on contended CI, green on fast runners and locally. This is what's been reddening main on the iOS acceptance job.
- **Fix:** `SampleSync.cancel()` (direct cancel, no `LOGGEDOUT` broadcast) + `whenQuiesced()`. `AppReset.reset()` now cancels and waits for the sync to actually stop *before* clearing the token, then fires `LOGGEDOUT`/`HOME` **last** — so the logged-out menu is a reliable "reset complete" signal that the harness polls (`~Log In.`) instead of a fixed 500ms sleep, closing the overlap race where the next login's token got nulled by a late-finishing reset.
- Badge assertions restored to **exact counts** (`of 1` / `no badge`): once reset is clean, the nudged login finds nothing to resume → no download → `pending=0` → deterministically 1. The badge scenarios stay **last** in the feature file, on purpose, to keep surfacing any cross-scenario coupling rather than hiding it.

[Trello WB-116](https://trello.com/c/4S049g5t) — diagnosed while cutting a test release after WB-10b (#275) merged. The deeper strand (`SampleDownloader` sets `serverSyncTime` before photos finish) is the production-side WB-101/WB-103 concern, noted on the card and out of scope here.

## Test plan
- [x] `npx grunt unit-test-node` — 201 passing
- [x] `npx grunt --platform=ios --simulator acceptance-test` (sync_samples scenarios) — 4 passed, 22 steps; badge scenarios run last with exact counts
- [ ] Full CI green on main (the real contended-runner check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)