### PR TITLE
WB-133: CucumberLauncher — apply WB-49 fix (direct appium binary + 300s timeout)

### DIFF
--- a/build-tests/unit/CucumberLauncher_spec.js
+++ b/build-tests/unit/CucumberLauncher_spec.js
@@ -80,7 +80,7 @@ describe("CucumberLauncher", function() {
       await promise;
 
       expect(fakeSpawn.calledTwice).to.be.true;
-      expect(fakeSpawn.firstCall.args[1]).to.include("appium");
+      expect(fakeSpawn.firstCall.args[0]).to.match(/appium$/);
       expect(fakeSpawn.secondCall.args[1]).to.include("cucumber-js");
     });
 
@@ -109,6 +109,51 @@ describe("CucumberLauncher", function() {
       expect(appiumArgs).to.include("./appium.log");
       expect(appiumArgs).to.include("--log-level");
       expect(appiumArgs).to.include("info:debug");
+    });
+
+    // npx resolution adds ~8 min cold-start latency on macOS-15 runners
+    // (see WB-49). Spawn the directly-resolved binary instead.
+    it("spawns the direct appium binary, not npx", async function() {
+      fakeIsRunning.onFirstCall().resolves(false);
+      fakeIsRunning.onSecondCall().resolves(true);
+
+      const appiumChild = makeFakeChild();
+      const cucumberChild = makeFakeChild();
+      fakeSpawn.onFirstCall().returns(appiumChild);
+      fakeSpawn.onSecondCall().returns(cucumberChild);
+
+      const launcher = new CucumberLauncher({
+        spawn: fakeSpawn,
+        isAppiumRunning: fakeIsRunning,
+      });
+      const promise = launcher.run();
+      await exitAfterSpawn(fakeSpawn, 1, 0);
+      await promise;
+
+      const cmd = fakeSpawn.firstCall.args[0];
+      expect(cmd).to.not.equal("npx");
+      expect(cmd).to.match(/node_modules\/\.bin\/appium$/);
+    });
+
+    // The previous hard-coded 30s ceiling fired before macOS-15 CI runners
+    // could even cold-start Appium. Mirror AppiumLauncher's configurable
+    // serverStartTimeoutMs (default 300s) so the message names the real value.
+    it("throws after the configured serverStartTimeoutMs with the message naming the value", async function() {
+      fakeIsRunning.resolves(false);
+
+      const appiumChild = makeFakeChild();
+      fakeSpawn.returns(appiumChild);
+
+      const launcher = new CucumberLauncher({
+        spawn: fakeSpawn,
+        isAppiumRunning: fakeIsRunning,
+        serverStartTimeoutMs: 100,
+      });
+
+      let caught;
+      try { await launcher.run(); } catch (e) { caught = e; }
+      expect(caught, "expected timeout error").to.exist;
+      expect(caught.message).to.match(/Appium server failed to start within 0\.1s/);
     });
 
     it("stops the server after cucumber exits if we started it", async function() {

--- a/build-utils/CucumberLauncher.js
+++ b/build-utils/CucumberLauncher.js
@@ -1,5 +1,12 @@
 import { spawn as defaultSpawn } from "child_process";
+import path from "path";
+import { fileURLToPath } from "url";
 import { isAppiumRunning as defaultIsAppiumRunning } from "./AppiumLauncher.js";
+
+// Direct binary path — npx resolution adds ~8 min cold-start latency on
+// macOS-15 CI runners.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_APPIUM_BIN = path.resolve(__dirname, "..", "node_modules", ".bin", "appium");
 
 // BSD sysexits.h — "temporary failure, indicating something that is not
 // really an error... the request should be reattempted later." Used to
@@ -19,6 +26,7 @@ class CucumberLauncher {
   constructor({
     tags = "not @skip", name = null, appiumOptions = {}, spawn = defaultSpawn,
     isAppiumRunning = defaultIsAppiumRunning, killProcess = null,
+    appiumBin = DEFAULT_APPIUM_BIN, serverStartTimeoutMs = 300_000,
   } = {}) {
     this._tags = tags;
     this._name = name;
@@ -28,6 +36,8 @@ class CucumberLauncher {
     this._killProcess = killProcess || ((pid) => {
       try { process.kill(-pid, 'SIGTERM'); } catch (e) { /* already gone */ }
     });
+    this._appiumBin = appiumBin;
+    this._serverStartTimeoutMs = serverStartTimeoutMs;
     this._serverPid = null;
   }
 
@@ -36,18 +46,20 @@ class CucumberLauncher {
     // Log to a file at debug so the WDA/xcode trace (showXcodeLog) survives —
     // stdio is ignored, so without --log the appium output is lost and a hung
     // driver command can't be pinpointed. failure-diagnostics captures the file.
-    const child = this._spawn('npx', ['appium', '--log', './appium.log', '--log-level', 'info:debug'], {
+    const child = this._spawn(this._appiumBin, ['--log', './appium.log', '--log-level', 'info:debug'], {
       stdio: 'ignore',
       detached: true,
     });
     child.unref();
     this._serverPid = child.pid;
 
-    for (let i = 0; i < 60; i++) {
-      await new Promise(r => setTimeout(r, 500));
+    const pollIntervalMs = 500;
+    const maxAttempts = Math.max(1, Math.ceil(this._serverStartTimeoutMs / pollIntervalMs));
+    for (let i = 0; i < maxAttempts; i++) {
+      await new Promise(r => setTimeout(r, pollIntervalMs));
       if (await this._isAppiumRunning()) return;
     }
-    throw new Error('Appium server failed to start within 30s');
+    throw new Error(`Appium server failed to start within ${this._serverStartTimeoutMs / 1000}s`);
   }
 
   _stopServer() {


### PR DESCRIPTION
## Summary

- Mirrors the [WB-49](https://trello.com/c/fg6XvpJ4) fix into `CucumberLauncher` (the acceptance-test path it missed).
- Replaces `npx appium` spawn with the directly-resolved `node_modules/.bin/appium` to skip ~8 min of macOS-15 npx cold-start overhead.
- Makes the polling timeout configurable via constructor (`serverStartTimeoutMs`, default 300_000 ms) — matches `AppiumLauncher`'s contract.
- Error message now derives from the configured value so it names the real timeout, not a stale literal.

Re-surfaced during the WB-119 release on 2026-05-28: iOS acceptance on main failed with `Appium server failed to start within 30s` 44 s into the cucumber task — exact same failure mode WB-49 was supposed to close.

Trello: [WB-133](https://trello.com/c/1igIcjak)

## Test plan

- [x] `npx grunt build-test` — 167 passing locally; new spec assertions:
  - spawns the direct appium binary, not `npx`
  - throws after the configured `serverStartTimeoutMs` with the message naming the value
- [ ] CI: full `ci.yml` run green on this branch
- [ ] Post-merge: WB-119 release re-attempt no longer trips the 30 s ceiling

🤖 Generated with [Claude Code](https://claude.com/claude-code)