### PR TITLE
WB-115: tick sync progress per photo, not per sample

### DIFF
--- a/walta-app/app/lib/logic/SampleDownloader.js
+++ b/walta-app/app/lib/logic/SampleDownloader.js
@@ -112,28 +112,34 @@ function createSampleDownloader(delay, progress) {
             }
 
             function downloadSitePhoto([sample,serverSample]) {
-                // Skip when we already have it — photos are immutable on the server,
-                // so a present serverSitePhotoId means there's nothing to re-fetch.
-                if ( serverSample.photos.length > 0 && ! sample.get("serverSitePhotoId") ) {
-                    let sitePhotoPath = `site_download_${serverSample.id}`;
-                    info(`Downloading site photo for ${serverSample.id}`);
-                    return delayedPromise( Alloy.Globals.CerdiApi.retrieveSitePhoto(serverSample.id, sitePhotoPath), delay )
-                        .then( photo => {
-                            sample.setSitePhoto( Ti.Filesystem.applicationDataDirectory, sitePhotoPath);
-                            sample.set("serverSitePhotoId", photo.id);
-                            sample.save();
-                            Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: sample.get("sampleId"), message: "Downloading site photo" } );
-                            return [sample,serverSample];
-                        })
-                        .catch( err => {
-                            error(`Failed to download photo for [serverSampleId=${serverSample.id}]`)
-                            Logger.recordException(err);
-                            return [sample, serverSample];
-                        });
-                } else {
+                // No site photo to account for at all — keep plan and tick aligned by
+                // simply doing nothing here (the planning pre-pass also skipped it).
+                if ( serverSample.photos.length === 0 ) {
                     return Promise.resolve([sample,serverSample]);
                 }
-                
+                // Skip when we already have it — photos are immutable on the server,
+                // so a present serverSitePhotoId means there's nothing to re-fetch.
+                if ( sample.get("serverSitePhotoId") ) {
+                    progress.tick();
+                    return Promise.resolve([sample,serverSample]);
+                }
+                let sitePhotoPath = `site_download_${serverSample.id}`;
+                info(`Downloading site photo for ${serverSample.id}`);
+                return delayedPromise( Alloy.Globals.CerdiApi.retrieveSitePhoto(serverSample.id, sitePhotoPath), delay )
+                    .then( photo => {
+                        sample.setSitePhoto( Ti.Filesystem.applicationDataDirectory, sitePhotoPath);
+                        sample.set("serverSitePhotoId", photo.id);
+                        sample.save();
+                        Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: sample.get("sampleId"), message: "Downloading site photo" } );
+                        progress.tick();
+                        return [sample,serverSample];
+                    })
+                    .catch( err => {
+                        error(`Failed to download photo for [serverSampleId=${serverSample.id}]`)
+                        Logger.recordException(err);
+                        progress.tick();
+                        return [sample, serverSample];
+                    });
             }
             
             function downloadCreaturePhoto(taxon,serverSample) {
@@ -182,23 +188,34 @@ function createSampleDownloader(delay, progress) {
             function downloadCreaturePhotos([sample,serverSample]) {
                 let taxa = sample.loadTaxa();
 
-                // Download photos that haven't yet been assigned a taxonPhotoPath
-                // this means photos are only ever downloaded from the server when they
-                // do not exist on the client - this is a fair assumption since the photo
-                // can not be changed on the server.
-                // serverCreaturePhotoId === 0 marks "no photo on the server" (set by
-                // downloadCreaturePhoto), so it's excluded — only fresh or previously
-                // failed photos remain pending and get (re)tried (WB-101).
-                let pendingTaxaPhotos = taxa.filter( t => _.isNull(t.get("taxonPhotoPath")) && t.get("serverCreaturePhotoId") !== 0 );
-                return _.reduce( pendingTaxaPhotos,  
-                    (queue,t) => queue.then( () => delayedPromise( downloadCreaturePhoto(t,serverSample),delay)),
+                // Iterate ALL taxa, not just the pending ones: download photos that
+                // haven't been fetched yet (taxonPhotoPath null, server says it has one),
+                // and tick either way so per-photo progress accounting stays aligned
+                // with the metadata-based plan even on resync where most photos are
+                // already local.
+                // serverCreaturePhotoId === 0 marks "no photo on the server", so it's
+                // excluded — only fresh or previously failed photos get (re)tried (WB-101).
+                return taxa.reduce(
+                    (queue,t) => queue
+                        .then( () => {
+                            if ( _.isNull(t.get("taxonPhotoPath")) && t.get("serverCreaturePhotoId") !== 0 ) {
+                                return delayedPromise( downloadCreaturePhoto(t,serverSample), delay );
+                            }
+                        })
+                        .then( () => progress.tick() ),
                     Promise.resolve())
                     .then(()=>[sample,serverSample])
-                
+
             }
 
             function saveNewSamples( samples ) {
-                progress.plan( samples.length );
+                // Plan once for both samples and their photos, from the GET /samples
+                // metadata: a stable denominator avoids the bar jumping mid-stream
+                // when photos start downloading.
+                let photoCount = samples.reduce(
+                    (sum, s) => sum + (s.photos.length > 0 ? 1 : 0) + s.sampled_creatures.length,
+                    0);
+                progress.plan( samples.length + photoCount );
                 // Isolate each sample: a transient failure on one (e.g. 5xx
                 // after retries exhausted) leaves that sample without a
                 // serverSyncTime so the next sync retries it, while the rest

--- a/walta-app/app/lib/logic/SampleSync.js
+++ b/walta-app/app/lib/logic/SampleSync.js
@@ -66,6 +66,21 @@ function countPendingUploads() {
     return samples.length;
 }
 
+// Combined-pool seed: every unit the uploader will tick on — samples plus
+// their pending site and taxon photos. Must mirror SampleUploader.uploadSamples'
+// plan() arithmetic so the bar doesn't sprint past 99% when uploads run after
+// a download (and doesn't stall there either).
+function countPendingUploadUnits() {
+    let userId = Alloy.Globals.CerdiApi.retrieveUserId();
+    let samples = Alloy.createCollection("sample");
+    samples.loadUploadQueue(userId);
+    return samples.reduce((sum, s) => {
+        let pendingSite = (s.get("sitePhotoPath") && _.isNull(s.get("serverSitePhotoId"))) ? 1 : 0;
+        let pendingTaxa = s.loadTaxa().findPendingUploads().length;
+        return sum + 1 + pendingSite + pendingTaxa;
+    }, 0);
+}
+
 function hasPendingUploads() {
     return countPendingUploads() > 0;
 }
@@ -176,7 +191,7 @@ function runSync({ download, options }) {
     // upload phases. Upload work is countable up front, so seed it before
     // the download phase plans its own count — that keeps the bar from
     // jumping backwards when uploads begin after a download.
-    let progressDone = 0, progressTotal = countPendingUploads();
+    let progressDone = 0, progressTotal = countPendingUploadUnits();
     function tick(message) {
         progressDone++;
         syncStore.recordProgress(message, { current: progressDone, total: progressTotal });

--- a/walta-app/app/lib/logic/SampleUploader.js
+++ b/walta-app/app/lib/logic/SampleUploader.js
@@ -34,7 +34,7 @@ function loadCorrectSampleToUpdate(sample) {
     serverSitePhotoId is used to indicate that the photo has been
     sucessfully uploaded.
 */
-function uploadSitePhoto(sample,delay) {
+function uploadSitePhoto(sample,delay,progress) {
 
     function submitSitePhoto( sampleId, photoPath ) {
         info(`Uploading site photo path = ${photoPath} [serverSampleId=${sampleId}]`);
@@ -52,7 +52,7 @@ function uploadSitePhoto(sample,delay) {
             if ( needsOptimising(blob) ) {
                 log(`Optimising ${sitePhoto}`);
                 savePhoto( optimisePhoto(blob), sitePhoto );
-            } 
+            }
             log(`Uploading site photo: ${sitePhoto}`);
             return delayedPromise( submitSitePhoto( sampleId, sitePhoto ), delay)
                     .then( (res) => {
@@ -61,18 +61,20 @@ function uploadSitePhoto(sample,delay) {
                             "serverSitePhotoId": res.id
                         });
                         Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: sampleId, message: "Uploading site photo" } );
+                        progress.tick();
                         return sample;
                     })
                     .catch( (err) => {
                         Logger.recordException(err);
+                        progress.tick();
                         return sample;
                     })
-        } 
-    } 
+        }
+    }
     return sample;
 }
 
-function uploadTaxaPhoto(sample,t,delay) {
+function uploadTaxaPhoto(sample,t,delay,progress) {
 
     function submitCreaturePhoto( sampleId, taxonId, photoPath ) {
         info(`Uploading taxa photo path = ${photoPath} [serverSampleId=${sampleId},taxonId=${taxonId}]`);
@@ -92,22 +94,24 @@ function uploadTaxaPhoto(sample,t,delay) {
     if ( ! taxonPhotoId && (taxonId != null) ) {
         var photoPath = t.getPhoto();
         if ( photoPath ) {
-            
+
             let blob = loadPhoto( photoPath );
             if ( needsOptimising(blob) ) {
                 savePhoto( optimisePhoto( blob ), photoPath );
-            } 
+            }
             return delayedPromise( submitCreaturePhoto(sampleId, taxonId, photoPath ), delay )
                     .then( (res) => {
                         debug(`setting serverCreaturePhotoId = ${res.id}`);
                         t.save({"serverCreaturePhotoId": res.id});
                         Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: sampleId, message: "Uploading taxa photo" } );
+                        progress.tick();
                     })
                     .catch( (err) => {
                         error(`Error when attempting to upload taxon photo [serverSampleId=${sampleId},taxonId=${taxonId}]`)
                         Logger.recordException(err)
+                        progress.tick();
                     });
-                        
+
         }
     }
     return Promise.resolve();
@@ -117,18 +121,18 @@ function uploadTaxaPhoto(sample,t,delay) {
     serverCreaturePhotoId is used to determine if this taxon photo has
     already been uploaded to the server. 
 */
-function uploadTaxaPhotos(sample,delay) {
+function uploadTaxaPhotos(sample,delay,progress) {
     let taxa = sample.getTaxa();
     return taxa.reduce(
-                (uploadTaxaPhotos,t) => 
+                (uploadTaxaPhotos,t) =>
                     uploadTaxaPhotos
-                        .then( uploadTaxaPhoto(sample,t,delay)),
+                        .then( uploadTaxaPhoto(sample,t,delay,progress)),
                 Promise.resolve() )
             .then( () => sample );
-        
+
 }
 
-function uploadUnknownCreature(sample,t,delay) {
+function uploadUnknownCreature(sample,t,delay,progress) {
     var taxonId = t.getTaxonId();
     var sampleId = sample.get("serverSampleId");
     var serverCreatureId = t.get("serverCreatureId");
@@ -141,14 +145,14 @@ function uploadUnknownCreature(sample,t,delay) {
         let photoPath = t.getPhoto();
         let count = t.getAbundance();
         if ( photoPath ) {
-            
+
             let blob = loadPhoto( photoPath );
             if ( needsOptimising(blob) ) {
                 savePhoto( optimisePhoto( blob ), photoPath );
-            } 
+            }
             let actions;
-             
-            if ( !serverCreatureId ) { 
+
+            if ( !serverCreatureId ) {
                 actions = delayedPromise( Promise.resolve().then( () => Alloy.Globals.CerdiApi.submitUnknownCreature(sampleId, count, photoPath ) ), delay );
             } else {
                 actions = delayedPromise( Promise.resolve().then( () => Alloy.Globals.CerdiApi.updateUnknownCreature(serverCreatureId,count,photoPath) ), delay);
@@ -159,20 +163,22 @@ function uploadUnknownCreature(sample,t,delay) {
                     "serverCreaturePhotoId": res.photos[0].id
                 });
                 Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: sampleId, message: "Uploading unknown creature" } );
+                progress.tick();
             })
             .catch( (err) => {
                   Logger.recordException(err);
-            });             
+                  progress.tick();
+            });
         }
     }
     return Promise.resolve();
 }
 
