### PR TITLE
WB-118: Stop mid-sync TableView crash in SampleHistory (throttle reload)

### DIFF
--- a/walta-app/app/controllers/SampleHistory.js
+++ b/walta-app/app/controllers/SampleHistory.js
@@ -12,8 +12,20 @@ $.syncButton.setLabel("Sync");
 $.syncButton.on("click", syncNowClicked);
 acb.addTool( $.syncButton.getView() );
 
-Topics.subscribe( Topics.UPLOAD_PROGRESS, updateSampleList );
+// UPLOAD_PROGRESS fires several times per sample during a sync; reloading the
+// whole list on each tick rebuilds every TableView row and races Titanium's
+// cell cleanup (WB-118 crash). Throttle to coalesce the burst, and take an
+// authoritative reload when the sync finishes. WB-119 replaces this with
+// per-row ViewModel updates.
+var RELOAD_THROTTLE_MS = 1000;
+var closed = false;
+var reloadSampleList = _.throttle( updateSampleList, RELOAD_THROTTLE_MS );
+Topics.subscribe( Topics.UPLOAD_PROGRESS, reloadSampleList );
+Topics.subscribe( Topics.SYNC_FINISHED, updateSampleList );
 $.TopLevelWindow.addEventListener('close', function cleanUp() {
+    closed = true;
+    Topics.unsubscribe( Topics.UPLOAD_PROGRESS, reloadSampleList );
+    Topics.unsubscribe( Topics.SYNC_FINISHED, updateSampleList );
     if ( $.sampleMenu ) {
         $.sampleMenu.cleanUp();
     }
@@ -24,6 +36,7 @@ $.TopLevelWindow.addEventListener('close', function cleanUp() {
 	$.TopLevelWindow.removeEventListener('close', cleanUp );
 });
 function updateSampleList() {
+    if ( closed ) return;
     try {
         $.samples.loadSampleHistory(Alloy.Globals.CerdiApi.retrieveUserId());
     } catch(e) {

--- a/walta-app/app/spec/SampleHistory_spec.js
+++ b/walta-app/app/spec/SampleHistory_spec.js
@@ -59,4 +59,20 @@ describe("SampleHistory controller", function() {
     expect( ctl.syncFeedback ).to.exist;
   });
 
+  it('coalesces a burst of UPLOAD_PROGRESS events into a single reload', async function() {
+    await controllerOpenTest( ctl );
+    var reload = simple.mock( ctl.samples, "loadSampleHistory" );
+    Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: 1 } );
+    Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: 1 } );
+    Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: 1 } );
+    expect( reload.callCount ).to.equal(1);
+  });
+
+  it('refreshes the list once when the sync finishes', async function() {
+    await controllerOpenTest( ctl );
+    var reload = simple.mock( ctl.samples, "loadSampleHistory" );
+    Topics.fireTopicEvent( Topics.SYNC_FINISHED, { success: true } );
+    expect( reload.callCount ).to.equal(1);
+  });
+
 });


### PR DESCRIPTION
## Summary
- **First production crash, caught on Bugfender** (WB-117's sibling reasoning in action): a tester reproduced an `EXC_BAD_ACCESS` (`objc_moveWeak`) twice on an iPad mid-sync. Stack bottoms out in `-[TiUITableViewRowProxy redelegateViews:toView:]` → `firePropertyChanges` → `setFont_:` on a `TiUILabel` whose weak backing ref was torn down — Titanium's TableView cell-reuse losing a race.
- **Trigger was ours:** `SampleHistory` reloaded the whole `$.samples` collection on *every* `UPLOAD_PROGRESS` event, and that fires several times per sample (site photo, each taxa photo, sample record). Each reload re-runs the per-sample `transform()` (taxa DB load + signal-score calc) for every row and does a full TableView `setData()` rebuild — rapid-fire rebuilds racing cell cleanup.
- **Fix:** throttle the progress-driven reload (`_.throttle`, 1s) so a burst coalesces into one, plus an authoritative reload on `SYNC_FINISHED`. Unsubscribe both on window close and guard `updateSampleList` so a trailing throttled call can't touch a torn-down view (also closes a pre-existing UPLOAD_PROGRESS subscription leak).

This is the **tactical** fix — it keeps the existing `TableView` and closes the crash race. The deeper move to per-row `bindView()`/ViewModel updates is tracked separately in [WB-119](https://trello.com/c/GKzjO7ps) (ListView deliberately rejected for UX reasons).

Fixes [Trello WB-118](https://trello.com/c/KfGEQJ8d/118-samplehistory-tableview-crash-objcmoveweak-excbadaccess-during-cell-reuse-mid-sync).

## Test plan
- [x] `npx grunt --platform=ios --simulator unit-test --grep="SampleHistory controller"` (LiveView) — 8 passing; 2 new specs (burst coalesces to one reload; SYNC_FINISHED forces one)
- [x] `npx grunt --platform=android --simulator unit-test` — clean build (no LiveView), 8 passing
- [ ] Manual: sync a multi-sample account on iOS, confirm the list still updates and no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)