### PR TITLE
WB-131: SampleDownloader: client-side retry/backoff for transient 429 + 5xx

### DIFF
--- a/test/fixtures/tiFakes.js
+++ b/test/fixtures/tiFakes.js
@@ -1,0 +1,64 @@
+function makeScriptedHTTPClient(scripted, attempts = []) {
+    return function (params) {
+        return {
+            _headers: {},
+            onload: params.onload,
+            onerror: params.onerror,
+            open(method, url) { this._method = method; this._url = url; },
+            setRequestHeader(name, value) { this._headers[name] = value; },
+            getResponseHeader(name) { return (this._responseHeaders || {})[name]; },
+            send() {
+                const next = scripted.shift();
+                if (!next) throw new Error("No scripted response left");
+                attempts.push({ method: this._method, url: this._url, headers: { ...this._headers } });
+                this.status = next.status;
+                this.responseText = next.body;
+                this.responseData = Buffer.from(next.body || '');
+                this._responseHeaders = next.headers || {};
+                setImmediate(() => {
+                    if (next.status >= 400) this.onerror.call(this, {});
+                    else this.onload.call(this);
+                });
+            }
+        };
+    };
+}
+
+function makeFakeProps(initial = {}) {
+    const store = new Map(Object.entries(initial));
+    return {
+        getObject(name) { return store.get(name); },
+        setObject(name, value) { store.set(name, value); },
+        hasProperty(name) { return store.has(name); },
+        clear() { store.clear(); },
+    };
+}
+
+function installFakeTi({ httpClient, props, filesystem } = {}) {
+    global.Ti = {
+        Network: {
+            NETWORK_NONE: 0,
+            createHTTPClient: httpClient || (() => ({})),
+        },
+        App: {
+            Properties: props || makeFakeProps(),
+        },
+        API: { info() {}, error() {}, warn() {}, debug() {} },
+        Filesystem: filesystem || {
+            getFile: () => ({ exists: () => false }),
+            resourcesDirectory: "/tmp/r",
+            applicationDataDirectory: "/tmp/d",
+        },
+    };
+}
+
+function uninstallFakeTi() {
+    delete global.Ti;
+}
+
+module.exports = {
+    makeScriptedHTTPClient,
+    makeFakeProps,
+    installFakeTi,
+    uninstallFakeTi,
+};

--- a/test/logic/CerdiApi_retry_spec.js
+++ b/test/logic/CerdiApi_retry_spec.js
@@ -1,0 +1,85 @@
+require("mocha");
+const { expect } = require("chai");
+const {
+    makeScriptedHTTPClient,
+    makeFakeProps,
+    installFakeTi,
+    uninstallFakeTi,
+} = require("../fixtures/tiFakes");
+
+const FAST_RETRY = { baseDelayMs: 0, jitter: false, sleep: () => Promise.resolve() };
+
+describe("CerdiApi: 429/5xx retry", function () {
+    let CerdiApi;
+    let scripted;
+    let attempts;
+
+    beforeEach(function () {
+        scripted = [];
+        attempts = [];
+        installFakeTi({
+            httpClient: makeScriptedHTTPClient(scripted, attempts),
+            props: makeFakeProps({ userAccessTokenLive: { accessToken: 'fake-token' } }),
+        });
+        delete require.cache[require.resolve("../../walta-app/app/lib/logic/CerdiApi")];
+        CerdiApi = require("../../walta-app/app/lib/logic/CerdiApi");
+    });
+
+    afterEach(uninstallFakeTi);
+
+    it("retries a 429 response and resolves with the eventual 200 body", async function () {
+        scripted.push(
+            { status: 429, body: '{"message":"Too Many Attempts."}', headers: { 'Retry-After': '1' } },
+            { status: 200, body: '[]' },
+        );
+        const cerdi = CerdiApi.createCerdiApi("http://test.example", "secret", { retry: FAST_RETRY });
+        const result = await cerdi.retrieveSamples();
+        expect(result).to.deep.equal([]);
+        expect(attempts).to.have.length(2);
+    });
+
+    it("retries on 5xx and resolves with the eventual 200 body", async function () {
+        scripted.push(
+            { status: 503, body: 'Service Unavailable' },
+            { status: 200, body: '[]' },
+        );
+        const cerdi = CerdiApi.createCerdiApi("http://test.example", "secret", { retry: FAST_RETRY });
+        const result = await cerdi.retrieveSamples();
+        expect(result).to.deep.equal([]);
+        expect(attempts).to.have.length(2);
+    });
+
+    it("does not retry on 401", async function () {
+        scripted.push({ status: 401, body: '{"message":"Unauthenticated."}' });
+        const cerdi = CerdiApi.createCerdiApi("http://test.example", "secret", { retry: FAST_RETRY });
+        let rejected = null;
+        try {
+            await cerdi.retrieveSamples();
+        } catch (err) {
+            rejected = err;
+        }
+        expect(rejected).to.deep.equal({ message: "Unauthenticated." });
+        expect(attempts).to.have.length(1);
+    });
+
+    it("truncates multi-KB HTML error bodies in the network trace log", async function () {
+        const Logger = require("../../walta-app/app/lib/util/Logger");
+        const captured = [];
+        const unsub = Logger.subscribe({ facility: 'network' }, (e) => captured.push(e));
+        try {
+            const html = '<html><body>' + 'x'.repeat(5000) + '</body></html>';
+            scripted.push(
+                { status: 429, body: html },
+                { status: 200, body: '[]' },
+            );
+            const cerdi = CerdiApi.createCerdiApi("http://test.example", "secret", { retry: FAST_RETRY });
+            await cerdi.retrieveSamples();
+        } finally {
+            unsub();
+        }
+        const errLine = captured.find((e) => / ERROR /.test(e.message));
+        expect(errLine, "expected a network ERROR line").to.exist;
+        expect(errLine.message).to.include('truncated');
+        expect(errLine.message.length).to.be.lessThan(1000);
+    });
+});

