### PR TITLE
WB-144: Make --reset uninstall the app on physical iOS devices

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -629,8 +629,16 @@ const KobitonAPI = require("./features/support/kobiton");
         // simctl uninstall is a no-op (exits 0) if the app isn't installed.
         execFileSync('xcrun', ['simctl', 'uninstall', SIM_UDID, APP_ID], { stdio: 'inherit' });
         execFileSync('xcrun', ['simctl', 'install', SIM_UDID, appPath], { stdio: 'inherit' });
-      } else {
-        grunt.log.writeln('--reset is only supported for Android and iOS simulator; skipping');
+      } else if (platform === 'ios') {
+        if (!DEVICE_ID) grunt.fail.fatal('IOS_DEVICE_UDID must be set to --reset a physical iOS device');
+        // devicectl uninstall errors when the app isn't installed; swallow
+        // it so --reset works on a fresh device too. The subsequent launch
+        // task reinstalls.
+        try {
+          execFileSync('xcrun', ['devicectl', 'device', 'uninstall', 'app', '--device', DEVICE_ID, APP_ID], { stdio: 'inherit' });
+        } catch (_) {
+          grunt.log.writeln('App not installed on device — nothing to uninstall');
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- `reset-app` silently no-op'd on physical iOS — only Android (`pm clear`) and the iOS simulator (`simctl uninstall + install`) were wired up. The on-device branch printed `--reset is only supported for Android and iOS simulator; skipping` and moved on, so a stale auth token kept the app logged in across `--reset` runs.
- Add a third branch that runs `xcrun devicectl device uninstall app --device $IOS_DEVICE_UDID net.thewaterbug.waterbug`, swallowing the "not installed" error so the task is idempotent on a fresh device. The subsequent `launch:ios:debug` task reinstalls.

First slice of [Trello WB-144](https://trello.com/c/Z1cV628l/144-make-reset-uninstall-the-app-on-physical-ios-devices) — surfaced while testing WB-136 (#297) on iPhone 17e, where John's session leaked across a `--reset` run and forced a manual uninstall.

## Test plan
- [ ] `npx grunt --platform=ios --reset debug` against a connected physical iOS device — verify the device shows the LogIn screen (not a resumed session) on first launch
- [ ] Same command on a device that *isn't* currently holding the app installed — verify the swallowed `App not installed` log line appears and the build proceeds to launch + install

🤖 Generated with [Claude Code](https://claude.com/claude-code)