### PR TITLE
Forbid external identifiers in source comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ Before writing or editing code, consult [docs/coding-style.md](docs/coding-style
 
 **Comments: default to none.** Add one only for a non-obvious *why* — a hidden constraint, a workaround for a specific bug, an invariant the surrounding code can't convey — and keep it to a single line. Never narrate the change you're making, recap the bug you just fixed, or replay hypotheses you explored: that belongs in the commit message and PR description, which don't rot. If a block seems to need a paragraph, restructure the code or move the explanation to `docs/`. When in doubt, leave it out.
 
+**Comments must be self-contained.** Don't reference Trello card numbers (`WB-XXX`), PR numbers, GitHub issues, or anything else that lives outside the repo. Those identifiers belong in commit messages and PR descriptions — in a comment they couple the source to an external system that will rot, churn, or disappear, and a reader can't understand the comment without leaving the codebase. If the *why* needs more than the surrounding code can convey, write it so a future reader can grasp it from the comment alone.
+
 ## Methodology
 
 This project follows test-driven development (Kent Beck style): each behavioural change starts with a small failing test, then the minimal code to make it pass, then a tidy-up pass. Work in small increments and prefer small commits focused on a single change. The point is to drive design with tests and refactor continuously so tech debt doesn't accumulate — coverage is a byproduct of good tests, not the target.

--- a/docs/coding-style.md
+++ b/docs/coding-style.md
@@ -30,6 +30,7 @@ A few rules of thumb regardless of length:
 1. Don't paraphrase what the code already says.
 2. Don't narrate the change you're making — that context belongs in the commit message. Commits don't rot; source comments do.
 3. Don't recap the bug you just fixed for the same reason.
+4. Keep comments self-contained — no references to Trello cards (`WB-XXX`), PR numbers, GitHub issues, or any other external identifier. External coordinates rot, churn, or disappear; a comment that requires a reader to leave the codebase to make sense of it has already failed. Put that context in the commit message and PR description.
 
 ### Long comments belong in `docs/`
 


### PR DESCRIPTION
## Summary
- Add a rule to `CLAUDE.md` and `docs/coding-style.md` forbidding source comments that reference Trello cards (`WB-XXX`), PR numbers, or GitHub issue numbers. Those identifiers belong in commit messages and PR descriptions — in a comment they couple the source to an external system that rots, and a reader can't grasp the intent without leaving the codebase.
- Drive-by source-comment style fix triggered by review feedback on #285 (the WB-119 SampleHistory ViewModel) where I'd written `// WB-119: emit a final progress tick so ...` style comments. Splitting it out per the project's "One PR = one responsibility" rule.

## Test plan
- [x] N/A — docs only