### PR TITLE
WB-118: memory-warning breadcrumb + dev-gated memory ballast

### DIFF
--- a/docs/patterns/logger-sinks.md
+++ b/docs/patterns/logger-sinks.md
@@ -13,9 +13,13 @@ it (write to console, ship to Bugfender, persist to SQLite, …).
 - **Pluggable persistence.** Adding a new destination (e.g. SQLite for
   surviving background/resume) is a new sink, not another inline branch
   in every `Logger` method.
-- **Per-sink level filter.** `debug` is dev-only noise — it should hit
-  `ConsoleSink` but not be shipped to Bugfender or persisted to SQLite.
-  The level allowlist lives on the sink, not in `Logger`.
+- **Per-sink level filter.** Each sink declares which levels it accepts
+  via its own `levels` allowlist; the allowlist lives on the sink, not in
+  `Logger`. All five levels currently fan out to every sink — including
+  `debug`, which `SqlSink` persists for the diagnostics export and
+  `BugfenderSink` ships remotely so crash breadcrumbs are visible on the
+  dashboard (debug is still suppressed entirely on `development` builds via
+  `bugfenderEnabled`).
 - **Cross-run log visibility.** `SqlSink` writes entries through a
   separate `LogRepository` that persists them across background/resume,
   so the SyncFeedback "Show Logs" pane can query prior-run history via
@@ -69,7 +73,7 @@ Logs" pane); persistence and shipping live in sinks.
 `debug`, `trace`, `info`, `warn`, `error`. All five fan out to every
 registered sink and to every matching subscriber. Sinks narrow with a
 level allowlist; subscribers use `minLevel` to receive everything at
-or above a threshold. Ordering: `debug < trace < info < warn < error`.
+or above a threshold. Ordering: `trace < debug < info < warn < error`.
 
 ## Facility taxonomy
 

--- a/test/UrlActions_spec.js
+++ b/test/UrlActions_spec.js
@@ -3,110 +3,79 @@ const { expect } = require("chai");
 const sinon = require("sinon");
 const UrlActions = require("../walta-app/app/lib/UrlActions");
 
