### PR TITLE
WB-118: route debug logs to Bugfender for remote crash diagnosis

### DIFF
--- a/docs/patterns/logger-sinks.md
+++ b/docs/patterns/logger-sinks.md
@@ -13,9 +13,13 @@ it (write to console, ship to Bugfender, persist to SQLite, …).
 - **Pluggable persistence.** Adding a new destination (e.g. SQLite for
   surviving background/resume) is a new sink, not another inline branch
   in every `Logger` method.
-- **Per-sink level filter.** `debug` is dev-only noise — it should hit
-  `ConsoleSink` but not be shipped to Bugfender or persisted to SQLite.
-  The level allowlist lives on the sink, not in `Logger`.
+- **Per-sink level filter.** Each sink declares which levels it accepts
+  via its own `levels` allowlist; the allowlist lives on the sink, not in
+  `Logger`. All five levels currently fan out to every sink — including
+  `debug`, which `SqlSink` persists for the diagnostics export and
+  `BugfenderSink` ships remotely so crash breadcrumbs are visible on the
+  dashboard (debug is still suppressed entirely on `development` builds via
+  `bugfenderEnabled`).
 - **Cross-run log visibility.** `SqlSink` writes entries through a
   separate `LogRepository` that persists them across background/resume,
   so the SyncFeedback "Show Logs" pane can query prior-run history via
@@ -69,7 +73,7 @@ Logs" pane); persistence and shipping live in sinks.
 `debug`, `trace`, `info`, `warn`, `error`. All five fan out to every
 registered sink and to every matching subscriber. Sinks narrow with a
 level allowlist; subscribers use `minLevel` to receive everything at
-or above a threshold. Ordering: `debug < trace < info < warn < error`.
+or above a threshold. Ordering: `trace < debug < info < warn < error`.
 
 ## Facility taxonomy
 

--- a/test/util/sinks/BugfenderSink_spec.js
+++ b/test/util/sinks/BugfenderSink_spec.js
@@ -19,9 +19,9 @@ describe("BugfenderSink", function () {
         };
     });
 
-    it("create() returns a sink that lets trace/info/warn/error through (debug excluded as dev-only)", function () {
+    it("create() returns a sink that lets trace/debug/info/warn/error through", function () {
         const sink = BugfenderSink.create(fakeBugfender);
-        expect(sink.levels).to.deep.equal(["trace", "info", "warn", "error"]);
+        expect(sink.levels).to.deep.equal(["trace", "debug", "info", "warn", "error"]);
     });
 
     it("write() returns a Promise", function () {
@@ -63,9 +63,9 @@ describe("BugfenderSink", function () {
         expect(bfCalls).to.have.length(0);
     });
 
-    it("write() is a no-op for debug entries (defensive — dispatcher should filter)", async function () {
+    it("routes debug to Bugfender.d with facility as tag", async function () {
         const sink = BugfenderSink.create(fakeBugfender);
-        await sink.write({ level: "debug", facility: "x", message: "noise" });
-        expect(bfCalls).to.have.length(0);
+        await sink.write({ level: "debug", facility: "sync", message: "needsUpdate: remote newer" });
+        expect(bfCalls).to.deep.equal([{ method: "d", arg: { tag: "sync", message: "needsUpdate: remote newer" } }]);
     });
 });

--- a/walta-app/app/lib/util/sinks/BugfenderSink.js
+++ b/walta-app/app/lib/util/sinks/BugfenderSink.js
@@ -1,5 +1,6 @@
 const LEVEL_TO_METHOD = {
     trace: "t",
+    debug: "d",
     info:  "i",
     warn:  "w",
     error: "e"
@@ -7,7 +8,7 @@ const LEVEL_TO_METHOD = {
 
 exports.create = function (Bugfender) {
     return {
-        levels: ["trace", "info", "warn", "error"],
+        levels: ["trace", "debug", "info", "warn", "error"],
         write: function (entry) {
             if (!Bugfender) return Promise.resolve();
             const method = LEVEL_TO_METHOD[entry.level];


### PR DESCRIPTION
## Summary
- **Why:** the throttle fix shipped in build 2.0.4.30 but the crashes continued — and the two new Bugfender reports (a `KrollBridge::registerProxy` bad-access and a Core Animation commit abort, both during a heavy download sync) carry **no JS-side context**: the native traces show only `main`, and our logs only show network/sync traces. We can't tell which JS path triggered them.
- **Root cause of the blind spot:** the `BugfenderSink` level allowlist omitted `debug`, so every `Logger.debug()` call — used across `SampleDownloader`, `SampleUploader`, `PhotoUtils`, `SampleSync` and most controllers — was dropped before reaching Bugfender. This was a deliberate "dev-only" choice originally; we're reversing it so those breadcrumbs are visible remotely.
- Add `debug` to the allowlist and map it to `Bugfender.d`. Debug stays fully suppressed on `development` builds via `bugfenderEnabled`, so this only adds log volume on production/beta.
- **Drive-by (in scope):** `docs/patterns/logger-sinks.md` had gone stale — it still claimed debug was neither shipped to Bugfender nor persisted to SQLite (WB-111 already added SQLite persistence) and listed the pre-WB-111 inverted `debug < trace` ordering. Both corrected.

Enabling slice of [Trello WB-118](https://trello.com/c/KfGEQJ8d/118-samplehistory-tableview-crash-objcmoveweak-excbadaccess-during-cell-reuse-mid-sync) — this does **not** fix the crash; it makes the next crash diagnosable. The build-2.0.4.30 reports show two *new* signatures (not the original `objc_moveWeak` row-cleanup), and the device logs were dominated by photo-download proxy creation, so the table-rebuild theory is no longer the only suspect. Breadcrumb instrumentation + a low-RAM device repro are the follow-up slices.

## Test plan
- [x] `npx grunt unit-test-node` — passes (204 passing; BugfenderSink specs updated RED→GREEN)
- [ ] No UI/build change — device/simulator visual checks N/A
- [ ] Remote verification: confirm `debug`-level lines appear on the Bugfender dashboard from a test-release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)