### PR TITLE
WB-101: continue sync queue when one sample fails to download

### DIFF
--- a/walta-app/app/lib/logic/SampleDownloader.js
+++ b/walta-app/app/lib/logic/SampleDownloader.js
@@ -199,10 +199,17 @@ function createSampleDownloader(delay, progress) {
 
             function saveNewSamples( samples ) {
                 progress.plan( samples.length );
+                // Isolate each sample: a transient failure on one (e.g. 5xx
+                // after retries exhausted) leaves that sample without a
+                // serverSyncTime so the next sync retries it, while the rest
+                // of the queue still drains.
                 return _.reduce( samples,
                     (updateAllSamples, serverSample ) => updateAllSamples
-                            .then( () => serverSample )
-                            .then( updateIncomingSample )
+                            .then( () => updateIncomingSample(serverSample) )
+                            .catch( err => {
+                                error(`Failed to download sample [serverSampleId=${serverSample.id}] — leaving pending for next sync`);
+                                Logger.recordException(err);
+                            })
                             .then( () => progress.tick() ),Promise.resolve() )
                     .then( () => updatedCount );
             }

--- a/walta-app/app/spec/SampleSync_spec.js
+++ b/walta-app/app/spec/SampleSync_spec.js
@@ -459,7 +459,7 @@ describe("SampleSync", function () {
         });
         it('should upload new photo if site photo is changed', async function() {
             let sample = makeSampleData( { sitePhotoPath: makeTestPhoto("site.jpg") });
-            sample.save(); 
+            sample.save();
             simple.mock(Alloy.Globals.CerdiApi,"retrieveUserId")
                 .returnWith(38);
             simple.mock(Alloy.Globals.CerdiApi,"submitSitePhoto").resolveWith({id:1});
@@ -471,6 +471,46 @@ describe("SampleSync", function () {
             sample.save();
             await createSampleUploader().uploadSamples();
             expect(Alloy.Globals.CerdiApi.submitSitePhoto.callCount).to.equal(2);
+        });
+
+        it('keeps processing remaining samples when one sample upload fails', async function() {
+            // A transient failure uploading one sample (e.g. 5xx after retries
+            // exhausted) must not strand the rest of the queue. The failing
+            // sample stays pending so a later sync retries it.
+            let firstSample = makeSampleData({ waterbodyName: "first" });
+            firstSample.save();
+            let doomedSample = makeSampleData({ waterbodyName: "doomed" });
+            doomedSample.save();
+            let thirdSample = makeSampleData({ waterbodyName: "third" });
+            thirdSample.save();
+
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveUserId").returnWith(38);
+            simple.mock(Alloy.Globals.CerdiApi, "submitSitePhoto").resolveWith({id:1});
+            simple.mock(Alloy.Globals.CerdiApi, "submitSample")
+                .callFn((sampleJson) => {
+                    if (sampleJson.waterbody_name === "doomed") {
+                        return Promise.reject(new Error("HTTP 503"));
+                    }
+                    let nextId = sampleJson.waterbody_name === "first" ? 1001 : 1003;
+                    return Promise.resolve({ id: nextId, user_id: 38 });
+                });
+
+            await createSampleUploader().uploadSamples();
+
+            let firstReloaded = Alloy.createModel("sample");
+            firstReloaded.loadById(firstSample.get("sampleId"));
+            expect(firstReloaded.get("serverSampleId"), "first sample uploaded").to.equal(1001);
+            expect(firstReloaded.get("serverSyncTime"), "first sample marked complete").to.be.a("number");
+
+            let thirdReloaded = Alloy.createModel("sample");
+            thirdReloaded.loadById(thirdSample.get("sampleId"));
+            expect(thirdReloaded.get("serverSampleId"), "third sample uploaded after failed second").to.equal(1003);
+            expect(thirdReloaded.get("serverSyncTime"), "third sample marked complete").to.be.a("number");
+
+            let doomedReloaded = Alloy.createModel("sample");
+            doomedReloaded.loadById(doomedSample.get("sampleId"));
+            expect(doomedReloaded.get("serverSampleId"), "failed sample left pending for retry").to.not.be.ok;
+            expect(doomedReloaded.get("serverSyncTime"), "failed sample not marked complete").to.not.be.a("number");
         });
     });
 
@@ -950,8 +990,44 @@ describe("SampleSync", function () {
             expect(sample.get("serverSampleId")).to.equal(235);
             expect(sample.get("waterbodyName")).to.equal("second test sample");
         });
-        
-    }); 
+
+        it('keeps processing remaining samples when one sample download fails', async function() {
+            // A transient failure on one sample (e.g. 429 after retries exhausted,
+            // server error fetching unknown creatures) must not strand the rest
+            // of the queue. The failing sample stays pending so a later sync
+            // retries it.
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveUnknownCreatures")
+                .callFn((serverSampleId) => {
+                    if (serverSampleId === 235) {
+                        return Promise.reject(new Error("HTTP 503"));
+                    }
+                    return Promise.resolve([]);
+                });
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveSamples")
+                .resolveWith([
+                    makeCerdiSampleData({ id: 234, waterbody_name: "first" }),
+                    makeCerdiSampleData({ id: 235, waterbody_name: "doomed" }),
+                    makeCerdiSampleData({ id: 236, waterbody_name: "third" }),
+                ]);
+
+            await createSampleDownloader().downloadSamples();
+
+            let sample = Alloy.Models.instance("sample");
+            sample.loadByServerId(234);
+            expect(sample.get("serverSampleId"), "first sample persisted").to.equal(234);
+            expect(sample.get("serverSyncTime"), "first sample marked synced").to.be.a("number");
+
+            sample = Alloy.createModel("sample");
+            sample.loadByServerId(236);
+            expect(sample.get("serverSampleId"), "third sample persisted after failed second").to.equal(236);
+            expect(sample.get("serverSyncTime"), "third sample marked synced after failed second").to.be.a("number");
+
+            sample = Alloy.createModel("sample");
+            sample.loadByServerId(235);
+            expect(sample.get("serverSyncTime"), "failed sample left pending for retry").to.not.be.a("number");
+        });
+
+    });
 
     it('should not duplicate record if edited whilst uploading', async function() {
         clearMockSampleData();


### PR DESCRIPTION
## Summary
- **Per-sample isolation in `SampleDownloader.saveNewSamples`.** Wrap each `updateIncomingSample(serverSample)` in a `.catch` that records the exception and leaves the sample without a `serverSyncTime`, then ticks progress and continues. A transient failure on one sample (e.g. `retrieveUnknownCreatures` 503 after WB-131 retries exhaust, or a `persistSample`/`setTimestamp` error) no longer bubbles out of `downloadSamples`, no longer hits `runSync`'s "Sync finished with errors" catch, and no longer halts the rest of the queue.
- **Regression guard for the uploader.** Added a test asserting the uploader keeps draining the queue when one sample's `submitSample` rejects. This already passes against current code — `uploadNextSample`'s inner `.catch` swallows per-sample rejections into 0, so the brittle "Promise.reject anything that isn't 'data was invalid'" branch in `uploadRemainingSamples` is effectively dead. The test documents and pins the behaviour; cleanup of the dead branch is left for a separate refactor.

Follow-up slice of [Trello WB-101](https://trello.com/c/D8Vu0oCA/101-sync-strands-creature-site-photos-after-a-transient-download-failure-serversynctime-set-despite-failed-photo-fetch). The first slice ([#263](https://github.com/TheWaterBugCompany/WALTA/pull/263)) fixed photo-level stranding — `serverSyncTime` no longer gates a photo that failed to fetch, so the next sync retries the photo. This slice fixes the queue-level halt symptom flagged on the card (2026-05-28) against John's v31-test Bugfender logs: previously a single 429 burst not only stranded one sample's photos but blocked every remaining sample in that sync cycle.

Builds on [#291 (WB-131)](https://github.com/TheWaterBugCompany/WALTA/pull/291) — with client-side retry/backoff in place, the natural semantics for "retries exhaust on one sample" is now "leave it pending, continue the queue", which is what this PR implements.

The app-badge-stuck-at-2 sub-symptom on the same card has been moved to [WB-114](https://trello.com/c/jf3REHVq) (lightweight sync-needed probe).

## Test plan
- [x] New `keeps processing remaining samples when one sample download fails` test — fails on pre-fix code (HTTP 503 escapes), passes after fix.
- [x] New `keeps processing remaining samples when one sample upload fails` regression guard — passes pre- and post-fix.
- [x] Full SampleSync on-device suite — 52 passing on iOS simulator.
- [x] `npx grunt unit-test-node` — 234 passing.
- [ ] CI green (Android + iOS device specs, acceptance).
- [ ] Manual: trigger a transient API failure mid-sync against `--app-config=development` and confirm the remaining samples in the queue still download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)