### PR TITLE
WB-134: consolidate Node-test Ti.API + console fakes into test/fixtures/

### DIFF
--- a/test/Logger_spec.js
+++ b/test/Logger_spec.js
@@ -1,5 +1,10 @@
 require("mocha");
 const { expect } = require("chai");
+const {
+    installFakeTi,
+    uninstallFakeTi,
+    makeCapturingTiAPI,
+} = require("./fixtures/tiFakes");
 
 // see docs/patterns/logger-sinks.md
 describe("Logger sink dispatch", function () {
@@ -107,13 +112,8 @@ describe("Logger sink dispatch", function () {
     });
 
     it("falls back to Ti.API.log when a sink's write() rejects", async function () {
-        const fallbackCalls = [];
-        global.Ti = {
-            API: {
-                log(level, message) { fallbackCalls.push({ level, message }); },
-                debug() {}, info() {}, warn() {}, error() {}
-            }
-        };
+        const { api, calls: fallbackCalls } = makeCapturingTiAPI();
+        installFakeTi({ api });
         try {
             Logger.addSink({ write() { return Promise.reject(new Error("disk full")); } });
             expect(() => Logger.log("hello")).to.not.throw();
@@ -123,7 +123,7 @@ describe("Logger sink dispatch", function () {
             expect(fallbackCalls[0].message).to.match(/disk full/);
             expect(fallbackCalls[0].message).to.match(/hello/);
         } finally {
-            delete global.Ti;
+            uninstallFakeTi();
         }
     });
 });
@@ -202,31 +202,21 @@ describe("Logger.configure", function () {
         return new Promise(r => setImmediate(r));
     }
 
-    function fakeTi() {
-        const calls = [];
-        global.Ti = {
-            API: {
-                debug(m) { calls.push({ method: "debug", m }); },
-                info(m)  { calls.push({ method: "info",  m }); },
-                warn(m)  { calls.push({ method: "warn",  m }); },
-                error(m) { calls.push({ method: "error", m }); },
-                log() {}
-            }
-        };
-        return calls;
-    }
-
-    afterEach(function () { delete global.Ti; });
+    let tiCalls;
+    beforeEach(function () {
+        const captured = makeCapturingTiAPI();
+        tiCalls = captured.calls;
+        installFakeTi({ api: captured.api });
+    });
+    afterEach(uninstallFakeTi);
 
     it("does not route Logger.log() to Ti.API before configure() registers ConsoleSink", async function () {
-        const tiCalls = fakeTi();
         Logger.log("hello");
         await flushMicroTasks();
         expect(tiCalls).to.have.length(0);
     });
 
     it("routes Logger entries to Ti.API exactly once after configure()", async function () {
-        const tiCalls = fakeTi();
         Logger.configure();
         Logger.log("trace msg");
         Logger.warn("warn msg");

--- a/test/fixtures/tiFakes.js
+++ b/test/fixtures/tiFakes.js
@@ -34,7 +34,7 @@ function makeFakeProps(initial = {}) {
     };
 }
 
-function installFakeTi({ httpClient, props, filesystem } = {}) {
+function installFakeTi({ httpClient, props, filesystem, api } = {}) {
     global.Ti = {
         Network: {
             NETWORK_NONE: 0,
@@ -43,7 +43,7 @@ function installFakeTi({ httpClient, props, filesystem } = {}) {
         App: {
             Properties: props || makeFakeProps(),
         },
-        API: { info() {}, error() {}, warn() {}, debug() {} },
+        API: api || { info() {}, error() {}, warn() {}, debug() {}, log() {} },
         Filesystem: filesystem || {
             getFile: () => ({ exists: () => false }),
             resourcesDirectory: "/tmp/r",
@@ -56,9 +56,46 @@ function uninstallFakeTi() {
     delete global.Ti;
 }
 
+function makeCapturingTiAPI() {
+    const calls = [];
+    const api = {
+        debug(m) { calls.push({ method: "debug", m }); },
+        info(m)  { calls.push({ method: "info",  m }); },
+        warn(m)  { calls.push({ method: "warn",  m }); },
+        error(m) { calls.push({ method: "error", m }); },
+        log(level, message) { calls.push({ method: "log", level, message }); },
+    };
+    return { api, calls };
+}
+
+function makeCapturingConsole() {
+    const orig = {
+        log: console.log,
+        info: console.info,
+        warn: console.warn,
+        error: console.error,
+    };
+    const calls = [];
+    console.log   = function (m) { calls.push({ method: "log",   m }); };
+    console.info  = function (m) { calls.push({ method: "info",  m }); };
+    console.warn  = function (m) { calls.push({ method: "warn",  m }); };
+    console.error = function (m) { calls.push({ method: "error", m }); };
+    return {
+        calls,
+        restore() {
+            console.log   = orig.log;
+            console.info  = orig.info;
+            console.warn  = orig.warn;
+            console.error = orig.error;
+        },
+    };
+}
+
 module.exports = {
     makeScriptedHTTPClient,
     makeFakeProps,
     installFakeTi,
     uninstallFakeTi,
+    makeCapturingTiAPI,
+    makeCapturingConsole,
 };

--- a/test/util/sinks/ConsoleSink_spec.js
+++ b/test/util/sinks/ConsoleSink_spec.js
@@ -1,55 +1,35 @@
 require("mocha");
 const { expect } = require("chai");
+const {
+    installFakeTi,
+    uninstallFakeTi,
+    makeCapturingTiAPI,
+    makeCapturingConsole,
+} = require("../../fixtures/tiFakes");
 
 describe("ConsoleSink", function () {
     let ConsoleSink;
-    let tiCalls;
-    let consoleCalls;
 
     beforeEach(function () {
         delete require.cache[require.resolve("../../../walta-app/app/lib/util/sinks/ConsoleSink")];
         ConsoleSink = require("../../../walta-app/app/lib/util/sinks/ConsoleSink");
-        tiCalls = [];
-        consoleCalls = [];
     });
 
-    afterEach(function () {
-        delete global.Ti;
-    });
-
-    function fakeTi() {
-        global.Ti = {
-            API: {
-                debug(m) { tiCalls.push({ method: "debug", m }); },
-                info(m)  { tiCalls.push({ method: "info",  m }); },
-                warn(m)  { tiCalls.push({ method: "warn",  m }); },
-                error(m) { tiCalls.push({ method: "error", m }); }
-            }
-        };
-    }
-
-    function fakeConsole() {
-        const orig = { log: console.log, info: console.info, warn: console.warn, error: console.error };
-        console.log = function (m) { consoleCalls.push({ method: "log", m }); };
-        console.info = function (m) { consoleCalls.push({ method: "info", m }); };
-        console.warn = function (m) { consoleCalls.push({ method: "warn", m }); };
-        console.error = function (m) { consoleCalls.push({ method: "error", m }); };
-        return function restore() {
-            console.log = orig.log;
-            console.info = orig.info;
-            console.warn = orig.warn;
-            console.error = orig.error;
-        };
-    }
+    afterEach(uninstallFakeTi);
 
     it("write() returns a Promise", function () {
-        fakeTi();
+        installFakeTi({ api: makeCapturingTiAPI().api });
         const result = ConsoleSink.write({ ts: 0, level: "trace", facility: "x", message: "hi" });
         expect(result).to.be.an.instanceof(Promise);
     });
 
     describe("with Ti.API present", function () {
-        beforeEach(fakeTi);
+        let tiCalls;
+        beforeEach(function () {
+            const captured = makeCapturingTiAPI();
+            tiCalls = captured.calls;
+            installFakeTi({ api: captured.api });
+        });
 
         it("routes trace to Ti.API.debug", async function () {
             await ConsoleSink.write({ level: "trace", message: "t" });
@@ -78,14 +58,14 @@ describe("ConsoleSink", function () {
     });
 
     describe("without Ti.API (Node fallback)", function () {
-        let restoreConsole;
-        beforeEach(function () { restoreConsole = fakeConsole(); });
-        afterEach(function () { restoreConsole(); });
+        let cap;
+        beforeEach(function () { cap = makeCapturingConsole(); });
+        afterEach(function () { cap.restore(); });
 
         it("routes trace and debug to console.log", async function () {
             await ConsoleSink.write({ level: "trace", message: "t" });
             await ConsoleSink.write({ level: "debug", message: "d" });
-            expect(consoleCalls).to.deep.equal([
+            expect(cap.calls).to.deep.equal([
                 { method: "log", m: "t" },
                 { method: "log", m: "d" }
             ]);
@@ -95,7 +75,7 @@ describe("ConsoleSink", function () {
             await ConsoleSink.write({ level: "info",  message: "i" });
             await ConsoleSink.write({ level: "warn",  message: "w" });
             await ConsoleSink.write({ level: "error", message: "e" });
-            expect(consoleCalls).to.deep.equal([
+            expect(cap.calls).to.deep.equal([
                 { method: "info",  m: "i" },
                 { method: "warn",  m: "w" },
                 { method: "error", m: "e" }


### PR DESCRIPTION
## Summary
- Two `Logger_spec.js` `fakeTi()` blocks and `ConsoleSink_spec.js`'s `fakeTi()`/`fakeConsole()` all had the same shape — record method calls into an outer array, restore on afterEach. Three copies. Moved them into `test/fixtures/tiFakes.js` (the fixture WB-131 introduced).
- `makeCapturingTiAPI()` → `{ api, calls }`. `debug/info/warn/error` record `{method, m}` (matching the existing assertion shape); `log` records `{method:"log", level, message}` so Logger's sink-failure fallback path (`Ti.API.log(level, fallback)`) is also testable through the same helper.
- `makeCapturingConsole()` → `{ calls, restore }`. Patches `console.log/info/warn/error`; the returned `restore()` puts the originals back in `afterEach`.
- `installFakeTi({ api })` opt — lets the existing CerdiApi-style callers pass in the capturing API instead of the default no-op. Added `log() {}` to the default API too, since Logger's fallback path references it.
- `PhotoUtils_spec` (Ti.Filesystem path-joining) and `RuntimeMode_spec` (Ti.Platform + getString) were considered — both are purpose-specific and don't fit the generic shape, so they keep their inline mocks.

[Trello WB-134](https://trello.com/c/HAG6o4lY/134-consolidate-node-test-tiapi-console-fakes-into-test-fixtures) — discovered during WB-131 review (the user spotted that I was redefining the mocked Ti world inline).

## Stacked on WB-131

This branch is based on `task/wb-131-retry-backoff-429` (PR #289) because the shared `tiFakes.js` file is introduced there. Will rebase onto `main` automatically once #289 merges.

## Test plan
- [x] `npx grunt unit-test-node` — 234 passing (same as before; no test added/removed, just migrated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)