### PR TITLE
WB-114: Lightweight sync-needed probe to auto-clear the badge

### DIFF
--- a/test/logic/UploadBadge_spec.js
+++ b/test/logic/UploadBadge_spec.js
@@ -39,22 +39,17 @@ describe("UploadBadge", function () {
 
     it("adds one to the pending count when a sync is recommended", function () {
       pending = 2;
-      badge.onLogin();
+      badge.recommend();
       expect(badge.value()).to.equal(3);
     });
 
     it("is just 1 when a sync is recommended but nothing is pending", function () {
-      badge.onLogin();
+      badge.recommend();
       expect(badge.value()).to.equal(1);
     });
   });
 
   describe("state transitions", function () {
-    it("recommends a sync after login (historical samples not yet pulled)", function () {
-      badge.onLogin();
-      expect(badge.value()).to.equal(1);
-    });
-
     it("does not add the recommendation on local activity — the new sample shows via the pending count", function () {
       pending = 1;
       badge.onLocalActivity();
@@ -62,31 +57,31 @@ describe("UploadBadge", function () {
     });
 
     it("clears the recommendation when a full sync completes successfully", function () {
-      badge.onLogin();
+      badge.recommend();
       badge.onSyncFinished({ success: true, fullSync: true });
       expect(badge.value()).to.equal(0);
     });
 
     it("keeps the recommendation after an upload-only sync (history still not pulled)", function () {
-      badge.onLogin();
+      badge.recommend();
       badge.onSyncFinished({ success: true, fullSync: false });
       expect(badge.value()).to.equal(1);
     });
 
     it("keeps the recommendation when a full sync fails", function () {
-      badge.onLogin();
+      badge.recommend();
       badge.onSyncFinished({ success: false, fullSync: true });
       expect(badge.value()).to.equal(1);
     });
 
     it("clears the recommendation on logout", function () {
-      badge.onLogin();
+      badge.recommend();
       badge.onLogout();
       expect(badge.value()).to.equal(0);
     });
 
     it("still counts queued uploads after a full sync clears the recommendation", function () {
-      badge.onLogin();
+      badge.recommend();
       pending = 3;
       badge.onSyncFinished({ success: true, fullSync: true });
       expect(badge.value()).to.equal(3);
@@ -96,12 +91,12 @@ describe("UploadBadge", function () {
   describe("badge side-effects", function () {
     it("sets the badge to the pending count plus the recommendation", function () {
       pending = 2;
-      badge.onLogin();
+      badge.recommend();
       expect(lastBadge()).to.equal(3);
     });
 
     it("clears the badge to 0 when nothing is pending and not recommended", function () {
-      badge.onLogin();
+      badge.recommend();
       badge.onLogout();
       expect(lastBadge()).to.equal(0);
     });
@@ -115,7 +110,7 @@ describe("UploadBadge", function () {
         FORCE_UPLOAD: "forceupload", SYNC_FINISHED: "syncfinished",
         subscribe: (t, cb) => { (subs[t] = subs[t] || []).push(cb); },
         unsubscribe: (t, cb) => { subs[t] = (subs[t] || []).filter((c) => c !== cb); },
-        fire: (t, e) => (subs[t] || []).forEach((cb) => cb(e)),
+        fire: (t, e) => Promise.all((subs[t] || []).map((cb) => cb(e))),
       };
     }
 
@@ -133,19 +128,70 @@ describe("UploadBadge", function () {
       expect(lastBadge()).to.equal(2);
     });
 
-    it("recommends after login and clears after a successful full sync", function () {
+    it("recommends after login when the probe says a sync is needed", async function () {
       const topics = fakeTopics();
-      const b = wire(topics);
-      topics.fire(topics.LOGGEDIN);
+      const b = wire(topics, { checkSyncNeeded: () => Promise.resolve(true) });
+      await topics.fire(topics.LOGGEDIN);
       expect(b.value()).to.equal(1);
       topics.fire(topics.SYNC_FINISHED, { success: true, fullSync: true });
       expect(b.value()).to.equal(0);
     });
 
-    it("clears on logout", function () {
+    it("does not recommend after login when the probe says nothing is needed", async function () {
       const topics = fakeTopics();
-      const b = wire(topics);
-      topics.fire(topics.LOGGEDIN);
+      const b = wire(topics, { checkSyncNeeded: () => Promise.resolve(false) });
+      await topics.fire(topics.LOGGEDIN);
+      expect(b.value()).to.equal(0);
+    });
+
+    it("clears a stale recommendation after login when the probe says nothing is needed", async function () {
+      const topics = fakeTopics();
+      store.setBool("syncRecommended", true);
+      const b = wire(topics, { checkSyncNeeded: () => Promise.resolve(false) });
+      await topics.fire(topics.LOGGEDIN);
+      expect(b.value()).to.equal(0);
+    });
+
+    it("leaves the recommendation flag alone when the probe can't answer (offline / in-flight)", async function () {
+      const topics = fakeTopics();
+      store.setBool("syncRecommended", true);
+      const b = wire(topics, { checkSyncNeeded: () => Promise.resolve(undefined) });
+      await topics.fire(topics.LOGGEDIN);
+      expect(b.value(), "stays recommended").to.equal(1);
+    });
+
+    it("clears authoritatively after a successful full sync without re-probing", async function () {
+      const topics = fakeTopics();
+      let probes = 0;
+      const b = wire(topics, { checkSyncNeeded: () => { probes++; return Promise.resolve(true); } });
+      store.setBool("syncRecommended", true);
+      await topics.fire(topics.SYNC_FINISHED, { success: true, fullSync: true });
+      expect(b.value(), "flag cleared by sync outcome").to.equal(0);
+      expect(probes, "no probe needed when full sync already cleared the flag").to.equal(0);
+    });
+
+    it("re-probes after a non-full-sync to keep the badge truthful (piggybacks on the 30-min timer)", async function () {
+      const topics = fakeTopics();
+      let probes = 0;
+      const b = wire(topics, { checkSyncNeeded: () => { probes++; return Promise.resolve(false); } });
+      store.setBool("syncRecommended", true);   // stale recommendation
+      await topics.fire(topics.SYNC_FINISHED, { success: true, fullSync: false });
+      expect(probes, "probed after upload-only sync").to.equal(1);
+      expect(b.value(), "stale flag cleared by probe").to.equal(0);
+    });
+
+    it("re-probes after a failed full sync", async function () {
+      const topics = fakeTopics();
+      let probes = 0;
+      wire(topics, { checkSyncNeeded: () => { probes++; return Promise.resolve(true); } });
+      await topics.fire(topics.SYNC_FINISHED, { success: false, fullSync: true });
+      expect(probes).to.equal(1);
+    });
+
+    it("clears on logout", async function () {
+      const topics = fakeTopics();
+      const b = wire(topics, { checkSyncNeeded: () => Promise.resolve(true) });
+      await topics.fire(topics.LOGGEDIN);
       topics.fire(topics.LOGGEDOUT);
       expect(b.value()).to.equal(0);
     });
@@ -158,12 +204,12 @@ describe("UploadBadge", function () {
       expect(badges.length).to.be.greaterThan(0);
     });
 
-    it("dispose() drops its Topics subscriptions", function () {
+    it("dispose() drops its Topics subscriptions", async function () {
       const topics = fakeTopics();
-      const b = wire(topics);
+      const b = wire(topics, { checkSyncNeeded: () => Promise.resolve(true) });
       b.dispose();
       const before = badges.length;
-      topics.fire(topics.LOGGEDIN);
+      await topics.fire(topics.LOGGEDIN);
       expect(badges.length).to.equal(before);
     });
   });

--- a/walta-app/app/controllers/index-app.js
+++ b/walta-app/app/controllers/index-app.js
@@ -84,6 +84,7 @@ var androidBadge = OS_ANDROID ? AndroidNotificationBadge.createAndroidBadgeSette
 UploadBadge.init({
   properties: Ti.App.Properties,
   pendingCount: SampleSync.countSamplesNeedingUpload,
+  checkSyncNeeded: SampleSync.checkSyncNeeded,
   setBadge: function (n) {
     if (OS_IOS) Ti.UI.iOS.appBadge = n;
     else if (OS_ANDROID) androidBadge(n);

--- a/walta-app/app/lib/logic/SampleDownloader.js
+++ b/walta-app/app/lib/logic/SampleDownloader.js
@@ -7,48 +7,27 @@ var debug = (m, tag = "sync") => Logger.debug(m, tag);
 var info = (m, tag = "sync") => Logger.info(m, tag);
 var warn = (m, tag = "sync") => Logger.warn(m, tag);
 var error = (m, tag = "sync") => Logger.error(m, tag);
+
+// Does the server's copy of this sample have changes the local doesn't? Pure
+// read against `serverSyncTime` so it can drive both the real download and the
+// lightweight probe that auto-clears the sync-recommended badge (WB-114).
+function needsUpdate(serverSample, sample) {
+    if ( ! sample.get("serverSampleId") ) return true;
+
+    let serverSyncTime = sample.get("serverSyncTime");
+    if ( _.isUndefined(serverSyncTime) ) return true;
+
+    // 10s grace so the timestamp drift between our just-finished upload and the
+    // server's updated_at doesn't re-pull the same sample.
+    return moment(serverSample.updated_at).subtract(10, "s").isAfter(moment(serverSyncTime));
+}
+
 function createSampleDownloader(delay, progress) {
     progress = progress || { plan() {}, tick() {} };
     return {
         downloadSamples() {
             debug(`Queuing sample retrieval from server... `);
             let updatedCount = 0;
-            
-            // only update if updated after it was last uploaded - this allows user changes
-            // to not be overwritten.
-            function needsUpdate(serverSample,sample) {
-
-                debug(`Checking if sampleId=${sample.get("sampleId")} needs downloading `);
-                // This can be true if the sample wasn't reviously on the device sibce a new 
-                // record as been created and this will be blank.
-                if ( ! sample.get("serverSampleId") ) {
-                    debug(`Yes there is no serverSampleId yet.`);
-                    return true;
-                } 
-
-                let serverSyncTime = sample.get("serverSyncTime");
-                if ( _.isUndefined(serverSyncTime) ) {
-                    debug(`Yes there is no serverSyncTime yet.`);
-                    return true;
-                }
-                
-                let serverUpdateTimeM = moment(serverSample.updated_at);
-                let serverSyncTimeM = moment(serverSyncTime); 
-
-                debug(`serverUpdateTimeM=${serverSyncTimeM.valueOf()} serverSyncTimeM=${serverSyncTimeM.valueOf()}`);
-
-                // We need to subtract a small window to account for upload delay; otherwise
-                // a download will be intitiated every time an upload occurs.
-                if ( serverUpdateTimeM.subtract(10,"s").isAfter(serverSyncTimeM) ) {
-                    debug(`Yes the sample was updated on the server after the sync.`);
-                    return true;
-                }
-
-                debug(`No download needed.`);
-
-                return false; // update not needed
-
-            }
             function updateIncomingSample(serverSample) {
                 let sample = Alloy.createModel("sample");
                 // The sync time is set to when we started the download process
@@ -238,3 +217,4 @@ function createSampleDownloader(delay, progress) {
 };
 
 exports.createSampleDownloader = createSampleDownloader;
+exports.needsUpdate = needsUpdate;

--- a/walta-app/app/lib/logic/SampleSync.js
+++ b/walta-app/app/lib/logic/SampleSync.js
@@ -3,7 +3,7 @@ var Topics = require('ui/Topics');
 var SyncStore = require('models/SyncStore');
 
 var { createSampleUploader } = require("logic/SampleUploader");
-var { createSampleDownloader } = require("logic/SampleDownloader");
+var { createSampleDownloader, needsUpdate } = require("logic/SampleDownloader");
 
 var SYNC_INTERVAL = 1000*60*30; // 30 minutes
 var isSyncing = false;
@@ -94,6 +94,30 @@ function countSamplesNeedingUpload() {
     let samples = Alloy.createCollection("sample");
     samples.loadUploadQueue(userId);
     return samples.filter((s) => s.hasPendingUploads()).length;
+}
+
+// Cheap probe: does the user actually have work to sync? Skips photos and
+// per-sample fetches — only `GET /samples` and a local needsUpdate pass.
+// Returns true / false to drive the sync-recommended badge, or undefined when
+// we can't tell (logged out, offline, or a real sync is already in flight) so
+// the caller leaves the existing flag value alone (WB-114).
+function checkSyncNeeded() {
+    if ( ! Alloy.Globals.CerdiApi.retrieveUserToken() ) return Promise.resolve(undefined);
+    if ( Ti.Network.networkType === Ti.Network.NETWORK_NONE ) return Promise.resolve(undefined);
+    if ( isSyncing ) return Promise.resolve(undefined);
+    if ( countSamplesNeedingUpload() > 0 ) return Promise.resolve(true);
+    return Promise.resolve()
+        .then( () => Alloy.Globals.CerdiApi.retrieveSamples() )
+        .then( (serverSamples) => _.some( serverSamples || [], (s) => {
+            let local = Alloy.createModel("sample");
+            local.loadByServerId(s.id);
+            return needsUpdate(s, local);
+        }))
+        .catch( (err) => {
+            // Network blip / 5xx on the probe is a no-signal, not "all clear".
+            debug(`Sync-needed probe failed: ${err && err.message}`);
+            return undefined;
+        });
 }
 
 function clearUploadTimer() {
@@ -299,6 +323,7 @@ exports.forceSync = forceSync;
 exports.uploadPending = uploadPending;
 exports.countPendingUploads = countPendingUploads;
 exports.countSamplesNeedingUpload = countSamplesNeedingUpload;
+exports.checkSyncNeeded = checkSyncNeeded;
 exports.resumeInterruptedWork = resumeInterruptedWork;
 exports.networkChanged = networkChanged;
 exports.areWeSyncing = areWeSyncing;

--- a/walta-app/app/lib/logic/UploadBadge.js
+++ b/walta-app/app/lib/logic/UploadBadge.js
@@ -23,7 +23,8 @@ function createUploadBadge({ properties, pendingCount, setBadge }) {
   return {
     value,
     refresh,
-    onLogin: recommend,        // history not yet pulled this session
+    recommend,
+    clear,
     onLocalActivity: refresh,  // new/edited sample already shows via the pending count
     onLogout: clear,
     onSyncFinished({ success, fullSync }) {
@@ -35,17 +36,40 @@ function createUploadBadge({ properties, pendingCount, setBadge }) {
 
 // Wire a badge to the app's Topics + platform IO. `topics` is the Topics
 // module (or a test fake); `requestPermission` is optional (iOS badge
-// permission). Refreshes once on startup so a relaunch reflects current state.
-function init({ properties, pendingCount, setBadge, topics, requestPermission }) {
+// permission). `checkSyncNeeded` is the WB-114 probe — on login (and any
+// other refresh trigger callers wire in), it answers true/false/undefined and
+// drives the flag from the answer rather than blindly recommending.
+// Refreshes once on startup so a relaunch reflects current state.
+function init({ properties, pendingCount, setBadge, topics, checkSyncNeeded, requestPermission }) {
   const badge = createUploadBadge({ properties, pendingCount, setBadge });
   const subs = [];
   function on(topic, fn) { topics.subscribe(topic, fn); subs.push([topic, fn]); }
-  on(topics.LOGGEDIN, () => badge.onLogin());
+
+  function probeAndApply() {
+    return Promise.resolve()
+      .then(() => checkSyncNeeded && checkSyncNeeded())
+      .then((needed) => {
+        if (needed === true) badge.recommend();
+        else if (needed === false) badge.clear();
+        else badge.refresh();   // undefined: leave the flag alone, just sync the badge
+      });
+  }
+
+  on(topics.LOGGEDIN, probeAndApply);
   on(topics.LOGGEDOUT, () => badge.onLogout());
   on(topics.FORCE_UPLOAD, () => badge.onLocalActivity());
-  on(topics.SYNC_FINISHED, (e) => badge.onSyncFinished(e || {}));
+  // A successful full sync authoritatively clears the flag; any other outcome
+  // (upload-only, failure) leaves the flag's accuracy uncertain, so reprobe.
+  // This piggybacks on the 30-min SampleSync timer — every periodic attempt
+  // fires SYNC_FINISHED, which keeps the badge truthful between manual syncs.
+  on(topics.SYNC_FINISHED, (e) => {
+    const evt = e || {};
+    if (evt.success && evt.fullSync) { badge.onSyncFinished(evt); return; }
+    return probeAndApply();
+  });
   if (requestPermission) requestPermission();
   badge.refresh();
+  badge.probe = probeAndApply;
   // Lets a test (or a re-init) drop the Topics subscriptions it added.
   badge.dispose = () => subs.forEach(([t, fn]) => topics.unsubscribe(t, fn));
   return badge;

--- a/walta-app/app/spec/SampleSync_spec.js
+++ b/walta-app/app/spec/SampleSync_spec.js
@@ -1782,4 +1782,85 @@ describe("SampleSync", function () {
             expect(SampleSync.countSamplesNeedingUpload(), "one pending").to.equal(1);
         });
     })
+
+    // The sync-recommended badge used to be set blindly on login and only
+    // cleared by a full sync. The probe answers "does the server have changes
+    // we don't, or do we have local uploads pending?" cheaply enough to run on
+    // login + the existing 30-min timer, so the badge becomes truthful.
+    context("WB-114: sync-needed probe", function () {
+        function mockLoggedIn() {
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveUserToken").returnWith({ accessToken: "tok" });
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveUserId").returnWith(38);
+        }
+
+        this.beforeEach(function () {
+            clearMockSampleData();
+        });
+
+        this.afterEach(function () {
+            simple.restore();
+        });
+
+        it("returns true when there are pending uploads, without touching the server", async function () {
+            mockLoggedIn();
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveSamples").resolveWith([]);
+            // A fresh sample with a site photo has a pending upload.
+            makeSampleData({ sitePhotoPath: makeTestPhoto("site.jpg") }).save();
+
+            const needed = await SampleSync.checkSyncNeeded();
+
+            expect(needed, "needed").to.equal(true);
+            expect(Alloy.Globals.CerdiApi.retrieveSamples.callCount, "skips the server probe").to.equal(0);
+        });
+
+        it("returns true when the server has a sample newer than local", async function () {
+            mockLoggedIn();
+            // local copy synced a while ago; server says it was updated later
+            makeSampleData({
+                serverSampleId: 473,
+                serverSitePhotoId: 5,
+                serverSyncTime: moment("2020-01-01").valueOf(),
+                updatedAt: moment("2020-01-01").valueOf(),
+            }).save();
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveSamples").resolveWith([
+                makeCerdiSampleData({ id: 473, updated_at: moment("2020-06-01").format() }),
+            ]);
+
+            expect(await SampleSync.checkSyncNeeded()).to.equal(true);
+        });
+
+        it("returns false when nothing is pending locally and the server has no newer copies", async function () {
+            mockLoggedIn();
+            makeSampleData({
+                serverSampleId: 473,
+                serverSitePhotoId: 5,
+                serverSyncTime: moment("2020-06-01").valueOf(),
+                updatedAt: moment("2020-01-01").valueOf(),
+            }).save();
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveSamples").resolveWith([
+                makeCerdiSampleData({ id: 473, updated_at: moment("2020-05-01").format() }),
+            ]);
+
+            expect(await SampleSync.checkSyncNeeded()).to.equal(false);
+        });
+
+        it("returns true when the server has a sample the device has never seen", async function () {
+            mockLoggedIn();
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveSamples").resolveWith([
+                makeCerdiSampleData({ id: 999, updated_at: moment("2020-06-01").format() }),
+            ]);
+
+            expect(await SampleSync.checkSyncNeeded()).to.equal(true);
+        });
+
+        it("returns undefined when not logged in (state untouched)", async function () {
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveUserToken").returnWith(null);
+            simple.mock(Alloy.Globals.CerdiApi, "retrieveSamples").resolveWith([]);
+
+            const needed = await SampleSync.checkSyncNeeded();
+
+            expect(needed, "no answer when not logged in").to.equal(undefined);
+            expect(Alloy.Globals.CerdiApi.retrieveSamples.callCount, "no API call").to.equal(0);
+        });
+    });
 });

--- a/walta-app/app/spec/UploadBadge_spec.js
+++ b/walta-app/app/spec/UploadBadge_spec.js
@@ -6,15 +6,17 @@ var { init, SYNC_RECOMMENDED_KEY } = require("logic/UploadBadge");
 // this proves the real Topics events drive the badge end-to-end (up to the
 // platform appBadge call, stubbed here via setBadge).
 describe("UploadBadge (device wiring)", function () {
-    let badges, badge, pending;
+    let badges, badge, pending, probeAnswer;
 
     beforeEach(function () {
         Ti.App.Properties.setBool(SYNC_RECOMMENDED_KEY, false);
         badges = [];
         pending = 0;
+        probeAnswer = true;
         badge = init({
             properties: Ti.App.Properties,
             pendingCount: () => pending,
+            checkSyncNeeded: () => Promise.resolve(probeAnswer),
             setBadge: (n) => badges.push(n),
             topics: Topics,
         });
@@ -27,9 +29,18 @@ describe("UploadBadge (device wiring)", function () {
 
     function lastBadge() { return badges[badges.length - 1]; }
 
-    it("shows the badge when login is broadcast via Topics", function () {
+    it("shows the badge after login when the probe says a sync is needed", async function () {
+        probeAnswer = true;
         Topics.fireTopicEvent(Topics.LOGGEDIN);
+        await badge.probe();
         expect(lastBadge()).to.equal(1);
+    });
+
+    it("does not show the badge after login when the probe says nothing is needed", async function () {
+        probeAnswer = false;
+        Topics.fireTopicEvent(Topics.LOGGEDIN);
+        await badge.probe();
+        expect(lastBadge()).to.equal(0);
     });
 
     it("reflects pending uploads on local activity without adding the recommendation", function () {
@@ -38,20 +49,28 @@ describe("UploadBadge (device wiring)", function () {
         expect(lastBadge()).to.equal(2);
     });
 
-    it("clears the badge after a successful full sync", function () {
+    it("clears the badge after a successful full sync", async function () {
+        probeAnswer = true;
         Topics.fireTopicEvent(Topics.LOGGEDIN);
+        await badge.probe();
         Topics.fireTopicEvent(Topics.SYNC_FINISHED, { success: true, fullSync: true });
         expect(lastBadge()).to.equal(0);
     });
 
-    it("keeps the badge after an upload-only sync (history still not pulled)", function () {
+    it("re-probes after an upload-only sync (keeps the badge truthful between full syncs)", async function () {
+        probeAnswer = true;
         Topics.fireTopicEvent(Topics.LOGGEDIN);
+        await badge.probe();
+        probeAnswer = false;
         Topics.fireTopicEvent(Topics.SYNC_FINISHED, { success: true, fullSync: false });
-        expect(lastBadge()).to.equal(1);
+        await badge.probe();
+        expect(lastBadge()).to.equal(0);
     });
 
-    it("clears the badge on logout", function () {
+    it("clears the badge on logout", async function () {
+        probeAnswer = true;
         Topics.fireTopicEvent(Topics.LOGGEDIN);
+        await badge.probe();
         Topics.fireTopicEvent(Topics.LOGGEDOUT);
         expect(lastBadge()).to.equal(0);
     });


### PR DESCRIPTION
## Summary
- The app-icon "sync recommended" flag (WB-10a) was set blindly on `LOGGEDIN` and only cleared by a successful full sync — so a user who was already up to date kept being nudged to run an unnecessary, heavy sync. This PR turns the flag into a real staleness check.
- New `SampleSync.checkSyncNeeded()` asks the cheap question: "do we have pending uploads, or does the server have a sample whose `updated_at` is newer than our `serverSyncTime`?" One `GET /samples` + a local `needsUpdate` pass — no per-sample fetch, no photos. Returns `true` / `false` / `undefined` (the last when offline / not logged in / a real sync is in flight, so the caller leaves the flag alone).
- `UploadBadge` consumes it: on `LOGGEDIN` it runs the probe and sets/clears the flag from the answer, replacing the blind set. It also re-probes after every `SYNC_FINISHED` that wasn't a successful full sync — which piggybacks on the existing 30-min `SampleSync` timer for free, since every periodic attempt fires `SYNC_FINISHED`. A successful full sync still clears the flag authoritatively (no probe call needed).
- `SampleDownloader.needsUpdate` extracted out of the `downloadSamples` closure to module scope so the probe can reuse it without duplicating logic.

First (and likely only) slice of [Trello WB-114](https://trello.com/c/jf3REHVq/114-lightweight-sync-needed-probe-to-auto-clear-the-sync-recommended-badge). Subsumes the "badge=2 after errored sync" symptom previously noted on WB-101 (per the card's 2026-05-29 comment) — that was the same blind-on-login flag persisting after a non-full-sync.

## Test plan
- [x] `npx grunt unit-test-node` — 239 passing
- [x] `npx grunt --platform=ios --simulator unit-test --grep="SampleSync"` — 60 passing (includes new `WB-114: sync-needed probe` context)
- [x] `npx grunt --platform=ios --simulator unit-test --grep="UploadBadge"` — 6 passing (probe-driven LOGGEDIN + reprobe wiring)
- [x] Full iOS device unit suite
- [x] Full Android device unit suite
- [ ] On-device verification: log in with an already-up-to-date account, confirm the badge clears without running a full sync; log in with new server-side samples, confirm the badge appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)