-function uploadUnknownCreatures(sample,delay) {
+function uploadUnknownCreatures(sample,delay,progress) {
     let taxa = sample.getTaxa();
-    return taxa.reduce( 
-        (uploadUnknown,t) => 
-            uploadUnknown.then( uploadUnknownCreature(sample,t,delay)),
+    return taxa.reduce(
+        (uploadUnknown,t) =>
+            uploadUnknown.then( uploadUnknownCreature(sample,t,delay,progress)),
                 Promise.resolve() )
         .then( () => sample );
 }
@@ -220,7 +226,15 @@ function createSampleUploader(delay, progress) {
             return Promise.resolve()
                 .then(loadSamples)
                 .then((samples) => {
-                    progress.plan( samples.length );
+                    // Plan once: samples plus their pending photos (site + taxa).
+                    // Walking the queue here keeps the denominator stable through
+                    // the upload phase so the bar doesn't jump when each photo lands.
+                    let photoCount = samples.reduce((sum, s) => {
+                        let pendingSite = (s.get("sitePhotoPath") && _.isNull(s.get("serverSitePhotoId"))) ? 1 : 0;
+                        let pendingTaxa = s.loadTaxa().findPendingUploads().length;
+                        return sum + pendingSite + pendingTaxa;
+                    }, 0);
+                    progress.plan( samples.length + photoCount );
                     return this.uploadRemainingSamples(samples);
                 });
         },
@@ -305,9 +319,9 @@ function createSampleUploader(delay, progress) {
                 return uploadOrUpdate
                         .then( updateSample )
                         .then( () => sample  )
-                        .then( (sample) => uploadSitePhoto(sample,delay) )
-                        .then( (sample) => uploadTaxaPhotos(sample,delay) )
-                        .then( (sample) => uploadUnknownCreatures(sample,delay))
+                        .then( (sample) => uploadSitePhoto(sample,delay,progress) )
+                        .then( (sample) => uploadTaxaPhotos(sample,delay,progress) )
+                        .then( (sample) => uploadUnknownCreatures(sample,delay,progress))
                         .then( (sample) => deletePendingUnknownCreatures(sample,delay))
                         .then( (sample) => markSampleComplete(sample,delay) )
                         .then( () => 1 )

--- a/walta-app/app/spec/SampleSync_spec.js
+++ b/walta-app/app/spec/SampleSync_spec.js
@@ -222,7 +222,7 @@ describe("SampleSync", function () {
             expect(Alloy.Globals.CerdiApi.submitSample.calls[0].args[0].waterbody_name).to.equal("test water body name");
             expect(sample.get("serverSyncTime")).to.be.a('number');
         });
-        it('returns the count of uploaded samples and reports progress per sample', async function() {
+        it('returns the count of uploaded samples and reports progress per sample plus its site photo', async function() {
             simple.mock(Alloy.Globals.CerdiApi,"retrieveUserId").returnWith(38);
             simple.mock(Alloy.Globals.CerdiApi,"submitSample").resolveWith({id:123, user_id:38});
             simple.mock(Alloy.Globals.CerdiApi,"submitSitePhoto").resolveWith({id:1});
@@ -232,8 +232,25 @@ describe("SampleSync", function () {
             const progress = { plan: (n) => planned.push(n), tick: () => ticks.push(1) };
             const count = await createSampleUploader(undefined, progress).uploadSamples();
             expect(count, "uploaded count").to.equal(1);
-            expect(planned, "planned total").to.deep.equal([1]);
-            expect(ticks.length, "ticks").to.equal(1);
+            expect(planned.reduce((a,b)=>a+b,0), "planned total (sample + site photo)").to.equal(2);
+            expect(ticks.length, "ticks (sample + site photo)").to.equal(2);
+        });
+        it('reports progress for each pending taxon photo upload alongside the sample', async function() {
+            simple.mock(Alloy.Globals.CerdiApi,"retrieveUserId").returnWith(38);
+            simple.mock(Alloy.Globals.CerdiApi,"submitSample").resolveWith({id:123, user_id:38});
+            simple.mock(Alloy.Globals.CerdiApi,"submitSitePhoto").resolveWith({id:1});
+            simple.mock(Alloy.Globals.CerdiApi,"submitCreaturePhoto").resolveWith({id:7});
+            let sample = makeSampleData();
+            sample.save();
+            let t1 = Alloy.createModel("taxa", { sampleId: sample.get("sampleId"), taxonId: 1, taxonPhotoPath: makeTestPhoto("taxon1.jpg"), abundance: "1-2", updatedAt: 0 });
+            t1.save();
+            let t2 = Alloy.createModel("taxa", { sampleId: sample.get("sampleId"), taxonId: 2, taxonPhotoPath: makeTestPhoto("taxon2.jpg"), abundance: "3-5", updatedAt: 0 });
+            t2.save();
+            const planned = [], ticks = [];
+            const progress = { plan: (n) => planned.push(n), tick: () => ticks.push(1) };
+            await createSampleUploader(undefined, progress).uploadSamples();
+            expect(planned.reduce((a,b)=>a+b,0), "planned total (sample + site + 2 taxa)").to.equal(4);
+            expect(ticks.length, "ticks (sample + site + 2 taxa)").to.equal(4);
         });
         it('fires UPLOAD_PROGRESS after the sample is marked complete (serverSyncTime set)', async function() {
             simple.mock(Alloy.Globals.CerdiApi,"retrieveUserId").returnWith(38);
@@ -601,8 +618,42 @@ describe("SampleSync", function () {
             const progress = { plan: (n) => planned.push(n), tick: () => ticks.push(1) };
             const count = await createSampleDownloader(undefined, progress).downloadSamples();
             expect(count, "updated count").to.equal(1);
-            expect(planned, "planned total").to.deep.equal([1]);
+            expect(planned.reduce((a,b)=>a+b,0), "planned total").to.equal(1);
             expect(ticks.length, "ticks").to.equal(1);
+        });
+        it('reports progress for the site photo alongside the sample', async function () {
+            let siteMock = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "/spec/resources/site-mock.jpg");
+            simple.mock(Alloy.Globals.CerdiApi,"retrieveUnknownCreatures")
+                .resolveWith([]);
+            simple.mock(Alloy.Globals.CerdiApi,"retrieveSamples")
+                .resolveWith([makeCerdiSampleData({ photos: [{"id": 1948}] })]);
+            Alloy.Globals.CerdiApi.retrieveSitePhoto = function (serverSampleId, photoPath) {
+                siteMock.copy(Ti.Filesystem.applicationDataDirectory + Ti.Filesystem.separator + photoPath);
+                return Promise.resolve({"id": 1948});
+            };
+            const planned = [], ticks = [];
+            const progress = { plan: (n) => planned.push(n), tick: () => ticks.push(1) };
+            await createSampleDownloader(undefined, progress).downloadSamples();
+            expect(planned.reduce((a,b)=>a+b,0), "planned total (sample + site photo)").to.equal(2);
+            expect(ticks.length, "ticks (sample + site photo)").to.equal(2);
+        });
+        it('reports progress for each creature photo alongside the sample', async function () {
+            simple.mock(Alloy.Globals.CerdiApi,"retrieveUnknownCreatures")
+                .resolveWith([]);
+            simple.mock(Alloy.Globals.CerdiApi,"retrieveSamples")
+                .resolveWith([makeCerdiSampleData({
+                    sampled_creatures: [
+                        { "id": 2390, "sample_id": 473, "creature_id": 1, "count": 2, "photos_count": 1 },
+                        { "id": 2391, "sample_id": 473, "creature_id": 2, "count": 5, "photos_count": 1 }
+                    ]
+                })]);
+            simple.mock(Alloy.Globals.CerdiApi,"retrieveCreaturePhoto")
+                .rejectWith({ message: "no photo" });
+            const planned = [], ticks = [];
+            const progress = { plan: (n) => planned.push(n), tick: () => ticks.push(1) };
+            await createSampleDownloader(undefined, progress).downloadSamples();
+            expect(planned.reduce((a,b)=>a+b,0), "planned total (sample + 2 creature photos)").to.equal(3);
+            expect(ticks.length, "ticks (sample + 2 creature photos)").to.equal(3);
         });
         it('fires UPLOAD_PROGRESS after setTimestamp finishes (serverSyncTime set)', async function () {
             simple.mock(Alloy.Globals.CerdiApi,"retrieveUnknownCreatures")


### PR DESCRIPTION
## Summary
- Plan the sync progress denominator up front from the `GET /samples` metadata (`photos.length` + `sampled_creatures.length`) so the bar denominator stays stable and the per-photo numerator can move smoothly on photo-heavy samples.
- Add `progress.tick()` calls alongside the existing `Topics.UPLOAD_PROGRESS` fires at every photo download/upload site in `SampleDownloader` and `SampleUploader` (including the skip/fail branches, so the bar still reaches the planned denominator on resume).
- Seed the combined-pool count with a new `countPendingUploadUnits()` that mirrors the uploader's planning arithmetic — samples + pending site + pending taxa — so uploads after a download don't stall the bar at 99% or sprint past it.

Closes [Trello WB-115](https://trello.com/c/KTxDe8J0/115-sync-progress-bar-should-count-each-photo-download-upload-not-just-whole-samples). Activity-aware summary counts (`downloaded N / uploaded M` in the log) stay at the sample level per the card.

## Test plan
- [x] `npx grunt unit-test-node` — 234 passing
- [x] `npx grunt --platform=ios --simulator unit-test --grep=SampleSync` — 55 passing (incl. 5 new/updated progress specs)
- [x] `npx grunt --platform=ios --simulator unit-test --grep=SyncFeedback` — 11 passing
- [x] Manual smoke on Android device — bar advances per photo (confirmed `0% → 1% → 2% → …` movement on a photo-heavy sync; on huge syncs the visible jumps are bounded by integer-percent rounding — followup [Trello WB-141](https://trello.com/c/KQw6bs7B/141-sync-bar-appears-stuck-on-huge-syncs-sub-integer-precision))
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)