### PR TITLE
WB-142: Correct "taxa photo" wording to "taxon photo" in sync UI and logs

### DIFF
--- a/test/models/SyncStore_spec.js
+++ b/test/models/SyncStore_spec.js
@@ -135,7 +135,7 @@ describe("SyncStore", function () {
   describe("recordSuccess()", function () {
     it("moves to 'success' with percent 100 and clears the step headline", function () {
       store.recordStart();
-      store.recordProgress("Uploading taxa photo", { current: 4, total: 4 });
+      store.recordProgress("Uploading taxon photo", { current: 4, total: 4 });
       store.recordSuccess();
       expect(store.status).to.equal("success");
       expect(store.percent).to.equal(100);

--- a/test/viewmodels/SyncFeedback_spec.js
+++ b/test/viewmodels/SyncFeedback_spec.js
@@ -47,12 +47,12 @@ describe("SyncFeedbackViewModel", function () {
 
     it("reflects a sync already in progress when the popup opens", function () {
       store.recordStart();
-      store.recordProgress("Uploading taxa photo", { current: 1, total: 4 });
+      store.recordProgress("Uploading taxon photo", { current: 1, total: 4 });
       const latecomer = new SyncFeedbackViewModel({ syncController, logRepository: fakeLogRepository() });
       try {
         expect(latecomer.status).to.equal("syncing");
         expect(latecomer.percent).to.equal(25);
-        expect(latecomer.statusText).to.equal("Uploading taxa photo");
+        expect(latecomer.statusText).to.equal("Uploading taxon photo");
       } finally {
         latecomer.dispose();
       }
@@ -198,8 +198,8 @@ describe("SyncFeedbackViewModel", function () {
 
     it("uses the publisher's terse step message during a sync", function () {
       store.recordStart();
-      store.recordProgress("Uploading taxa photo", { current: 1, total: 4 });
-      expect(vm.progressText).to.equal("25% Uploading taxa photo");
+      store.recordProgress("Uploading taxon photo", { current: 1, total: 4 });
+      expect(vm.progressText).to.equal("25% Uploading taxon photo");
     });
 
     it("falls back to '0% Syncing' immediately after recordStart, before the first step message", function () {
@@ -209,7 +209,7 @@ describe("SyncFeedbackViewModel", function () {
 
     it("is '100% Synced' on success", function () {
       store.recordStart();
-      store.recordProgress("Uploading taxa photo", { current: 4, total: 4 });
+      store.recordProgress("Uploading taxon photo", { current: 4, total: 4 });
       store.recordSuccess();
       expect(vm.progressText).to.equal("100% Synced");
     });

--- a/walta-app/app/lib/logic/SampleDownloader.js
+++ b/walta-app/app/lib/logic/SampleDownloader.js
@@ -126,7 +126,7 @@ function createSampleDownloader(delay, progress) {
                 let serverCreaturePhotoId = taxon.get("serverCreaturePhotoId");
                 let taxonPhotoPath;
                 let retrievePhoto;
-                info(`Downloading taxa photo [serverSampleId=${serverSample.id},taxonId=${taxonId}]`);
+                info(`Downloading taxon photo [serverSampleId=${serverSample.id},taxonId=${taxonId}]`);
                 
                 // In the case of unknown creatures the photo id is already known so we can
                 // directly retrieve the photo via this id, otherwise we need to look up the
@@ -156,7 +156,7 @@ function createSampleDownloader(delay, progress) {
                                 taxon.set("serverCreaturePhotoId",0); 
                                 taxon.save();
                             }
-                            Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: taxon.getSampleId(), message: "Downloading taxa photo" } );
+                            Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: taxon.getSampleId(), message: "Downloading taxon photo" } );
                         })
                         .catch( err => {
                             error(`Failed to download photo for [serverSampleId=${serverSample.id},taxonId=${taxonId}]`);

--- a/walta-app/app/lib/logic/SampleUploader.js
+++ b/walta-app/app/lib/logic/SampleUploader.js
@@ -77,7 +77,7 @@ function uploadSitePhoto(sample,delay,progress) {
 function uploadTaxaPhoto(sample,t,delay,progress) {
 
     function submitCreaturePhoto( sampleId, taxonId, photoPath ) {
-        info(`Uploading taxa photo path = ${photoPath} [serverSampleId=${sampleId},taxonId=${taxonId}]`);
+        info(`Uploading taxon photo path = ${photoPath} [serverSampleId=${sampleId},taxonId=${taxonId}]`);
         return Promise.resolve()
                 .then( () => Alloy.Globals.CerdiApi.submitCreaturePhoto( sampleId, taxonId, photoPath ) )
                 .then( (res) => {
@@ -103,7 +103,7 @@ function uploadTaxaPhoto(sample,t,delay,progress) {
                     .then( (res) => {
                         debug(`setting serverCreaturePhotoId = ${res.id}`);
                         t.save({"serverCreaturePhotoId": res.id});
-                        Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: sampleId, message: "Uploading taxa photo" } );
+                        Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: sampleId, message: "Uploading taxon photo" } );
                         progress.tick();
                     })
                     .catch( (err) => {

--- a/walta-app/app/spec/SyncFeedback_spec.js
+++ b/walta-app/app/spec/SyncFeedback_spec.js
@@ -166,14 +166,14 @@ describe("SyncFeedback controller", function () {
         beforeEach(async () => {
             var { syncController, store } = createSyncController(SyncStore);
             store.recordStart();
-            store.recordProgress("Uploading taxa photo", { current: 3, total: 4 });
+            store.recordProgress("Uploading taxon photo", { current: 3, total: 4 });
             ctl = Alloy.createController("SyncFeedback", { syncController });
             win = wrapViewInWindow(ctl.getView());
             await windowOpenTest(win);
         });
 
         it("shows the bar partially filled with the publisher's step message", () => {
-            expect(ctl.progressText.text).to.equal("75% Uploading taxa photo");
+            expect(ctl.progressText.text).to.equal("75% Uploading taxon photo");
             expect(ctl.progressFill.width).to.equal("75%");
         });
     });


### PR DESCRIPTION
## Summary
- Each sync progress message and info-log line in `SampleUploader`/`SampleDownloader` describes a single photo for a single taxon — "taxa" is the plural, so the singular "taxon" is correct.
- Updated the two device specs and the two Node specs that assert on the literal status string so the rename doesn't regress.

Closes [Trello WB-142](https://trello.com/c/vTSj7m31/142-correct-taxa-photo-wording-to-taxon-photo-in-sync-ui-and-logs). Comments in `SampleSync_spec.js` that say "taxa photos" (plural) are grammatically fine and left alone, per the card.

## Test plan
- [x] `npx grunt unit-test-node` — passes (239)
- [ ] `npx grunt --platform=ios unit-test` — device spec `SyncFeedback_spec` exercises the new "75% Uploading taxon photo" assertion
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)