### PR TITLE
WB-130: add NSLocationAlwaysAndWhenInUseUsageDescription purpose string

### DIFF
--- a/walta-app/tiapp.xml.template
+++ b/walta-app/tiapp.xml.template
@@ -43,6 +43,10 @@
         <string>
             We need to record the location of the waterbody survey.
         </string>
+        <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+        <string>
+            We need to record the location of the waterbody survey.
+        </string>
         <key>NSPhotoLibraryUsageDescription</key>
         <string>
             To allow attaching photos to samples and sites.


### PR DESCRIPTION
## Summary
- App Store Connect raised non-blocking warning **ITMS-90683** on builds 2.0.4.24 and 2.0.4.31: the bundle is missing an `NSLocationAlwaysAndWhenInUseUsageDescription` purpose string. A bundled SDK references the always-authorization location API, so Apple requires the string even though the app only requests when-in-use location (recording the survey waterbody location).
- Added the key to the iOS plist in `walta-app/tiapp.xml.template`, mirroring the existing when-in-use purpose string. The committed `tiapp.xml` is gitignored and regenerated from the template at build time by `injectSecrets()`, so the template is the only source to change.

Fixes [Trello WB-130](https://trello.com/c/hnIeNlfd/130-app-store-warning-itms-90683-add-nslocationalwaysandwheninuseusagedescription-purpose-string) — clears the ITMS-90683 location purpose-string warning.

## Test plan
- [ ] `npx grunt --platform=ios debug` builds with the regenerated `tiapp.xml` containing both location keys
- [ ] Next iOS upload to App Store Connect / TestFlight no longer raises ITMS-90683 for the location key

> No automated test layer covers Info.plist metadata; the binding verification is the App Store Connect upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)