### PR TITLE
WB-135: include response headers in [network] trace (with sensitive-name redaction)

### DIFF
--- a/test/fixtures/tiFakes.js
+++ b/test/fixtures/tiFakes.js
@@ -7,6 +7,10 @@ function makeScriptedHTTPClient(scripted, attempts = []) {
             open(method, url) { this._method = method; this._url = url; },
             setRequestHeader(name, value) { this._headers[name] = value; },
             getResponseHeader(name) { return (this._responseHeaders || {})[name]; },
+            getAllResponseHeaders() {
+                const h = this._responseHeaders || {};
+                return Object.keys(h).map((k) => `${k}: ${h[k]}`).join('\r\n');
+            },
             send() {
                 const next = scripted.shift();
                 if (!next) throw new Error("No scripted response left");

--- a/test/logic/CerdiApi_trace_spec.js
+++ b/test/logic/CerdiApi_trace_spec.js
@@ -1,0 +1,94 @@
+require("mocha");
+const { expect } = require("chai");
+const {
+    makeScriptedHTTPClient,
+    makeFakeProps,
+    installFakeTi,
+    uninstallFakeTi,
+} = require("../fixtures/tiFakes");
+
+const FAST_RETRY = { baseDelayMs: 0, jitter: false, sleep: () => Promise.resolve() };
+
+describe("CerdiApi: network trace headers", function () {
+    let CerdiApi;
+    let Logger;
+    let scripted;
+    let attempts;
+    let networkLogs;
+    let unsubLogger;
+
+    beforeEach(function () {
+        scripted = [];
+        attempts = [];
+        installFakeTi({
+            httpClient: makeScriptedHTTPClient(scripted, attempts),
+            props: makeFakeProps({ userAccessTokenLive: { accessToken: 'fake-token' } }),
+        });
+        delete require.cache[require.resolve("../../walta-app/app/lib/logic/CerdiApi")];
+        CerdiApi = require("../../walta-app/app/lib/logic/CerdiApi");
+        Logger = require("../../walta-app/app/lib/util/Logger");
+        networkLogs = [];
+        unsubLogger = Logger.subscribe({ facility: 'network' }, (e) => networkLogs.push(e));
+    });
+
+    afterEach(function () {
+        if (unsubLogger) unsubLogger();
+        uninstallFakeTi();
+    });
+
+    it("includes response headers on a successful 200 trace", async function () {
+        scripted.push({
+            status: 200,
+            body: '[]',
+            headers: { 'Content-Type': 'application/json', 'X-RateLimit-Remaining': '57' },
+        });
+        const cerdi = CerdiApi.createCerdiApi("http://test.example", "secret", { retry: FAST_RETRY });
+        await cerdi.retrieveSamples();
+        const responseLine = networkLogs.find((e) => /^<- 200/.test(e.message));
+        expect(responseLine, "expected a 200 response trace").to.exist;
+        expect(responseLine.message).to.include('Content-Type');
+        expect(responseLine.message).to.include('application/json');
+        expect(responseLine.message).to.include('X-RateLimit-Remaining');
+        expect(responseLine.message).to.include('57');
+    });
+
+    it("includes response headers on a 429 error trace", async function () {
+        scripted.push(
+            {
+                status: 429,
+                body: '{"message":"Too Many Attempts."}',
+                headers: { 'Retry-After': '8', 'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': '1779937511' },
+            },
+            { status: 200, body: '[]' },
+        );
+        const cerdi = CerdiApi.createCerdiApi("http://test.example", "secret", { retry: FAST_RETRY });
+        await cerdi.retrieveSamples();
+        const errorLine = networkLogs.find((e) => /^<- 429 .* ERROR/.test(e.message));
+        expect(errorLine, "expected a 429 error trace").to.exist;
+        expect(errorLine.message).to.include('Retry-After');
+        expect(errorLine.message).to.include('"8"');
+        expect(errorLine.message).to.include('X-RateLimit-Remaining');
+        expect(errorLine.message).to.include('X-RateLimit-Reset');
+    });
+
+    it("redacts the value of sensitive headers by name", async function () {
+        scripted.push({
+            status: 200,
+            body: '[]',
+            headers: {
+                'Content-Type': 'application/json',
+                'Set-Cookie': 'session=abc123; Path=/; HttpOnly',
+                'Authorization': 'Bearer eyJ-secret-payload',
+            },
+        });
+        const cerdi = CerdiApi.createCerdiApi("http://test.example", "secret", { retry: FAST_RETRY });
+        await cerdi.retrieveSamples();
+        const responseLine = networkLogs.find((e) => /^<- 200/.test(e.message));
+        expect(responseLine, "expected a 200 response trace").to.exist;
+        expect(responseLine.message).to.include('Set-Cookie');
+        expect(responseLine.message).to.include('Authorization');
+        expect(responseLine.message).to.not.include('session=abc123');
+        expect(responseLine.message).to.not.include('eyJ-secret-payload');
+        expect(responseLine.message).to.include('[REDACTED]');
+    });
+});

--- a/walta-app/app/lib/logic/CerdiApi.js
+++ b/walta-app/app/lib/logic/CerdiApi.js
@@ -27,6 +27,47 @@ function truncate(s) {
     return `${s.slice(0, MAX_ERROR_BODY_CHARS)}…[${s.length - MAX_ERROR_BODY_CHARS} more chars truncated]`;
 }
 
+const SENSITIVE_HEADER_NAMES = new Set([
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+    'x-auth-token',
+    'x-api-key',
+    'x-csrf-token',
+]);
+
+function parseHeaders(raw) {
+    if (typeof raw !== 'string' || !raw.length) return null;
+    const out = {};
+    const lines = raw.split(/\r?\n/);
+    for (const line of lines) {
+        if (!line) continue;
+        const idx = line.indexOf(':');
+        if (idx <= 0) continue;
+        const name = line.slice(0, idx).trim();
+        const value = line.slice(idx + 1).trim();
+        out[name] = value;
+    }
+    return Object.keys(out).length ? out : null;
+}
+
+function redactHeaders(headers) {
+    if (!headers || typeof headers !== 'object') return headers;
+    const out = {};
+    for (const key of Object.keys(headers)) {
+        out[key] = SENSITIVE_HEADER_NAMES.has(key.toLowerCase()) ? '[REDACTED]' : headers[key];
+    }
+    return out;
+}
+
+function formatResponseHeaders(client) {
+    if (typeof client.getAllResponseHeaders !== 'function') return '';
+    const parsed = parseHeaders(client.getAllResponseHeaders());
+    if (!parsed) return '';
+    return ` headers=${JSON.stringify(redactHeaders(parsed))}`;
+}
+
 function parseRetryAfter(raw) {
     if (raw == null) return undefined;
     const n = parseInt(raw, 10);
@@ -45,28 +86,30 @@ function sendOnce(method, url, contentType, acceptType, accessToken, sendDataFun
     return new Promise((resolve, reject) => {
         var client = Ti.Network.createHTTPClient({
             onload: function () {
+                const headers = formatResponseHeaders(this);
                 if (acceptType === 'application/json') {
                     const parsed = JSON.parse(this.responseText);
-                    trace(`<- ${this.status} ${method} ${url} ${JSON.stringify(redactBody(parsed))}`);
+                    trace(`<- ${this.status} ${method} ${url} ${JSON.stringify(redactBody(parsed))}${headers}`);
                     resolve(parsed);
                 } else {
                     const bytes = this.responseData ? this.responseData.length : 0;
-                    trace(`<- ${this.status} ${method} ${url} (${bytes} bytes)`);
+                    trace(`<- ${this.status} ${method} ${url} (${bytes} bytes)${headers}`);
                     resolve(this.responseData);
                 }
             },
             onerror: function (err) {
                 const status = this.status || '?';
+                const headers = formatResponseHeaders(this);
                 let body = err;
                 if (this.responseText) {
                     try {
                         body = JSON.parse(this.responseText);
-                        trace(`<- ${status} ${method} ${url} ERROR ${JSON.stringify(redactBody(body))}`);
+                        trace(`<- ${status} ${method} ${url} ERROR ${JSON.stringify(redactBody(body))}${headers}`);
                     } catch (_) {
-                        trace(`<- ${status} ${method} ${url} ERROR ${truncate(this.responseText)}`);
+                        trace(`<- ${status} ${method} ${url} ERROR ${truncate(this.responseText)}${headers}`);
                     }
                 } else {
-                    trace(`<- ${status} ${method} ${url} ERROR (no body)`);
+                    trace(`<- ${status} ${method} ${url} ERROR (no body)${headers}`);
                 }
                 const retryAfterRaw = typeof this.getResponseHeader === 'function'
                     ? this.getResponseHeader('Retry-After')


### PR DESCRIPTION
## Summary
- `[network]` trace lines for both successful and error responses now include `headers={...}` parsed from `getAllResponseHeaders()`. Was previously dropping these — `Retry-After`, `x-ratelimit-*`, `Content-Type` only surfaced via the `[exception]` dump in Bugfender (and only on errors). On John's v31-test session the `retry-after: 8` was sitting in `responseHeaders` unused.
- Sensitive headers are redacted by name (lowercased exact-match): `authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-auth-token`, `x-api-key`, `x-csrf-token`. Names stay so "Set-Cookie was present" remains diagnostically visible; the value becomes `"[REDACTED]"`.
- `tiFakes.js` scripted HTTPClient now serves `getAllResponseHeaders()` from the same header map it already had for `getResponseHeader()` — small extension to the WB-131 fixture.

Out of scope:
- Request-side headers (would need relocating the request trace into `sendOnce`, broader diff). Defer if needed.
- Proactive `x-ratelimit-*` throttling — separate card [WB-136](https://trello.com/c/8h7A7iuC).

[Trello WB-135](https://trello.com/c/bURJPNGP/135-cerdiapi-network-trace-include-response-headers-with-sensitive-name-redaction). Related: the vision for a unified network queue (where all of this would live in one place) is captured in [WB-137](https://trello.com/c/j0qWLtWD) for the record.

## Stacked on WB-131

This branch is based on `task/wb-131-retry-backoff-429` (PR #289) — same file (`CerdiApi.js`) and the new tests use the WB-131 `tiFakes.js` fixture. Rebases onto `main` automatically once #289 merges.

## Test plan
- [x] `npx grunt unit-test-node` — 237 passing (234 prior + 3 new for redact/include behaviour)
- [ ] On-device check: confirm a real CERDI request shows headers in the `[network]` log on Bugfender, with no Set-Cookie/Authorization values leaking
- [ ] Sanity check that the headers don't blow up Bugfender log size on a typical session (should be well below the multi-KB HTML body the WB-131 truncation addresses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)