-describe("UrlActions", function () {
-  let cerdiApi, onLoggedIn, actions;
+describe("UrlActions.create (generic dispatcher)", function () {
+  it("invokes the named action's handler with the parsed params", function () {
+    const handler = sinon.stub();
+    UrlActions.create({ greet: handler }).dispatch("walta://greet?name=ada");
+    expect(handler.calledOnceWith({ name: "ada" })).to.equal(true);
+  });
 
+  it("decodes percent-encoded params (e.g. @ and spaces)", function () {
+    const handler = sinon.stub();
+    UrlActions.create({ login: handler }).dispatch("walta://login?email=a%40b.c&password=p%20w");
+    expect(handler.calledOnceWith({ email: "a@b.c", password: "p w" })).to.equal(true);
+  });
+
+  it("returns the handler's result so callers can await it", async function () {
+    const { dispatch } = UrlActions.create({ go: () => Promise.resolve("done") });
+    expect(await dispatch("walta://go")).to.equal("done");
+  });
+
+  it("ignores non-walta schemes", function () {
+    const handler = sinon.stub();
+    const result = UrlActions.create({ login: handler }).dispatch("https://example.com/login?x=1");
+    expect(handler.notCalled).to.equal(true);
+    expect(result).to.equal(undefined);
+  });
+
+  it("ignores unknown action names", function () {
+    expect(UrlActions.create({}).dispatch("walta://nope?foo=bar")).to.equal(undefined);
+  });
+
+  it("ignores malformed / null input without throwing", function () {
+    const { dispatch } = UrlActions.create({});
+    expect(() => dispatch("not a url at all")).to.not.throw();
+    expect(() => dispatch(null)).to.not.throw();
+    expect(() => dispatch(undefined)).to.not.throw();
+  });
+});
+
+describe("UrlActions.buildActions (declarative catalog)", function () {
+  let cerdiApi, onLoggedIn, appReset, setBallast;
   beforeEach(function () {
-    cerdiApi = { loginUser: sinon.stub().resolves({ accessToken: "tok" }) };
+    cerdiApi = { loginUser: sinon.stub().resolves({ accessToken: "tok" }), serverUrl: "x" };
     onLoggedIn = sinon.stub();
-    actions = UrlActions.create({ cerdiApi, onLoggedIn });
+    appReset = sinon.stub();
+    setBallast = sinon.stub();
   });
 
-  describe("dispatch(login)", function () {
-    it("calls loginUser with the email and password from the URL", async function () {
-      await actions.dispatch("walta://login?email=a@b.c&password=p");
-      expect(cerdiApi.loginUser.calledOnce).to.be.true;
-      expect(cerdiApi.loginUser.firstCall.args).to.deep.equal(["a@b.c", "p"]);
-    });
-
-    it("fires the onLoggedIn callback after the login promise resolves", async function () {
-      await actions.dispatch("walta://login?email=a@b.c&password=p");
-      expect(onLoggedIn.calledOnce).to.be.true;
-      expect(onLoggedIn.calledAfter(cerdiApi.loginUser)).to.be.true;
-    });
-
-    it("decodes percent-encoded params (e.g. @ in the email)", async function () {
-      await actions.dispatch("walta://login?email=a%40b.c&password=p%20w");
-      expect(cerdiApi.loginUser.firstCall.args).to.deep.equal(["a@b.c", "p w"]);
-    });
-
-    it("does not fire onLoggedIn when login rejects", async function () {
-      cerdiApi.loginUser = sinon.stub().rejects(new Error("bad creds"));
-      const promise = actions.dispatch("walta://login?email=a@b.c&password=wrong");
-      await promise.catch(() => {}); // swallow — we just want to inspect side-effects
-      expect(onLoggedIn.called).to.be.false;
-    });
+  it("login calls loginUser with the credentials and fires onLoggedIn after it resolves", async function () {
+    const actions = UrlActions.buildActions({ cerdiApi, onLoggedIn });
+    await actions.login({ email: "a@b.c", password: "p" });
+    expect(cerdiApi.loginUser.calledOnceWith("a@b.c", "p")).to.equal(true);
+    expect(onLoggedIn.calledOnce).to.equal(true);
   });
 
-  describe("dispatch(ballast)", function () {
-    // Dev-only WB-118 repro knob — gated behind a setBallast callback that
-    // index-app.js only supplies on non-production builds, like reset.
-    it("registers the ballast action and calls setBallast with the parsed mb", async function () {
-      const setBallast = sinon.stub();
-      const withBallast = UrlActions.create({ cerdiApi, onLoggedIn, setBallast });
-      await withBallast.dispatch("walta://ballast?mb=256");
-      expect(setBallast.calledOnceWith(256)).to.equal(true);
-    });
-
-    it("does not register the ballast action without a setBallast callback", function () {
-      expect(actions.dispatch("walta://ballast?mb=256")).to.equal(undefined);
-    });
+  it("login does not fire onLoggedIn when loginUser rejects", async function () {
+    cerdiApi.loginUser = sinon.stub().rejects(new Error("bad creds"));
+    const actions = UrlActions.buildActions({ cerdiApi, onLoggedIn });
+    try { await actions.login({ email: "a@b.c", password: "p" }); } catch (e) { /* expected */ }
+    expect(onLoggedIn.notCalled).to.equal(true);
   });
 
-  describe("dispatch (invalid input)", function () {
-    it("ignores non-walta schemes", function () {
-      const result = actions.dispatch("https://example.com/login?email=a@b.c");
-      expect(result).to.be.undefined;
-      expect(cerdiApi.loginUser.called).to.be.false;
-    });
-
-    it("ignores unknown action names", function () {
-      const result = actions.dispatch("walta://nope?foo=bar");
-      expect(result).to.be.undefined;
-      expect(cerdiApi.loginUser.called).to.be.false;
-    });
-
-    it("ignores malformed URLs without throwing", function () {
-      expect(() => actions.dispatch("not a url at all")).to.not.throw();
-      expect(cerdiApi.loginUser.called).to.be.false;
-    });
-
-    it("ignores null/undefined input", function () {
-      expect(() => actions.dispatch(null)).to.not.throw();
-      expect(() => actions.dispatch(undefined)).to.not.throw();
-    });
+  // reset (wipe) and ballast (balloon memory) are dev-only — a release build
+  // must never expose them to a stray URL. Gated on allowDev.
+  it("omits reset and ballast when allowDev is false", function () {
+    const actions = UrlActions.buildActions({ cerdiApi, onLoggedIn, appReset, setBallast, allowDev: false });
+    expect(actions.reset).to.equal(undefined);
+    expect(actions.ballast).to.equal(undefined);
   });
 
-  describe("registry", function () {
-    it("exposes the action registry so future actions can be registered", function () {
-      expect(actions.actions.login).to.exist;
-      expect(actions.actions.login.params).to.deep.equal(["email", "password"]);
-      expect(actions.actions.login.handler).to.be.a("function");
-    });
-  });
-
-  describe("dispatch(reset)", function () {
-    // The reset action is the cucumber Before-hook fast path — replaces a
-    // slow `terminateApp + launch + poll` cycle. Production builds must not
-    // register it (a stray walta://reset URL must not wipe user data), so
-    // the action is gated behind an `appReset` callback that index-app.js
-    // only passes in non-production builds.
-    it("registers the reset action and invokes appReset when called", async function () {
-      const appReset = sinon.stub();
-      const withReset = UrlActions.create({ cerdiApi, onLoggedIn, appReset });
-      expect(withReset.actions.reset).to.exist;
-      expect(withReset.actions.reset.params).to.deep.equal([]);
-      await withReset.dispatch("walta://reset");
-      expect(appReset.calledOnce).to.be.true;
-    });
-
-    it("omits the reset action when no appReset callback is provided", function () {
-      // production-build safety: if index-app.js doesn't pass appReset
-      // (because Ti.App.deployType === 'production'), the action is absent
-      // from the registry and a walta://reset URL is silently ignored.
-      expect(actions.actions.reset).to.be.undefined;
-      const result = actions.dispatch("walta://reset");
-      expect(result).to.be.undefined;
-    });
+  it("includes reset and ballast when allowDev is true", async function () {
+    const actions = UrlActions.buildActions({ cerdiApi, onLoggedIn, appReset, setBallast, allowDev: true });
+    await actions.reset();
+    expect(appReset.calledOnce).to.equal(true);
+    await actions.ballast({ mb: "256" });
+    expect(setBallast.calledOnceWith(256)).to.equal(true);
   });
 });

--- a/test/UrlActions_spec.js
+++ b/test/UrlActions_spec.js
@@ -38,6 +38,21 @@ describe("UrlActions", function () {
     });
   });
 
+  describe("dispatch(ballast)", function () {
+    // Dev-only WB-118 repro knob — gated behind a setBallast callback that
+    // index-app.js only supplies on non-production builds, like reset.
+    it("registers the ballast action and calls setBallast with the parsed mb", async function () {
+      const setBallast = sinon.stub();
+      const withBallast = UrlActions.create({ cerdiApi, onLoggedIn, setBallast });
+      await withBallast.dispatch("walta://ballast?mb=256");
+      expect(setBallast.calledOnceWith(256)).to.equal(true);
+    });
+
+    it("does not register the ballast action without a setBallast callback", function () {
+      expect(actions.dispatch("walta://ballast?mb=256")).to.equal(undefined);
+    });
+  });
+
   describe("dispatch (invalid input)", function () {
     it("ignores non-walta schemes", function () {
       const result = actions.dispatch("https://example.com/login?email=a@b.c");

--- a/test/UrlActions_spec.js
+++ b/test/UrlActions_spec.js
@@ -3,37 +3,40 @@ const { expect } = require("chai");
 const sinon = require("sinon");
 const UrlActions = require("../walta-app/app/lib/UrlActions");
 
-describe("UrlActions.create (generic dispatcher)", function () {
-  it("invokes the named action's handler with the parsed params", function () {
-    const handler = sinon.stub();
-    UrlActions.create({ greet: handler }).dispatch("walta://greet?name=ada");
-    expect(handler.calledOnceWith({ name: "ada" })).to.equal(true);
+describe("UrlActions.create (deeplink dispatch)", function () {
+  const MemoryBallast = require("util/MemoryBallast");
+  let cerdiApi;
+  beforeEach(function () {
+    cerdiApi = { loginUser: sinon.stub().resolves({ accessToken: "tok" }), serverUrl: "x" };
+    global.Alloy = { Events: { trigger: sinon.stub() } };
+  });
+  afterEach(function () {
+    delete global.Alloy;
+    MemoryBallast.deflate();
   });
 
-  it("decodes percent-encoded params (e.g. @ and spaces)", function () {
-    const handler = sinon.stub();
-    UrlActions.create({ login: handler }).dispatch("walta://login?email=a%40b.c&password=p%20w");
-    expect(handler.calledOnceWith({ email: "a@b.c", password: "p w" })).to.equal(true);
+  it("routes a walta:// url to the matching action with percent-decoded params", function () {
+    UrlActions.create({ cerdiApi }).dispatch("walta://login?email=a%40b.c&password=p%20w");
+    expect(cerdiApi.loginUser.calledOnceWith("a@b.c", "p w")).to.equal(true);
   });
 
-  it("returns the handler's result so callers can await it", async function () {
-    const { dispatch } = UrlActions.create({ go: () => Promise.resolve("done") });
-    expect(await dispatch("walta://go")).to.equal("done");
+  it("returns the handler's result so callers can await it", function () {
+    const result = UrlActions.create({ cerdiApi, allowDev: true }).dispatch("walta://ballast?mb=1");
+    expect(result).to.equal(1 * 1024 * 1024);
   });
 
   it("ignores non-walta schemes", function () {
-    const handler = sinon.stub();
-    const result = UrlActions.create({ login: handler }).dispatch("https://example.com/login?x=1");
-    expect(handler.notCalled).to.equal(true);
+    const result = UrlActions.create({ cerdiApi }).dispatch("https://example.com/login?email=a%40b.c");
+    expect(cerdiApi.loginUser.notCalled).to.equal(true);
     expect(result).to.equal(undefined);
   });
 
   it("ignores unknown action names", function () {
-    expect(UrlActions.create({}).dispatch("walta://nope?foo=bar")).to.equal(undefined);
+    expect(UrlActions.create({ cerdiApi }).dispatch("walta://nope?foo=bar")).to.equal(undefined);
   });
 
   it("ignores malformed / null input without throwing", function () {
-    const { dispatch } = UrlActions.create({});
+    const { dispatch } = UrlActions.create({ cerdiApi });
     expect(() => dispatch("not a url at all")).to.not.throw();
     expect(() => dispatch(null)).to.not.throw();
     expect(() => dispatch(undefined)).to.not.throw();

--- a/test/UrlActions_spec.js
+++ b/test/UrlActions_spec.js
@@ -41,41 +41,50 @@ describe("UrlActions.create (generic dispatcher)", function () {
 });
 
 describe("UrlActions.buildActions (declarative catalog)", function () {
-  let cerdiApi, onLoggedIn, appReset, setBallast;
+  const MemoryBallast = require("util/MemoryBallast");
+  let cerdiApi;
   beforeEach(function () {
     cerdiApi = { loginUser: sinon.stub().resolves({ accessToken: "tok" }), serverUrl: "x" };
-    onLoggedIn = sinon.stub();
-    appReset = sinon.stub();
-    setBallast = sinon.stub();
+    // Topics fires through Alloy.Events; shim the framework bus so the real
+    // Topics module (ours) runs unmocked.
+    global.Alloy = { Events: { trigger: sinon.stub() } };
+  });
+  afterEach(function () {
+    delete global.Alloy;
+    MemoryBallast.deflate();
   });
 
-  it("login calls loginUser with the credentials and fires onLoggedIn after it resolves", async function () {
-    const actions = UrlActions.buildActions({ cerdiApi, onLoggedIn });
+  it("login calls loginUser with the credentials and fires the LOGGEDIN topic after it resolves", async function () {
+    const actions = UrlActions.buildActions({ cerdiApi });
     await actions.login({ email: "a@b.c", password: "p" });
     expect(cerdiApi.loginUser.calledOnceWith("a@b.c", "p")).to.equal(true);
-    expect(onLoggedIn.calledOnce).to.equal(true);
+    expect(global.Alloy.Events.trigger.calledOnceWith("waterbug:loggedin")).to.equal(true);
   });
 
-  it("login does not fire onLoggedIn when loginUser rejects", async function () {
+  it("login does not fire LOGGEDIN when loginUser rejects", async function () {
     cerdiApi.loginUser = sinon.stub().rejects(new Error("bad creds"));
-    const actions = UrlActions.buildActions({ cerdiApi, onLoggedIn });
+    const actions = UrlActions.buildActions({ cerdiApi });
     try { await actions.login({ email: "a@b.c", password: "p" }); } catch (e) { /* expected */ }
-    expect(onLoggedIn.notCalled).to.equal(true);
+    expect(global.Alloy.Events.trigger.notCalled).to.equal(true);
   });
 
   // reset (wipe) and ballast (balloon memory) are dev-only — a release build
   // must never expose them to a stray URL. Gated on allowDev.
   it("omits reset and ballast when allowDev is false", function () {
-    const actions = UrlActions.buildActions({ cerdiApi, onLoggedIn, appReset, setBallast, allowDev: false });
+    const actions = UrlActions.buildActions({ cerdiApi, allowDev: false });
     expect(actions.reset).to.equal(undefined);
     expect(actions.ballast).to.equal(undefined);
   });
 
-  it("includes reset and ballast when allowDev is true", async function () {
-    const actions = UrlActions.buildActions({ cerdiApi, onLoggedIn, appReset, setBallast, allowDev: true });
-    await actions.reset();
-    expect(appReset.calledOnce).to.equal(true);
-    await actions.ballast({ mb: "256" });
-    expect(setBallast.calledOnceWith(256)).to.equal(true);
+  it("exposes reset and ballast when allowDev is true", function () {
+    const actions = UrlActions.buildActions({ cerdiApi, allowDev: true });
+    expect(actions.reset).to.be.a("function");
+    expect(actions.ballast).to.be.a("function");
+  });
+
+  it("ballast inflates the real MemoryBallast buffer to the requested size", async function () {
+    const actions = UrlActions.buildActions({ cerdiApi, allowDev: true });
+    await actions.ballast({ mb: "1" });
+    expect(MemoryBallast.heldBytes()).to.equal(1 * 1024 * 1024);
   });
 });

--- a/test/util/MemoryBallast_spec.js
+++ b/test/util/MemoryBallast_spec.js
@@ -1,0 +1,29 @@
+require("mocha");
+const { expect } = require("chai");
+
+// Dev-only WB-118 repro aid: hold a buffer to consume RAM and induce iOS
+// memory warnings on devices with more headroom than the crashing 3 GB iPad.
+const MemoryBallast = require("../../walta-app/app/lib/util/MemoryBallast");
+
+describe("MemoryBallast", function () {
+    afterEach(function () { MemoryBallast.deflate(); });
+
+    it("holds the requested number of mebibytes", function () {
+        const held = MemoryBallast.inflate(8);
+        expect(held).to.equal(8 * 1024 * 1024);
+        expect(MemoryBallast.heldBytes()).to.equal(8 * 1024 * 1024);
+    });
+
+    it("holds nothing for a zero or negative request", function () {
+        expect(MemoryBallast.inflate(0)).to.equal(0);
+        expect(MemoryBallast.heldBytes()).to.equal(0);
+        expect(MemoryBallast.inflate(-5)).to.equal(0);
+        expect(MemoryBallast.heldBytes()).to.equal(0);
+    });
+
+    it("releases what it holds on deflate()", function () {
+        MemoryBallast.inflate(4);
+        MemoryBallast.deflate();
+        expect(MemoryBallast.heldBytes()).to.equal(0);
+    });
+});

--- a/test/util/MemoryMonitor_spec.js
+++ b/test/util/MemoryMonitor_spec.js
@@ -1,0 +1,43 @@
+require("mocha");
+const { expect } = require("chai");
+
+// MemoryMonitor logs iOS memory warnings at warn level so they reach Bugfender —
+// the suspected trigger for the WB-118 proxy-purge crash family. Socialised test:
+// real Logger + a capturing subscriber; only Ti.App (the IO boundary) is faked.
+const Logger = require("../../walta-app/app/lib/util/Logger");
+const MemoryMonitor = require("../../walta-app/app/lib/util/MemoryMonitor");
+
+describe("MemoryMonitor", function () {
+    function fakeApp() {
+        const listeners = {};
+        return {
+            addEventListener(name, cb) { (listeners[name] = listeners[name] || []).push(cb); },
+            removeEventListener(name, cb) { listeners[name] = (listeners[name] || []).filter(f => f !== cb); },
+            fire(name) { (listeners[name] || []).slice().forEach(f => f()); }
+        };
+    }
+
+    let captured, unsubscribe;
+    beforeEach(function () {
+        captured = [];
+        unsubscribe = Logger.subscribe({ facility: "memory" }, e => captured.push(e));
+    });
+    afterEach(function () { unsubscribe(); });
+
+    it("logs a warn-level 'memory' breadcrumb when iOS fires a memorywarning", function () {
+        const app = fakeApp();
+        const dispose = MemoryMonitor.start(app);
+        app.fire("memorywarning");
+        dispose();
+        expect(captured).to.have.length(1);
+        expect(captured[0]).to.include({ level: "warn", facility: "memory" });
+    });
+
+    it("stops logging after dispose()", function () {
+        const app = fakeApp();
+        const dispose = MemoryMonitor.start(app);
+        dispose();
+        app.fire("memorywarning");
+        expect(captured).to.have.length(0);
+    });
+});

--- a/test/util/sinks/BugfenderSink_spec.js
+++ b/test/util/sinks/BugfenderSink_spec.js
@@ -19,9 +19,9 @@ describe("BugfenderSink", function () {
         };
     });
 
-    it("create() returns a sink that lets trace/info/warn/error through (debug excluded as dev-only)", function () {
+    it("create() returns a sink that lets trace/debug/info/warn/error through", function () {
         const sink = BugfenderSink.create(fakeBugfender);
-        expect(sink.levels).to.deep.equal(["trace", "info", "warn", "error"]);
+        expect(sink.levels).to.deep.equal(["trace", "debug", "info", "warn", "error"]);
     });
 
     it("write() returns a Promise", function () {
@@ -63,9 +63,9 @@ describe("BugfenderSink", function () {
         expect(bfCalls).to.have.length(0);
     });
 
-    it("write() is a no-op for debug entries (defensive — dispatcher should filter)", async function () {
+    it("routes debug to Bugfender.d with facility as tag", async function () {
         const sink = BugfenderSink.create(fakeBugfender);
-        await sink.write({ level: "debug", facility: "x", message: "noise" });
-        expect(bfCalls).to.have.length(0);
+        await sink.write({ level: "debug", facility: "sync", message: "needsUpdate: remote newer" });
+        expect(bfCalls).to.deep.equal([{ method: "d", arg: { tag: "sync", message: "needsUpdate: remote newer" } }]);
     });
 });

--- a/walta-app/app/controllers/index-app.js
+++ b/walta-app/app/controllers/index-app.js
@@ -9,9 +9,7 @@ var UploadBadge = require("logic/UploadBadge");
 var AndroidNotificationBadge = require("logic/AndroidNotificationBadge");
 var PlatformSpecific = require("logic/PlatformSpecific");
 var UrlActions = require("UrlActions");
-var AppReset = require("util/AppReset");
 var MemoryMonitor = require("util/MemoryMonitor");
-var MemoryBallast = require("util/MemoryBallast");
 var { System } = require("logic/System");
 var { View } = require("logic/View");
 var { Survey } = require("logic/Survey");
@@ -32,12 +30,6 @@ Alloy.Globals.CerdiApi = CerdiApi.createCerdiApi( Alloy.CFG.cerdiServerUrl, Allo
 // or memory-ballooned by a stray URL.
 var urlActions = UrlActions.create(UrlActions.buildActions({
   cerdiApi: Alloy.Globals.CerdiApi,
-  onLoggedIn: function () { Topics.fireTopicEvent(Topics.LOGGEDIN); },
-  appReset: AppReset.reset,
-  setBallast: function (mb) {
-    MemoryBallast.inflate(mb);
-    log(`memory ballast: holding ${mb} MB to induce pressure`);
-  },
   allowDev: Ti.App.deployType !== 'production',
 }));
 function handleDeeplink(url) {

--- a/walta-app/app/controllers/index-app.js
+++ b/walta-app/app/controllers/index-app.js
@@ -35,6 +35,12 @@ var urlActions = UrlActions.create({
   cerdiApi: Alloy.Globals.CerdiApi,
   onLoggedIn: function () { Topics.fireTopicEvent(Topics.LOGGEDIN); },
   appReset: Ti.App.deployType !== 'production' ? AppReset.reset : undefined,
+  // walta://ballast?mb=N — dev-only WB-118 repro knob. Fire it before
+  // walta://login so the login-triggered sync runs under memory pressure.
+  setBallast: Ti.App.deployType !== 'production' ? function (mb) {
+    MemoryBallast.inflate(mb);
+    log(`memory ballast: holding ${mb} MB to induce pressure`);
+  } : undefined,
 });
 function handleDeeplink(url) {
   log(`[walta-deeplink] dispatch url=${url}`);
@@ -73,17 +79,6 @@ SampleSync.init();
 // racing in-flight JS proxy creation. Android has no equivalent Ti event.
 if (OS_IOS) {
   MemoryMonitor.start(Ti.App);
-}
-
-// Dev-only WB-118 repro knob: set the `memoryBallastMb` property and relaunch
-// to consume RAM and force memory warnings on a device with more headroom than
-// the 3 GB iPad. Never on production builds.
-if (Ti.App.deployType !== 'production') {
-  var ballastMb = Ti.App.Properties.getInt('memoryBallastMb', 0);
-  if (ballastMb > 0) {
-    MemoryBallast.inflate(ballastMb);
-    log(`memory ballast: holding ${ballastMb} MB to induce pressure`);
-  }
 }
 
 // App-icon "sync recommended" indicator (WB-10). iOS sets the numeric

--- a/walta-app/app/controllers/index-app.js
+++ b/walta-app/app/controllers/index-app.js
@@ -11,6 +11,7 @@ var PlatformSpecific = require("logic/PlatformSpecific");
 var UrlActions = require("UrlActions");
 var AppReset = require("util/AppReset");
 var MemoryMonitor = require("util/MemoryMonitor");
+var MemoryBallast = require("util/MemoryBallast");
 var { System } = require("logic/System");
 var { View } = require("logic/View");
 var { Survey } = require("logic/Survey");
@@ -72,6 +73,17 @@ SampleSync.init();
 // racing in-flight JS proxy creation. Android has no equivalent Ti event.
 if (OS_IOS) {
   MemoryMonitor.start(Ti.App);
+}
+
+// Dev-only WB-118 repro knob: set the `memoryBallastMb` property and relaunch
+// to consume RAM and force memory warnings on a device with more headroom than
+// the 3 GB iPad. Never on production builds.
+if (Ti.App.deployType !== 'production') {
+  var ballastMb = Ti.App.Properties.getInt('memoryBallastMb', 0);
+  if (ballastMb > 0) {
+    MemoryBallast.inflate(ballastMb);
+    log(`memory ballast: holding ${ballastMb} MB to induce pressure`);
+  }
 }
 
 // App-icon "sync recommended" indicator (WB-10). iOS sets the numeric

--- a/walta-app/app/controllers/index-app.js
+++ b/walta-app/app/controllers/index-app.js
@@ -22,16 +22,15 @@ DiagnosticsBundle.subscribe();
 // FIXME: deprecate using globals
 Alloy.Globals.CerdiApi = CerdiApi.createCerdiApi( Alloy.CFG.cerdiServerUrl, Alloy.CFG.cerdiApiSecret );
 
-// `walta://` URL scheme dispatcher — the action catalog lives in
-// UrlActions.buildActions(). Acceptance tests use
+// `walta://` URL scheme dispatcher. Acceptance tests use
 // `walta://login?email=...&password=...` to bypass the login UI. The dev-only
 // actions (`walta://reset` cucumber fast-path WB-67; `walta://ballast?mb=N`
 // WB-118 repro knob) are gated by allowDev so a release build can't be wiped
 // or memory-ballooned by a stray URL.
-var urlActions = UrlActions.create(UrlActions.buildActions({
+var urlActions = UrlActions.create({
   cerdiApi: Alloy.Globals.CerdiApi,
   allowDev: Ti.App.deployType !== 'production',
-}));
+});
 function handleDeeplink(url) {
   log(`[walta-deeplink] dispatch url=${url}`);
   Promise.resolve(urlActions.dispatch(url))

--- a/walta-app/app/controllers/index-app.js
+++ b/walta-app/app/controllers/index-app.js
@@ -24,24 +24,22 @@ DiagnosticsBundle.subscribe();
 // FIXME: deprecate using globals
 Alloy.Globals.CerdiApi = CerdiApi.createCerdiApi( Alloy.CFG.cerdiServerUrl, Alloy.CFG.cerdiApiSecret );
 
-// `walta://` URL scheme dispatcher — see UrlActions.js for the action
-// registry. Acceptance tests use `walta://login?email=...&password=...`
-// to bypass the login UI; the same surface is available in production.
-//
-// `walta://reset` (cucumber Before-hook fast path) is registered only in
-// non-production builds (WB-67) — release builds must not be wiped by a
-// stray reset URL.
-var urlActions = UrlActions.create({
+// `walta://` URL scheme dispatcher — the action catalog lives in
+// UrlActions.buildActions(). Acceptance tests use
+// `walta://login?email=...&password=...` to bypass the login UI. The dev-only
+// actions (`walta://reset` cucumber fast-path WB-67; `walta://ballast?mb=N`
+// WB-118 repro knob) are gated by allowDev so a release build can't be wiped
+// or memory-ballooned by a stray URL.
+var urlActions = UrlActions.create(UrlActions.buildActions({
   cerdiApi: Alloy.Globals.CerdiApi,
   onLoggedIn: function () { Topics.fireTopicEvent(Topics.LOGGEDIN); },
-  appReset: Ti.App.deployType !== 'production' ? AppReset.reset : undefined,
-  // walta://ballast?mb=N — dev-only WB-118 repro knob. Fire it before
-  // walta://login so the login-triggered sync runs under memory pressure.
-  setBallast: Ti.App.deployType !== 'production' ? function (mb) {
+  appReset: AppReset.reset,
+  setBallast: function (mb) {
     MemoryBallast.inflate(mb);
     log(`memory ballast: holding ${mb} MB to induce pressure`);
-  } : undefined,
-});
+  },
+  allowDev: Ti.App.deployType !== 'production',
+}));
 function handleDeeplink(url) {
   log(`[walta-deeplink] dispatch url=${url}`);
   Promise.resolve(urlActions.dispatch(url))

--- a/walta-app/app/controllers/index-app.js
+++ b/walta-app/app/controllers/index-app.js
@@ -10,6 +10,7 @@ var AndroidNotificationBadge = require("logic/AndroidNotificationBadge");
 var PlatformSpecific = require("logic/PlatformSpecific");
 var UrlActions = require("UrlActions");
 var AppReset = require("util/AppReset");
+var MemoryMonitor = require("util/MemoryMonitor");
 var { System } = require("logic/System");
 var { View } = require("logic/View");
 var { Survey } = require("logic/Survey");
@@ -66,6 +67,12 @@ if (OS_IOS) {
 }
 
 SampleSync.init();
+
+// Log iOS memory warnings (WB-118): the SDK purges proxies on a warning,
+// racing in-flight JS proxy creation. Android has no equivalent Ti event.
+if (OS_IOS) {
+  MemoryMonitor.start(Ti.App);
+}
 
 // App-icon "sync recommended" indicator (WB-10). iOS sets the numeric
 // appBadge; Android has no numeric badge, so it drives a notification-dot

--- a/walta-app/app/lib/UrlActions.js
+++ b/walta-app/app/lib/UrlActions.js
@@ -1,4 +1,4 @@
-function create({ cerdiApi, onLoggedIn, appReset }) {
+function create({ cerdiApi, onLoggedIn, appReset, setBallast }) {
   const actions = {
     login: {
       params: ["email", "password"],
@@ -27,6 +27,17 @@ function create({ cerdiApi, onLoggedIn, appReset }) {
     actions.reset = {
       params: [],
       handler: () => Promise.resolve(appReset()),
+    };
+  }
+
+  // walta://ballast?mb=<N> — dev-only WB-118 repro knob. Like reset, only
+  // registered when index-app.js supplies a setBallast callback (non-production
+  // builds), so a release build ignores the URL and can never balloon its own
+  // memory. Session-only: inflates now, does not persist.
+  if (setBallast) {
+    actions.ballast = {
+      params: ["mb"],
+      handler: ({ mb }) => Promise.resolve(setBallast(parseInt(mb, 10) || 0)),
     };
   }
 

--- a/walta-app/app/lib/UrlActions.js
+++ b/walta-app/app/lib/UrlActions.js
@@ -1,50 +1,12 @@
-function create({ cerdiApi, onLoggedIn, appReset, setBallast }) {
-  const actions = {
-    login: {
-      params: ["email", "password"],
-      handler: ({ email, password }) => {
-        if (typeof Ti !== 'undefined') {
-          Ti.API.debug(`[walta-deeplink] login handler: serverUrl=${cerdiApi.serverUrl} email=${email}`);
-        }
-        return cerdiApi.loginUser(email, password)
-          .then((resp) => {
-            if (typeof Ti !== 'undefined') Ti.API.debug(`[walta-deeplink] login resolved`);
-            return onLoggedIn();
-          })
-          .catch((err) => {
-            if (typeof Ti !== 'undefined') Ti.API.error(`[walta-deeplink] login failed: ${err && err.message}`);
-            throw err;
-          });
-      }
-    }
-  };
-
-  // walta://reset — cucumber Before-hook fast path. Only registered when
-  // an appReset callback is supplied (i.e. non-production builds), so a
-  // release build silently ignores walta://reset URLs and can't have its
-  // user data wiped by a stray deeplink.
-  if (appReset) {
-    actions.reset = {
-      params: [],
-      handler: () => Promise.resolve(appReset()),
-    };
-  }
-
-  // walta://ballast?mb=<N> — dev-only WB-118 repro knob. Like reset, only
-  // registered when index-app.js supplies a setBallast callback (non-production
-  // builds), so a release build ignores the URL and can never balloon its own
-  // memory. Session-only: inflates now, does not persist.
-  if (setBallast) {
-    actions.ballast = {
-      params: ["mb"],
-      handler: ({ mb }) => Promise.resolve(setBallast(parseInt(mb, 10) || 0)),
-    };
-  }
-
+// Generic walta:// deeplink dispatcher. It knows nothing about specific
+// actions — it parses walta://<name>?k=v&k=v and calls the matching handler
+// with the parsed params. The action catalog is declared once in
+// buildActions(); adding an action touches only that catalog, not this
+// dispatch mechanism. index-app.js wires the two together.
+function create(actions) {
+  // Manual parser — Titanium 13.x's V8 doesn't expose the WHATWG URL
+  // constructor in the JS runtime, so `new URL(...)` throws.
   function parse(url) {
-    // Manual parser — Titanium 13.x's V8 doesn't expose the WHATWG URL
-    // constructor in the JS runtime, so `new URL(...)` throws and the
-    // dispatch silently returns. Format: walta://<action>?k=v&k=v
     const m = String(url || "").match(/^walta:\/\/([^/?#]+)(?:\?([^#]*))?/);
     if (!m) return null;
     const params = {};
@@ -60,14 +22,42 @@ function create({ cerdiApi, onLoggedIn, appReset, setBallast }) {
   function dispatch(url) {
     const parsed = parse(url);
     if (!parsed) return;
-    const action = actions[parsed.name];
-    if (!action) return;
-    const args = {};
-    action.params.forEach(k => { args[k] = parsed.params[k]; });
-    return action.handler(args);
+    const handler = actions[parsed.name];
+    if (!handler) return;
+    return handler(parsed.params);
   }
 
   return { dispatch, actions };
 }
 
-module.exports = { create };
+// The declarative action catalog. Dev-only actions (reset wipes user data,
+// ballast balloons memory for WB-118 repro) are included only when allowDev —
+// index-app passes deployType !== 'production' — so a release build can never
+// be wiped or memory-ballooned by a stray walta:// URL.
+function buildActions({ cerdiApi, onLoggedIn, appReset, setBallast, allowDev }) {
+  const actions = {
+    login: ({ email, password }) => {
+      if (typeof Ti !== 'undefined') {
+        Ti.API.debug(`[walta-deeplink] login handler: serverUrl=${cerdiApi.serverUrl} email=${email}`);
+      }
+      return cerdiApi.loginUser(email, password)
+        .then(() => {
+          if (typeof Ti !== 'undefined') Ti.API.debug(`[walta-deeplink] login resolved`);
+          return onLoggedIn();
+        })
+        .catch((err) => {
+          if (typeof Ti !== 'undefined') Ti.API.error(`[walta-deeplink] login failed: ${err && err.message}`);
+          throw err;
+        });
+    },
+  };
+
+  if (allowDev) {
+    actions.reset = () => Promise.resolve(appReset());
+    actions.ballast = ({ mb }) => Promise.resolve(setBallast(parseInt(mb, 10) || 0));
+  }
+
+  return actions;
+}
+
+module.exports = { create, buildActions };

--- a/walta-app/app/lib/UrlActions.js
+++ b/walta-app/app/lib/UrlActions.js
@@ -4,27 +4,27 @@ const MemoryBallast = require("util/MemoryBallast");
 const Logger = require("util/Logger");
 const log = (m) => Logger.log(m, "navigation");
 
-// Generic walta:// deeplink dispatcher. It knows nothing about specific
-// actions — it parses walta://<name>?k=v&k=v and calls the matching handler
-// with the parsed params. The action catalog is declared once in
-// buildActions(); adding an action touches only that catalog, not this
-// dispatch mechanism. index-app.js wires the two together.
-function create(actions) {
-  // Manual parser — Titanium 13.x's V8 doesn't expose the WHATWG URL
-  // constructor in the JS runtime, so `new URL(...)` throws.
-  function parse(url) {
-    const m = String(url || "").match(/^walta:\/\/([^/?#]+)(?:\?([^#]*))?/);
-    if (!m) return null;
-    const params = {};
-    (m[2] || "").split("&").filter(Boolean).forEach(pair => {
-      const eq = pair.indexOf("=");
-      const k = eq === -1 ? pair : pair.slice(0, eq);
-      const v = eq === -1 ? "" : pair.slice(eq + 1);
-      params[decodeURIComponent(k)] = decodeURIComponent(v);
-    });
-    return { name: m[1], params };
-  }
+// Manual parser — Titanium 13.x's V8 doesn't expose the WHATWG URL
+// constructor in the JS runtime, so `new URL(...)` throws.
+function parse(url) {
+  const m = String(url || "").match(/^walta:\/\/([^/?#]+)(?:\?([^#]*))?/);
+  if (!m) return null;
+  const params = {};
+  (m[2] || "").split("&").filter(Boolean).forEach(pair => {
+    const eq = pair.indexOf("=");
+    const k = eq === -1 ? pair : pair.slice(0, eq);
+    const v = eq === -1 ? "" : pair.slice(eq + 1);
+    params[decodeURIComponent(k)] = decodeURIComponent(v);
+  });
+  return { name: m[1], params };
+}
 
+// Build a walta:// deeplink dispatcher for the given boundaries. The dispatch
+// mechanism (parse walta://<name>?k=v and route to the matching handler) and
+// the action catalog are composed here, so the caller wires one thing:
+// `UrlActions.create({ cerdiApi, allowDev }).dispatch(url)`.
+function create(deps) {
+  const actions = buildActions(deps);
   function dispatch(url) {
     const parsed = parse(url);
     if (!parsed) return;
@@ -32,8 +32,7 @@ function create(actions) {
     if (!handler) return;
     return handler(parsed.params);
   }
-
-  return { dispatch, actions };
+  return { dispatch };
 }
 
 // The declarative action catalog. cerdiApi (network) and allowDev (a Ti

--- a/walta-app/app/lib/UrlActions.js
+++ b/walta-app/app/lib/UrlActions.js
@@ -1,3 +1,9 @@
+const Topics = require("ui/Topics");
+const AppReset = require("util/AppReset");
+const MemoryBallast = require("util/MemoryBallast");
+const Logger = require("util/Logger");
+const log = (m) => Logger.log(m, "navigation");
+
 // Generic walta:// deeplink dispatcher. It knows nothing about specific
 // actions — it parses walta://<name>?k=v&k=v and calls the matching handler
 // with the parsed params. The action catalog is declared once in
@@ -30,11 +36,14 @@ function create(actions) {
   return { dispatch, actions };
 }
 
-// The declarative action catalog. Dev-only actions (reset wipes user data,
-// ballast balloons memory for WB-118 repro) are included only when allowDev —
-// index-app passes deployType !== 'production' — so a release build can never
-// be wiped or memory-ballooned by a stray walta:// URL.
-function buildActions({ cerdiApi, onLoggedIn, appReset, setBallast, allowDev }) {
+// The declarative action catalog. cerdiApi (network) and allowDev (a Ti
+// deployType value) are the only true boundaries index-app must supply;
+// everything else is a collaborator this module owns and calls directly.
+// Dev-only actions (reset wipes user data, ballast balloons memory for WB-118
+// repro) are included only when allowDev — index-app passes
+// deployType !== 'production' — so a release build can never be wiped or
+// memory-ballooned by a stray walta:// URL.
+function buildActions({ cerdiApi, allowDev }) {
   const actions = {
     login: ({ email, password }) => {
       if (typeof Ti !== 'undefined') {
@@ -43,7 +52,7 @@ function buildActions({ cerdiApi, onLoggedIn, appReset, setBallast, allowDev }) 
       return cerdiApi.loginUser(email, password)
         .then(() => {
           if (typeof Ti !== 'undefined') Ti.API.debug(`[walta-deeplink] login resolved`);
-          return onLoggedIn();
+          Topics.fireTopicEvent(Topics.LOGGEDIN);
         })
         .catch((err) => {
           if (typeof Ti !== 'undefined') Ti.API.error(`[walta-deeplink] login failed: ${err && err.message}`);
@@ -53,8 +62,12 @@ function buildActions({ cerdiApi, onLoggedIn, appReset, setBallast, allowDev }) 
   };
 
   if (allowDev) {
-    actions.reset = () => Promise.resolve(appReset());
-    actions.ballast = ({ mb }) => Promise.resolve(setBallast(parseInt(mb, 10) || 0));
+    actions.reset = () => AppReset.reset();
+    actions.ballast = ({ mb }) => {
+      const held = MemoryBallast.inflate(parseInt(mb, 10) || 0);
+      log(`memory ballast: holding ${mb} MB to induce pressure`);
+      return held;
+    };
   }
 
   return actions;

--- a/walta-app/app/lib/logic/Navigation.js
+++ b/walta-app/app/lib/logic/Navigation.js
@@ -2,20 +2,6 @@ var Topics = require("ui/Topics");
 var { DialogCancelled } = require("logic/View");
 const Logger = require('util/Logger');
 const log = (m, tag = "navigation") => Logger.log(m, tag);
-const debug = (m, tag = "navigation") => Logger.debug(m, tag);
-
-function questionToString(args) {
-    if (!args || !args.node || !args.node.questions)
-        return "";
-    return `[0]= ${args.node.questions[0].text} [1]= ${args.node.questions[1].text}`;
-}
-
-function dumpHistory(history) {
-    debug("\ndump history:\n");
-    history.forEach((obj, i) => {
-        debug(`${i}: ${obj.ctl} ${obj.args.slide} ${(obj.args.node && obj.args.node.id) ? obj.args.node.id : "(no id)"} ${questionToString(obj.args)}`)
-    });
-}
 
 function Navigation(services) {
     this.history = [];
@@ -102,7 +88,7 @@ Navigation.prototype.openController = async function (ctl, args) {
             await this.garbageCollectControllers(page);
 
             this.history.push(page);
-            dumpHistory(this.history);
+            log(`opening controller ="${ctl}" with args.slide="${args.slide}"`);
             await this.onOpenView(ctl, args);
         } catch( err ) {
             // do nothing if dialog is aborted
@@ -129,7 +115,6 @@ Navigation.prototype.goBack = async function (args) {
                 newargs.slide = "left";
             }
         }
-        log(`opening controller (on back) ="${ctl}" with args.slide="${newargs.slide}"`);
         await this.openController(ctl, newargs);
 
     }

--- a/walta-app/app/lib/util/MemoryBallast.js
+++ b/walta-app/app/lib/util/MemoryBallast.js
@@ -1,0 +1,22 @@
+// Dev-only WB-118 repro aid (gated in index-app on deployType !== 'production').
+// Holds a buffer to consume RAM and provoke iOS memory warnings on devices with
+// more headroom than the 3 GB iPad that crashes. Tune up until warnings appear
+// WITHOUT an immediate jetsam — an OOM-kill is a clean SIGKILL, a different
+// signature from the proxy-purge race we're chasing.
+let _held = null;
+
+const PAGE = 4096;
+
+exports.inflate = function (megabytes) {
+    const mb = Math.max(0, Math.floor(megabytes));
+    if (mb === 0) { _held = null; return 0; }
+    _held = new Uint8Array(mb * 1024 * 1024);
+    // Touch one byte per page so iOS counts the pages as resident rather than
+    // lazily reserving them — otherwise the ballast never pressures memory.
+    for (let i = 0; i < _held.length; i += PAGE) _held[i] = 1;
+    return _held.length;
+};
+
+exports.deflate = function () { _held = null; };
+
+exports.heldBytes = function () { return _held ? _held.length : 0; };

--- a/walta-app/app/lib/util/MemoryMonitor.js
+++ b/walta-app/app/lib/util/MemoryMonitor.js
@@ -1,0 +1,16 @@
+const Logger = require('util/Logger');
+
+// iOS memory warnings trigger Titanium's KrollBridge/TableView-row proxy purge,
+// which races in-flight JS proxy creation — the suspected WB-118 crash trigger.
+// Log at warn so the breadcrumb reaches Bugfender (debug routing landed in #281).
+exports.start = function (app) {
+    let count = 0;
+    function onWarning() {
+        count += 1;
+        Logger.warn(`iOS memory warning #${count}`, "memory");
+    }
+    app.addEventListener("memorywarning", onWarning);
+    return function dispose() {
+        app.removeEventListener("memorywarning", onWarning);
+    };
+};

--- a/walta-app/app/lib/util/sinks/BugfenderSink.js
+++ b/walta-app/app/lib/util/sinks/BugfenderSink.js
@@ -1,5 +1,6 @@
 const LEVEL_TO_METHOD = {
     trace: "t",
+    debug: "d",
     info:  "i",
     warn:  "w",
     error: "e"
@@ -7,7 +8,7 @@ const LEVEL_TO_METHOD = {
 
 exports.create = function (Bugfender) {
     return {
-        levels: ["trace", "info", "warn", "error"],
+        levels: ["trace", "debug", "info", "warn", "error"],
         write: function (entry) {
             if (!Bugfender) return Promise.resolve();
             const method = LEVEL_TO_METHOD[entry.level];

--- a/walta-app/app/spec/Navigation_spec.js
+++ b/walta-app/app/spec/Navigation_spec.js
@@ -3,6 +3,7 @@ var { expect } = require("spec/lib/chai");
 var simple = require("spec/lib/simple-mock");
 var { closeWindow, controllerOpenTest } = require("spec/util/TestUtils");
 var { Navigation } = require('logic/Navigation');
+var Logger = require('util/Logger');
 describe("logic/Navigation service", function() {
   let services = {
     Key: {},
@@ -29,6 +30,18 @@ describe("logic/Navigation service", function() {
     simple.restore();
     simple.mock(services.View, "askDiscardEdits").resolveWith("discard");
   });
+  it('logs a navigation breadcrumb naming the opened controller', async function() {
+    var captured = [];
+    var unsubscribe = Logger.subscribe({ facility: "navigation" }, e => captured.push(e));
+    try {
+      let nav = new Navigation(services);
+      await nav.openController("SiteDetails");
+      expect(captured.some(e => e.message.indexOf("SiteDetails") >= 0)).to.equal(true);
+    } finally {
+      unsubscribe();
+    }
+  });
+
   it('should not ask to discard when tranistion to SiteDetails',async function() {
     let nav = new Navigation(services);
     


### PR DESCRIPTION
## Summary
Diagnostic instrumentation + repro tooling for [Trello WB-118](https://trello.com/c/KfGEQJ8d/118-samplehistory-tableview-crash-objcmoveweak-excbadaccess-during-cell-reuse-mid-sync). **Not** the crash fix (that stays WB-119, per-row ViewModel). **Stacked on #281** (debug→Bugfender routing); base retargets to `main` once #281 merges.

**Why now:** the build-2.0.4.30 crashes (`KrollBridge::registerProxy` bad-access; a Core Animation commit abort) hit mid heavy download sync on a 3 GB iPad with no JS context. SDK source shows a concrete trigger: on an iOS memory warning the SDK **purges proxies** (`KrollBridge registerForMemoryWarning`, `TiUITableViewRowProxy didReceiveMemoryWarning`), racing in-flight JS proxy creation. So memory pressure is a *directed* suspect.

- **MemoryMonitor** — logs `Ti.App`'s iOS `memorywarning` at **warn** level (facility `memory`) so it reaches Bugfender. IO-injected, node-tested. iOS-only.
- **MemoryBallast** — dev-only repro aid: `inflate(mb)` holds a page-touched (resident) buffer to provoke memory warnings on a device with more headroom than the crashing iPad. Node-tested.
- **`walta://ballast?mb=N`** — sets the ballast; gated to non-production. Session-only (no persist) so a too-aggressive value can't crash-loop. Repro: fire `walta://ballast?mb=512` then `walta://login?email=hh@hh.hh&...`.
- **Navigation breadcrumb** — `openController` logs one clean trace-level `opening controller` line per navigation, naming the foreground screen. Replaces `dumpHistory` (whole-stack debug dump), removed with its dead `questionToString` helper.
- **UrlActions refactor** (in scope — we were already touching actions): `create(actions)` is now a generic dispatcher; `buildActions(deps)` is the single declarative catalog. Adding a `walta://` action touches one place, not two; dev gating moved to an `allowDev` flag and is node-tested. Behaviour preserved.

## Test plan
- [x] `npx grunt unit-test-node` — 208 passing (MemoryMonitor, MemoryBallast, UrlActions create + buildActions)
- [x] `npx grunt --platform=ios --simulator unit-test --grep="logic/Navigation service"` — 8 passing
- [ ] CI acceptance — exercises `walta://login` + `walta://reset`, validates the refactored dispatch end-to-end
- [ ] On-device smoke: `memory` warn + `navigation` breadcrumbs on Bugfender under real pressure
- [ ] SE 2nd-gen repro: `walta://ballast?mb=N` then login on `hh@hh.hh`, large sync, watch for the crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)