### PR TITLE
WB-117: Disable Bugfender telemetry for development builds (CI + local dev)

### DIFF
--- a/test/Logger_spec.js
+++ b/test/Logger_spec.js
@@ -239,3 +239,24 @@ describe("Logger.configure", function () {
         ]);
     });
 });
+
+describe("Logger.bugfenderEnabled", function () {
+    let Logger;
+
+    beforeEach(function () {
+        delete require.cache[require.resolve("../walta-app/app/lib/util/Logger")];
+        Logger = require("../walta-app/app/lib/util/Logger");
+    });
+
+    it("is disabled for development builds (CI + local dev)", function () {
+        expect(Logger.bugfenderEnabled("development")).to.equal(false);
+    });
+
+    it("is enabled for production builds (store + beta/TestFlight/Play-internal)", function () {
+        expect(Logger.bugfenderEnabled("production")).to.equal(true);
+    });
+
+    it("is enabled for any non-development deployType", function () {
+        expect(Logger.bugfenderEnabled("test")).to.equal(true);
+    });
+});

--- a/walta-app/app/lib/util/Logger.js
+++ b/walta-app/app/lib/util/Logger.js
@@ -62,9 +62,17 @@ function _dispatch(level, facility, message) {
 const LOG_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
 const LOG_MAX_ROWS = 100000;
 
+// Development builds (local dev + CI acceptance emulators/sims) bundle the
+// Bugfender module but shouldn't ship telemetry — it pollutes the dashboard
+// and burns the free-tier log budget. Production covers store + beta builds.
+exports.bugfenderEnabled = function(deployType) {
+    return deployType !== "development";
+};
+
 exports.configure = function() {
     _sinks.push(require("./sinks/ConsoleSink"));
-    const Bugfender = getBugfender();
+    const deployType = (typeof Ti !== 'undefined' && Ti.App) ? Ti.App.deployType : undefined;
+    const Bugfender = exports.bugfenderEnabled(deployType) ? getBugfender() : null;
     _sinks.push(require("./sinks/BugfenderSink").create(Bugfender));
     try {
         if (typeof Ti !== 'undefined' && Ti.Database) {


### PR DESCRIPTION
## Summary
- Bugfender was initialised in `Logger.configure()` whenever the native module resolved — which is every build that bundles it. So CI acceptance runs (iPhone sims + Android emulators) and local dev builds registered fresh Bugfender devices and shipped logs/crashes to the dashboard, polluting it.
- Gate init **and** the `BugfenderSink` instance on a pure `bugfenderEnabled(deployType)` predicate. The build matrix only produces two deployTypes: `development` (debug / `test-sim` CI / local dev) and `production` (release + beta/TestFlight/Play-internal). `production` stays on so beta-tester telemetry is unaffected; `development` is now off.
- Console + SQL sinks remain active in every build.
- Extracted the decision as a pure predicate because the native module is unresolvable under Node, so the init path can't be observed through `configure()` directly — the predicate is the node-testable seam.

First (and likely only) slice of [Trello WB-117](https://trello.com/c/N7CS6v2u/117-disable-bugfender-telemetry-for-development-builds-ci-local-dev) — silence CI/dev Bugfender noise while keeping beta + store telemetry.

## Test plan
- [x] `npx grunt unit-test-node` — passes (204 passing; 3 new `bugfenderEnabled` specs)
- [x] `npx grunt build-test` — passes (164 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)