--- a/test/util/PromiseUtils_spec.js
+++ b/test/util/PromiseUtils_spec.js
@@ -1,0 +1,142 @@
+require("mocha");
+const { expect } = require("chai");
+const { withRetry } = require("../../walta-app/app/lib/util/PromiseUtils");
+
+const immediateSleep = () => Promise.resolve();
+
+describe("PromiseUtils.withRetry", function () {
+    it("returns the value when fn resolves first try", async function () {
+        let calls = 0;
+        const result = await withRetry(async () => { calls++; return "ok"; }, {
+            maxRetries: 3,
+            isRetryable: () => true,
+            sleep: immediateSleep,
+        });
+        expect(result).to.equal("ok");
+        expect(calls).to.equal(1);
+    });
+
+    it("retries until fn resolves and returns the eventual value", async function () {
+        let calls = 0;
+        const result = await withRetry(async () => {
+            calls++;
+            if (calls < 3) throw { status: 429 };
+            return "ok";
+        }, {
+            maxRetries: 3,
+            isRetryable: () => true,
+            sleep: immediateSleep,
+        });
+        expect(result).to.equal("ok");
+        expect(calls).to.equal(3);
+    });
+
+    it("throws the last error when retries are exhausted", async function () {
+        let calls = 0;
+        let thrown = null;
+        try {
+            await withRetry(async () => {
+                calls++;
+                throw { status: 429, attempt: calls };
+            }, {
+                maxRetries: 3,
+                isRetryable: () => true,
+                sleep: immediateSleep,
+            });
+        } catch (err) {
+            thrown = err;
+        }
+        expect(calls).to.equal(4);
+        expect(thrown).to.deep.equal({ status: 429, attempt: 4 });
+    });
+
+    it("does not retry when isRetryable returns false", async function () {
+        let calls = 0;
+        let thrown = null;
+        try {
+            await withRetry(async () => {
+                calls++;
+                throw { status: 401 };
+            }, {
+                maxRetries: 3,
+                isRetryable: (err) => err.status === 429,
+                sleep: immediateSleep,
+            });
+        } catch (err) {
+            thrown = err;
+        }
+        expect(calls).to.equal(1);
+        expect(thrown).to.deep.equal({ status: 401 });
+    });
+
+    it("sleeps for an exponentially growing delay between attempts", async function () {
+        const slept = [];
+        const sleep = async (ms) => { slept.push(ms); };
+        let calls = 0;
+        await withRetry(async () => {
+            calls++;
+            if (calls < 4) throw { status: 429 };
+            return "ok";
+        }, {
+            maxRetries: 3,
+            isRetryable: () => true,
+            baseDelayMs: 1000,
+            sleep,
+        });
+        expect(slept).to.deep.equal([1000, 2000, 4000]);
+    });
+
+    it("caps the delay at capDelayMs", async function () {
+        const slept = [];
+        const sleep = async (ms) => { slept.push(ms); };
+        let calls = 0;
+        await withRetry(async () => {
+            calls++;
+            if (calls < 5) throw { status: 429 };
+            return "ok";
+        }, {
+            maxRetries: 4,
+            isRetryable: () => true,
+            baseDelayMs: 1000,
+            capDelayMs: 3000,
+            sleep,
+        });
+        expect(slept).to.deep.equal([1000, 2000, 3000, 3000]);
+    });
+
+    it("honours err.retryAfterMs in place of the computed backoff", async function () {
+        const slept = [];
+        const sleep = async (ms) => { slept.push(ms); };
+        let calls = 0;
+        await withRetry(async () => {
+            calls++;
+            if (calls === 1) throw { status: 429, retryAfterMs: 7000 };
+            return "ok";
+        }, {
+            maxRetries: 1,
+            isRetryable: () => true,
+            baseDelayMs: 1000,
+            sleep,
+        });
+        expect(slept).to.deep.equal([7000]);
+    });
+
+    it("adds up-to-25% jitter when jitter is enabled", async function () {
+        const slept = [];
+        const sleep = async (ms) => { slept.push(ms); };
+        let calls = 0;
+        await withRetry(async () => {
+            calls++;
+            if (calls < 4) throw { status: 429 };
+            return "ok";
+        }, {
+            maxRetries: 3,
+            isRetryable: () => true,
+            baseDelayMs: 1000,
+            jitter: true,
+            random: () => 1,
+            sleep,
+        });
+        expect(slept).to.deep.equal([1250, 2500, 5000]);
+    });
+});

--- a/walta-app/app/lib/logic/CerdiApi.js
+++ b/walta-app/app/lib/logic/CerdiApi.js
@@ -1,4 +1,5 @@
 const Logger = require('util/Logger');
+const { withRetry } = require('util/PromiseUtils');
 const log = (m, tag = "auth") => Logger.log(m, tag);
 const trace = (m) => Logger.log(m, "network");
 var { loadPhoto, savePhoto } = require('util/PhotoUtils');
@@ -12,326 +13,327 @@ function redactBody(data) {
     }
     return copy;
 }
-function createHttpClient(method, url, contentType, acceptType = 'application/json', accessToken, sendDataFunction ) {
-    return new Promise( (resolve, reject) => {
+
+const DEFAULT_RETRY_OPTS = {
+    maxRetries: 3,
+    baseDelayMs: 1000,
+    capDelayMs: 30000,
+    jitter: true,
+};
+
+const MAX_ERROR_BODY_CHARS = 500;
+function truncate(s) {
+    if (typeof s !== 'string' || s.length <= MAX_ERROR_BODY_CHARS) return s;
+    return `${s.slice(0, MAX_ERROR_BODY_CHARS)}…[${s.length - MAX_ERROR_BODY_CHARS} more chars truncated]`;
+}
+
+function parseRetryAfter(raw) {
+    if (raw == null) return undefined;
+    const n = parseInt(raw, 10);
+    if (Number.isFinite(n) && String(n) === String(raw).trim()) return n * 1000;
+    const at = Date.parse(raw);
+    if (Number.isFinite(at)) return Math.max(0, at - Date.now());
+    return undefined;
+}
+
+function isRetryableHttpError(err) {
+    if (!err || typeof err.status !== 'number') return false;
+    return err.status === 429 || (err.status >= 500 && err.status < 600);
+}
+
+function sendOnce(method, url, contentType, acceptType, accessToken, sendDataFunction) {
+    return new Promise((resolve, reject) => {
         var client = Ti.Network.createHTTPClient({
-                onload: function() {
-                    if ( acceptType === 'application/json' ) {
-                        const parsed = JSON.parse(this.responseText);
-                        trace(`<- ${this.status} ${method} ${url} ${JSON.stringify(redactBody(parsed))}`);
-                        resolve(parsed);
-                    } else {
-                        const bytes = this.responseData ? this.responseData.length : 0;
-                        trace(`<- ${this.status} ${method} ${url} (${bytes} bytes)`);
-                        resolve( this.responseData );
-                    }
-                },
-                onerror: function(err) {
-                    const status = this.status || '?';
-                    if ( this.responseText ) {
-                        try {
-                            const parsed = JSON.parse(this.responseText);
-                            trace(`<- ${status} ${method} ${url} ERROR ${JSON.stringify(redactBody(parsed))}`);
-                            reject( parsed );
-                        } catch(err2) {
-                            trace(`<- ${status} ${method} ${url} ERROR ${this.responseText}`);
-                            reject(err);
-                        }
-                    } else {
-                        trace(`<- ${status} ${method} ${url} ERROR (no body)`);
-                        reject(err);
-                    }
+            onload: function () {
+                if (acceptType === 'application/json') {
+                    const parsed = JSON.parse(this.responseText);
+                    trace(`<- ${this.status} ${method} ${url} ${JSON.stringify(redactBody(parsed))}`);
+                    resolve(parsed);
+                } else {
+                    const bytes = this.responseData ? this.responseData.length : 0;
+                    trace(`<- ${this.status} ${method} ${url} (${bytes} bytes)`);
+                    resolve(this.responseData);
                 }
-            });
+            },
+            onerror: function (err) {
+                const status = this.status || '?';
+                let body = err;
+                if (this.responseText) {
+                    try {
+                        body = JSON.parse(this.responseText);
+                        trace(`<- ${status} ${method} ${url} ERROR ${JSON.stringify(redactBody(body))}`);
+                    } catch (_) {
+                        trace(`<- ${status} ${method} ${url} ERROR ${truncate(this.responseText)}`);
+                    }
+                } else {
+                    trace(`<- ${status} ${method} ${url} ERROR (no body)`);
+                }
+                const retryAfterRaw = typeof this.getResponseHeader === 'function'
+                    ? this.getResponseHeader('Retry-After')
+                    : undefined;
+                const wrapped = { status: this.status, body };
+                const retryAfterMs = parseRetryAfter(retryAfterRaw);
+                if (retryAfterMs !== undefined) wrapped.retryAfterMs = retryAfterMs;
+                reject(wrapped);
+            }
+        });
         client.open(method, url);
-        client.setRequestHeader('Accept',acceptType) ;
-        if ( contentType !== "multipart/form-data" && contentType !== null) 
+        client.setRequestHeader('Accept', acceptType);
+        if (contentType !== "multipart/form-data" && contentType !== null)
             client.setRequestHeader('Content-Type', contentType);
-        
-        if ( accessToken ) {
+        if (accessToken)
             client.setRequestHeader('Authorization', `Bearer ${accessToken}`);
-        }
-        sendDataFunction( client );
+        sendDataFunction(client);
     });
 }
 
-function makeJsonGetRequest( serverUrl, accessToken = null) {
-    trace(`GET ${serverUrl}`);
-    return createHttpClient("GET", serverUrl, null, "application/json", accessToken,
-                (client) => client.send() );
-}
-
-function makeJsonDeleteRequest( serverUrl, accessToken = null) {
-    trace(`DELETE ${serverUrl}`);
-    return createHttpClient("DELETE", serverUrl, null, "application/json", accessToken,
-                (client) => client.send() );
-}
-
-function makeJsonPostRequest( serverUrl, data, accessToken = null) {
-    trace(`POST ${serverUrl} ${JSON.stringify(redactBody(data))}`);
-    return createHttpClient("POST", serverUrl, "application/json", "application/json",accessToken,
-                (client) => client.send( JSON.stringify( data ) ) );
-}
-
-function makeJsonPutRequest( serverUrl, data, accessToken = null) {
-    trace(`PUT ${serverUrl} ${JSON.stringify(redactBody(data))}`);
-    return createHttpClient("PUT", serverUrl, "application/json", "application/json",accessToken,
-                (client) => client.send( JSON.stringify( data ) ) );
-}
-
-function makeImagePostRequest( serverUrl, imageData, data, accessToken = null ) {
-    data.photo = imageData;
-    trace(`POST ${serverUrl} (multipart, ${Object.keys(data).join(",")})`);
-    return createHttpClient("POST", serverUrl, "multipart/form-data", "application/json", accessToken,
-                (client) => client.send( data ) );
-}
-
-function makeImagePutRequest( serverUrl, imageData, data, accessToken = null ) {
-    data.photo = imageData;
-    trace(`PUT ${serverUrl} (multipart, ${Object.keys(data).join(",")})`);
-    return createHttpClient("PUT", serverUrl, "multipart/form-data", "application/json", accessToken,
-                (client) => client.send( data ) );
-}
-
-function makeImageGetRequest( serverUrl, accessToken = null ) {
-    trace(`GET ${serverUrl} (image)`);
-    return createHttpClient("GET", serverUrl, null, "image/jpeg", accessToken,
-                (client) => client.send() );
-}
-
-function retrievePhoto(photoId,serverUrl,accessToken,photoPath) {
-    function saveRetrievedPhoto(blob) {
-        savePhoto(blob,photoPath);
-        return { id: photoId, photoPath: photoPath};
-    }
-    return makeImageGetRequest(`${serverUrl}/photos/${photoId}/view`, accessToken)
-        .then(saveRetrievedPhoto);
-}
-
-function retrievePhotoFromMeta( serverUrl, photoUrl, accessToken, photoPath ) {
-    function findLatestPhoto(photos) {
-        //info("find latest photos: " + JSON.stringify(photos));
-        return photos[photos.length-1];
-    }
-    function downloadPhoto(photo) {
-        //info("downloadPhoto photo: " + JSON.stringify(photo));
-        return retrievePhoto(photo.id,serverUrl,accessToken,photoPath)
-    }
-   
-    function downloadPhotoIfExists(photos) {
-        if ( photos.length > 0 ) {
-            let photo = findLatestPhoto(photos);
-            return downloadPhoto(photo)
-                .then( () => photo ); // return the id so the caller can save it
-        }
-    }
-    let photoMeta = null;
-    return makeJsonGetRequest(`${serverUrl}/${photoUrl}`, accessToken )
-        .then( downloadPhotoIfExists );
-        
-}
-
-
-
-
-function createCerdiApi( serverUrl, client_secret  ) {
-        log(`Using CERDI API server ${serverUrl}` );
-        var cerdiApi = {
-            retrieveUserToken() {
-                return Ti.App.Properties.getObject('userAccessTokenLive');
-            },
-
-            _requireAccessToken() {
-                const token = this.retrieveUserToken();
-                if (!token) throw new Error("Not logged in");
-                return token.accessToken;
-            },
-
-            retrieveUserId() {
-                let token = this.retrieveUserToken();
-                if ( token ) {
-                    return token.id;
-                }
-            },
-
-            retrieveUsername() {
-                return Ti.App.Properties.getObject("userAccessUsername");
-            },
-
-            storeUserToken( email, accessToken ) {
-                //Ti.API.info(`accessToken = ${JSON.stringify(accessToken)}`)
-                Ti.App.Properties.setObject("userAccessUsername", email );
-                Ti.App.Properties.setObject('userAccessTokenLive', accessToken );
-            },
-        
-            obtainServerAccessToken() {
-                return Promise.resolve(Ti.App.Properties.getObject('appAccessTokenLive'))
-                    .then( (cachedAppAccessToken) => {
-                        if ( cachedAppAccessToken ) {
-                            log(`Got existing access token retrieved_at = ${cachedAppAccessToken.retrieved_at} expires_in = ${cachedAppAccessToken.expires_in}`);
-                            let tokenAge = Date.now() - cachedAppAccessToken.retrieved_at;
-                            if ( tokenAge < cachedAppAccessToken.expires_in*1000 )
-                                return cachedAppAccessToken;
-                            log("Expired token"); 
-                        } 
-                        
-                        log("Requesting a new token");
-                        return makeJsonPostRequest( this.serverUrl + '/token/create/server',
-                            {
-                                "client_secret": this.client_secret,
-                                "scope": this.scope
-                            });
-                    })
-                    .then( (appAccessToken) => {
-                        appAccessToken.retrieved_at = Date.now();
-                        Ti.App.Properties.setObject('appAccessTokenLive', appAccessToken);
-                        return appAccessToken.access_token;
-                    } );
-            },
-        
-            registerUser( userInfo ) {
-                return this.obtainServerAccessToken()
-                    .then( (accessToken) => 
-                        makeJsonPostRequest( this.serverUrl + '/user/create', 
-                            userInfo, accessToken))
-                    .then( (resp) => {
-                        return { id: resp.id, accessToken: resp.accessToken } ;
-                    });
-            },
-        
-            loginUser( email, password ) {
-                return this.obtainServerAccessToken()
-                    .then( (accessToken) =>
-                        makeJsonPostRequest( this.serverUrl + '/token/create', {
-                            "password": password,
-                            "email": email
-                        }, accessToken ) )
-                    .then( (resp) => {
-                        resp.retrieved_at = Date.now();
-                        this.storeUserToken( email, resp );
-                        
-                        return resp;
-                    })
-            },
-
-            submitSitePhoto( serverSampleId, photoPath ) {
-                var photoBlob = loadPhoto(photoPath);
-                let accessToken = this._requireAccessToken();
-                if ( accessToken == undefined )
-                    throw new Error("Not logged in - cannot submit sample");
-                return makeImagePostRequest( `${this.serverUrl}/samples/${serverSampleId}/photos`, photoBlob, {}, accessToken );
-            },
-
-            submitCreaturePhoto( serverSampleId, creatureId, photoPath ) {
-                var photoBlob = loadPhoto(photoPath);
-                let accessToken = this._requireAccessToken();
-                if ( accessToken == undefined )
-                    throw new Error("Not logged in - cannot submit sample");
-                return makeImagePostRequest( `${this.serverUrl}/samples/${serverSampleId}/creatures/${creatureId}/photos`, photoBlob, {}, accessToken );
-            },
-
-            retrievePhoto(photoId,photoPath) {
-                let accessToken = this._requireAccessToken();
-                if ( accessToken == undefined )
-                    throw new Error("Not logged in - cannot submit sample");
-                return retrievePhoto(photoId,this.serverUrl,accessToken,photoPath)
-            },
-
-            retrievePhotoMetadata(photoId) {
-                let accessToken = this._requireAccessToken();
-                return makeJsonGetRequest(`${this.serverUrl}/photos/${photoId}`, accessToken )
-            },
-
-            retrieveSitePhoto( serverSampleId,photoPath ) {
-                let accessToken = this._requireAccessToken();
-                let serverUrl = this.serverUrl;
-                if ( accessToken == undefined )
-                    throw new Error("Not logged in - cannot submit sample");
-                return retrievePhotoFromMeta(serverUrl,`samples/${serverSampleId}/photos`, 
-                            accessToken, photoPath);
-
-            },
-
-            retrieveCreaturePhoto( serverSampleId,creatureId,photoPath ) {
-                let accessToken = this._requireAccessToken();
-                let serverUrl = this.serverUrl;
-                if ( accessToken == undefined )
-                    throw new Error("Not logged in - cannot submit sample");
-                return retrievePhotoFromMeta(serverUrl,`samples/${serverSampleId}/creatures/${creatureId}/photos`,
-                            accessToken, photoPath);
-            },
-
-            submitSample( sample ) {
-                let accessToken = this._requireAccessToken();
-                if ( accessToken == undefined )
-                    throw new Error("Not logged in - cannot submit sample");
-                return makeJsonPostRequest( this.serverUrl + '/samples', sample, accessToken );
-            },
-
-            retrieveSampleById(serverSampleId) {
-                let accessToken = this._requireAccessToken();
-                if ( accessToken == undefined )
-                    throw new Error("Not logged in - cannot submit sample");
-                return makeJsonGetRequest( `${this.serverUrl}/samples/${serverSampleId}`, accessToken );
-            },
-
-            updateSampleById(serverSampleId,sample) {
-                let accessToken = this._requireAccessToken();
-                if ( accessToken == undefined )
-                    throw new Error("Not logged in - cannot submit sample");
-                return makeJsonPutRequest( `${this.serverUrl}/samples/${serverSampleId}`, sample, accessToken );
-            },
-            
-            updateUnknownCreature(unknownCreatureId,count,photoPath) {
-                var photoBlob = loadPhoto(photoPath);
-                let accessToken = this._requireAccessToken();
-                if ( accessToken == undefined )
-                    throw new Error("Not logged in - cannot submit sample");
-                return makeImagePutRequest( `${this.serverUrl}/unknownSampledCreatures/${unknownCreatureId}`, photoBlob, { count: count }, accessToken );
-        
-            },
-
-            submitUnknownCreature(serverSampleId,count,photoPath) {
-                var photoBlob = loadPhoto(photoPath);
-                let accessToken = this._requireAccessToken();
-                if ( accessToken == undefined )
-                    throw new Error("Not logged in - cannot submit sample");
-                return makeImagePostRequest( `${this.serverUrl}/samples/${serverSampleId}/unknownCreatures`, photoBlob, { count: count }, accessToken );
-            },
-
-            deleteUnknownCreature(unknownCreatureId) {
-                let accessToken = this._requireAccessToken();
-                if ( accessToken == undefined )
-                    throw new Error("Not logged in - cannot submit sample");
-                return makeJsonDeleteRequest( `${this.serverUrl}/unknownSampledCreatures/${unknownCreatureId}`, accessToken );
-            
-            },
-
-            retrieveUnknownCreatures(serverSampleId) {
-                let accessToken = this._requireAccessToken();
-                if ( accessToken == undefined )
-                    throw new Error("Not logged in - cannot submit sample");
-                return makeJsonGetRequest( `${this.serverUrl}/samples/${serverSampleId}/unknownCreatures`, accessToken );
-            },
-
-
-            retrieveSamples() {
-                let accessToken = this._requireAccessToken();
-                if ( accessToken == undefined )
-                    throw new Error("Not logged in - cannot submit sample");
-                return makeJsonGetRequest( this.serverUrl + '/samples', accessToken );
-            },
-
-            forgotPassword( email ) {
-                return this.obtainServerAccessToken()
-                    .then( accessToken => makeJsonPostRequest( this.serverUrl + '/password/email', { "email": email }, accessToken ) ); 
+function buildHttp(retryOpts) {
+    function createHttpClient(method, url, contentType, acceptType, accessToken, sendDataFunction) {
+        return withRetry(
+            () => sendOnce(method, url, contentType, acceptType, accessToken, sendDataFunction),
+            { ...retryOpts, isRetryable: isRetryableHttpError }
+        ).catch((err) => {
+            if (err && typeof err === 'object' && 'body' in err && 'status' in err) {
+                throw err.body;
             }
-        
-        }
-        cerdiApi.client_secret = client_secret;
-        cerdiApi.scope = 'create-users';
-        cerdiApi.serverUrl = serverUrl;
-        return cerdiApi;
+            throw err;
+        });
     }
+
+    function makeJsonGetRequest(serverUrl, accessToken = null) {
+        trace(`GET ${serverUrl}`);
+        return createHttpClient("GET", serverUrl, null, "application/json", accessToken,
+            (client) => client.send());
+    }
+
+    function makeJsonDeleteRequest(serverUrl, accessToken = null) {
+        trace(`DELETE ${serverUrl}`);
+        return createHttpClient("DELETE", serverUrl, null, "application/json", accessToken,
+            (client) => client.send());
+    }
+
+    function makeJsonPostRequest(serverUrl, data, accessToken = null) {
+        trace(`POST ${serverUrl} ${JSON.stringify(redactBody(data))}`);
+        return createHttpClient("POST", serverUrl, "application/json", "application/json", accessToken,
+            (client) => client.send(JSON.stringify(data)));
+    }
+
+    function makeJsonPutRequest(serverUrl, data, accessToken = null) {
+        trace(`PUT ${serverUrl} ${JSON.stringify(redactBody(data))}`);
+        return createHttpClient("PUT", serverUrl, "application/json", "application/json", accessToken,
+            (client) => client.send(JSON.stringify(data)));
+    }
+
+    function makeImagePostRequest(serverUrl, imageData, data, accessToken = null) {
+        data.photo = imageData;
+        trace(`POST ${serverUrl} (multipart, ${Object.keys(data).join(",")})`);
+        return createHttpClient("POST", serverUrl, "multipart/form-data", "application/json", accessToken,
+            (client) => client.send(data));
+    }
+
+    function makeImagePutRequest(serverUrl, imageData, data, accessToken = null) {
+        data.photo = imageData;
+        trace(`PUT ${serverUrl} (multipart, ${Object.keys(data).join(",")})`);
+        return createHttpClient("PUT", serverUrl, "multipart/form-data", "application/json", accessToken,
+            (client) => client.send(data));
+    }
+
+    function makeImageGetRequest(serverUrl, accessToken = null) {
+        trace(`GET ${serverUrl} (image)`);
+        return createHttpClient("GET", serverUrl, null, "image/jpeg", accessToken,
+            (client) => client.send());
+    }
+
+    function fetchPhoto(photoId, serverUrl, accessToken, photoPath) {
+        return makeImageGetRequest(`${serverUrl}/photos/${photoId}/view`, accessToken)
+            .then((blob) => {
+                savePhoto(blob, photoPath);
+                return { id: photoId, photoPath: photoPath };
+            });
+    }
+
+    function fetchPhotoFromMeta(serverUrl, photoUrl, accessToken, photoPath) {
+        return makeJsonGetRequest(`${serverUrl}/${photoUrl}`, accessToken)
+            .then((photos) => {
+                if (photos.length > 0) {
+                    const photo = photos[photos.length - 1];
+                    return fetchPhoto(photo.id, serverUrl, accessToken, photoPath)
+                        .then(() => photo);
+                }
+            });
+    }
+
+    return {
+        makeJsonGetRequest,
+        makeJsonDeleteRequest,
+        makeJsonPostRequest,
+        makeJsonPutRequest,
+        makeImagePostRequest,
+        makeImagePutRequest,
+        makeImageGetRequest,
+        fetchPhoto,
+        fetchPhotoFromMeta,
+    };
+}
+
+function createCerdiApi(serverUrl, client_secret, opts = {}) {
+    log(`Using CERDI API server ${serverUrl}`);
+    const http = buildHttp({ ...DEFAULT_RETRY_OPTS, ...(opts.retry || {}) });
+
+    var cerdiApi = {
+        retrieveUserToken() {
+            return Ti.App.Properties.getObject('userAccessTokenLive');
+        },
+
+        _requireAccessToken() {
+            const token = this.retrieveUserToken();
+            if (!token) throw new Error("Not logged in");
+            return token.accessToken;
+        },
+
+        retrieveUserId() {
+            let token = this.retrieveUserToken();
+            if (token) {
+                return token.id;
+            }
+        },
+
+        retrieveUsername() {
+            return Ti.App.Properties.getObject("userAccessUsername");
+        },
+
+        storeUserToken(email, accessToken) {
+            Ti.App.Properties.setObject("userAccessUsername", email);
+            Ti.App.Properties.setObject('userAccessTokenLive', accessToken);
+        },
+
+        obtainServerAccessToken() {
+            return Promise.resolve(Ti.App.Properties.getObject('appAccessTokenLive'))
+                .then((cachedAppAccessToken) => {
+                    if (cachedAppAccessToken) {
+                        log(`Got existing access token retrieved_at = ${cachedAppAccessToken.retrieved_at} expires_in = ${cachedAppAccessToken.expires_in}`);
+                        let tokenAge = Date.now() - cachedAppAccessToken.retrieved_at;
+                        if (tokenAge < cachedAppAccessToken.expires_in * 1000)
+                            return cachedAppAccessToken;
+                        log("Expired token");
+                    }
+                    log("Requesting a new token");
+                    return http.makeJsonPostRequest(this.serverUrl + '/token/create/server', {
+                        "client_secret": this.client_secret,
+                        "scope": this.scope
+                    });
+                })
+                .then((appAccessToken) => {
+                    appAccessToken.retrieved_at = Date.now();
+                    Ti.App.Properties.setObject('appAccessTokenLive', appAccessToken);
+                    return appAccessToken.access_token;
+                });
+        },
+
+        registerUser(userInfo) {
+            return this.obtainServerAccessToken()
+                .then((accessToken) =>
+                    http.makeJsonPostRequest(this.serverUrl + '/user/create', userInfo, accessToken))
+                .then((resp) => ({ id: resp.id, accessToken: resp.accessToken }));
+        },
+
+        loginUser(email, password) {
+            return this.obtainServerAccessToken()
+                .then((accessToken) =>
+                    http.makeJsonPostRequest(this.serverUrl + '/token/create', {
+                        "password": password,
+                        "email": email
+                    }, accessToken))
+                .then((resp) => {
+                    resp.retrieved_at = Date.now();
+                    this.storeUserToken(email, resp);
+                    return resp;
+                });
+        },
+
+        submitSitePhoto(serverSampleId, photoPath) {
+            var photoBlob = loadPhoto(photoPath);
+            let accessToken = this._requireAccessToken();
+            return http.makeImagePostRequest(`${this.serverUrl}/samples/${serverSampleId}/photos`, photoBlob, {}, accessToken);
+        },
+
+        submitCreaturePhoto(serverSampleId, creatureId, photoPath) {
+            var photoBlob = loadPhoto(photoPath);
+            let accessToken = this._requireAccessToken();
+            return http.makeImagePostRequest(`${this.serverUrl}/samples/${serverSampleId}/creatures/${creatureId}/photos`, photoBlob, {}, accessToken);
+        },
+
+        retrievePhoto(photoId, photoPath) {
+            let accessToken = this._requireAccessToken();
+            return http.fetchPhoto(photoId, this.serverUrl, accessToken, photoPath);
+        },
+
+        retrievePhotoMetadata(photoId) {
+            let accessToken = this._requireAccessToken();
+            return http.makeJsonGetRequest(`${this.serverUrl}/photos/${photoId}`, accessToken);
+        },
+
+        retrieveSitePhoto(serverSampleId, photoPath) {
+            let accessToken = this._requireAccessToken();
+            return http.fetchPhotoFromMeta(this.serverUrl, `samples/${serverSampleId}/photos`, accessToken, photoPath);
+        },
+
+        retrieveCreaturePhoto(serverSampleId, creatureId, photoPath) {
+            let accessToken = this._requireAccessToken();
+            return http.fetchPhotoFromMeta(this.serverUrl, `samples/${serverSampleId}/creatures/${creatureId}/photos`, accessToken, photoPath);
+        },
+
+        submitSample(sample) {
+            let accessToken = this._requireAccessToken();
+            return http.makeJsonPostRequest(this.serverUrl + '/samples', sample, accessToken);
+        },
+
+        retrieveSampleById(serverSampleId) {
+            let accessToken = this._requireAccessToken();
+            return http.makeJsonGetRequest(`${this.serverUrl}/samples/${serverSampleId}`, accessToken);
+        },
+
+        updateSampleById(serverSampleId, sample) {
+            let accessToken = this._requireAccessToken();
+            return http.makeJsonPutRequest(`${this.serverUrl}/samples/${serverSampleId}`, sample, accessToken);
+        },
+
+        updateUnknownCreature(unknownCreatureId, count, photoPath) {
+            var photoBlob = loadPhoto(photoPath);
+            let accessToken = this._requireAccessToken();
+            return http.makeImagePutRequest(`${this.serverUrl}/unknownSampledCreatures/${unknownCreatureId}`, photoBlob, { count: count }, accessToken);
+        },
+
+        submitUnknownCreature(serverSampleId, count, photoPath) {
+            var photoBlob = loadPhoto(photoPath);
+            let accessToken = this._requireAccessToken();
+            return http.makeImagePostRequest(`${this.serverUrl}/samples/${serverSampleId}/unknownCreatures`, photoBlob, { count: count }, accessToken);
+        },
+
+        deleteUnknownCreature(unknownCreatureId) {
+            let accessToken = this._requireAccessToken();
+            return http.makeJsonDeleteRequest(`${this.serverUrl}/unknownSampledCreatures/${unknownCreatureId}`, accessToken);
+        },
+
+        retrieveUnknownCreatures(serverSampleId) {
+            let accessToken = this._requireAccessToken();
+            return http.makeJsonGetRequest(`${this.serverUrl}/samples/${serverSampleId}/unknownCreatures`, accessToken);
+        },
+
+        retrieveSamples() {
+            let accessToken = this._requireAccessToken();
+            return http.makeJsonGetRequest(this.serverUrl + '/samples', accessToken);
+        },
+
+        forgotPassword(email) {
+            return this.obtainServerAccessToken()
+                .then((accessToken) => http.makeJsonPostRequest(this.serverUrl + '/password/email', { "email": email }, accessToken));
+        }
+    };
+    cerdiApi.client_secret = client_secret;
+    cerdiApi.scope = 'create-users';
+    cerdiApi.serverUrl = serverUrl;
+    return cerdiApi;
+}
 
 exports.createCerdiApi = createCerdiApi;

--- a/walta-app/app/lib/util/PromiseUtils.js
+++ b/walta-app/app/lib/util/PromiseUtils.js
@@ -19,5 +19,35 @@ function checkForErrors(promise) {
   }
 
 
+async function withRetry(fn, opts) {
+    const {
+        maxRetries = 3,
+        isRetryable = () => true,
+        baseDelayMs = 1000,
+        capDelayMs = 30000,
+        jitter = false,
+        random = Math.random,
+        sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
+    } = opts || {};
+    let attempt = 0;
+    while (true) {
+        try {
+            return await fn();
+        } catch (err) {
+            if (attempt >= maxRetries || !isRetryable(err)) throw err;
+            let delay;
+            if (typeof err === 'object' && err !== null && typeof err.retryAfterMs === 'number') {
+                delay = err.retryAfterMs;
+            } else {
+                const base = Math.min(baseDelayMs * Math.pow(2, attempt), capDelayMs);
+                delay = jitter ? base + Math.floor(base * 0.25 * random()) : base;
+            }
+            await sleep(delay);
+            attempt++;
+        }
+    }
+}
+
 exports.delayedPromise = delayedPromise;
 exports.checkForErrors = checkForErrors;
+exports.withRetry = withRetry;


### PR DESCRIPTION
## Summary
- Added `PromiseUtils.withRetry` — exponential backoff with cap, optional jitter, `retryAfterMs` short-circuit, injectable `sleep` for tests. Generic so future callers (uploader, sync loop) can reuse it.
- Wired retry into `CerdiApi.createHttpClient` so every request retries on `429` or `5xx`. Predicate is pure (`isRetryableHttpError`); non-retryable errors (401/4xx) reject immediately with the parsed body so existing call sites keep their reject shape.
- `Retry-After` header honoured: when present (Laravel sends it on JSON 429s), the next sleep uses the header value instead of the computed backoff.
- Refactored CerdiApi to move HTTP helpers (`makeJson*Request`, `makeImage*Request`, photo fetchers) into a `buildHttp(retryOpts)` closure built by `createCerdiApi`. Third arg `opts.retry` injects tuning — production gets the defaults (`{jitter:true, maxRetries:3, baseDelayMs:1000, capDelayMs:30000}`), tests pass `{sleep: () => Promise.resolve(), baseDelayMs:0}` for instant retries. No module-level state, no `__configureRetryForTests` test-only escape hatch.
- Network trace log truncates non-JSON error bodies at 500 chars — the multi-KB Laravel HTML 429 pages were drowning out useful context on Bugfender.
- New `test/fixtures/tiFakes.js` — `installFakeTi`, `makeScriptedHTTPClient`, `makeFakeProps`. Shaped for the upcoming Node-layer SampleDownloader tests too.

First slice of [Trello WB-131](https://trello.com/c/IWfsvc2f/131-sampledownloader-client-side-retry-backoff-for-transient-429-5xx-errors) — the retry layer itself. Acceptance criterion #3 (plug exhausted-retry into WB-101's leave-pending hook so a sample stays pending for the next sync rather than getting `serverSyncTime` set) is deferred to a follow-up commit once the WB-101 leave-pending interface is in place.

## Test plan
- [x] `npx grunt unit-test-node` — 234 passing (12 new: 8 × `withRetry` + 4 × `CerdiApi 429/5xx retry`)
- [ ] `npx grunt build-test`
- [ ] On-device smoke: trigger a 429 burst against the v31-test sandbox and confirm the retry recovers (per the John v31-test scenario)
- [ ] Verify Bugfender network log no longer carries multi-KB HTML 429 bodies

🤖 Generated with [Claude Code](https://claude.com/claude-code)