### PR TITLE
WB-143: Sample flipping the sample is complete flag

### DIFF
--- a/walta-app/app/controllers/Notes.js
+++ b/walta-app/app/controllers/Notes.js
@@ -26,7 +26,7 @@ function updateFields() {
 }
 
 function onPartialChange( data ) {
-    sample.set("complete", data.value );
+    sample.set("complete", data.value ? 1 : 0 );
     sample.save();
 }
 

--- a/walta-app/app/models/sample.js
+++ b/walta-app/app/models/sample.js
@@ -442,7 +442,7 @@ exports.definition = {
 					"serverUserId": sample.user_id,
 					"serverSampleId": sample.id,
 					"dateCompleted": sample.sample_date,
-					"complete": sample.complete,
+					"complete": sample.complete ? 1 : 0,
 					"notes": sample.notes,
 					"lat": parseFloat(sample.lat),
 					"lng": parseFloat(sample.lng),

--- a/walta-app/app/spec/Notes_spec.js
+++ b/walta-app/app/spec/Notes_spec.js
@@ -30,7 +30,7 @@ describe("Notes controller", function () {
       expect(ctl.partialToggle.value).to.equal(true);
       ctl.partialToggle.value = false;
       await waitForTick(10)();
-      expect(Alloy.Models.instance("sample").get("complete")).to.equal(false);
+      expect(!!Alloy.Models.instance("sample").get("complete")).to.equal(false);
     });
     it('should bind the notes field to the notes field in the sample model', async function () {
 
@@ -131,6 +131,38 @@ describe("WB-143: Notes screen does not flip complete on note-only edit", functi
 
     expect(!!Alloy.Models.instance("sample").get("complete"),
       `sample.complete after note-only edit: ${Alloy.Models.instance("sample").get("complete")}`)
+      .to.equal(false);
+  });
+
+  it("(E) toggling partial off persists complete=false and serialises as false on next upload", async function () {
+    let { makeSampleData } = require("spec/fixtures/SampleData_fixture");
+    let { clearDatabase } = require("spec/util/TestUtils");
+    let moment = require("lib/moment");
+    clearDatabase();
+
+    Alloy.Models.sample = makeSampleData({
+      serverSampleId: 1862,
+      complete: 1,
+      dateCompleted: moment().format(),
+      serverSyncTime: moment().valueOf()
+    });
+    Alloy.Models.sample.save();
+    let id = Alloy.Models.sample.get("sampleId");
+
+    ctl = Alloy.createController("Notes");
+    await controllerOpenTest(ctl);
+    expect(ctl.partialToggle.value, "toggle starts on for a complete sample").to.equal(true);
+
+    ctl.partialToggle.fireEvent("change", { value: false });
+    await waitForTick(10)();
+
+    let reloaded = Alloy.createModel("sample");
+    reloaded.loadById(id);
+    expect(!!reloaded.get("complete"),
+      `reloaded.complete after toggling off: ${reloaded.get("complete")} (typeof ${typeof reloaded.get("complete")})`)
+      .to.equal(false);
+    expect(reloaded.toCerdiApiJson().complete,
+      `serialised complete after toggling off: ${reloaded.toCerdiApiJson().complete}`)
       .to.equal(false);
   });
 });

--- a/walta-app/app/spec/Notes_spec.js
+++ b/walta-app/app/spec/Notes_spec.js
@@ -1,7 +1,8 @@
 require("spec/lib/ti-mocha");
 var Topics = require('ui/Topics');
 var simple = require("spec/lib/simple-mock");
-var { expect } = require("spec/lib/chai");
+var { use, expect } = require("spec/lib/chai");
+use( require('spec/lib/chai-falsy') );
 var { closeWindow, controllerOpenTest, waitForTick, isManualTests, waitForTopic } = require("spec/util/TestUtils");
 var { Navigation } = require('logic/Navigation');
 var { View } = require('logic/View');
@@ -30,7 +31,7 @@ describe("Notes controller", function () {
       expect(ctl.partialToggle.value).to.equal(true);
       ctl.partialToggle.value = false;
       await waitForTick(10)();
-      expect(!!Alloy.Models.instance("sample").get("complete")).to.equal(false);
+      expect(Alloy.Models.instance("sample").get("complete")).to.be.falsy;
     });
     it('should bind the notes field to the notes field in the sample model', async function () {
 
@@ -129,9 +130,9 @@ describe("WB-143: Notes screen does not flip complete on note-only edit", functi
     ctl.notesTextField.fireEvent("change", { value: "edit one character" });
     await waitForTick(10)();
 
-    expect(!!Alloy.Models.instance("sample").get("complete"),
+    expect(Alloy.Models.instance("sample").get("complete"),
       `sample.complete after note-only edit: ${Alloy.Models.instance("sample").get("complete")}`)
-      .to.equal(false);
+      .to.be.falsy;
   });
 
   it("(E) toggling partial off persists complete=false and serialises as false on next upload", async function () {
@@ -158,9 +159,9 @@ describe("WB-143: Notes screen does not flip complete on note-only edit", functi
 
     let reloaded = Alloy.createModel("sample");
     reloaded.loadById(id);
-    expect(!!reloaded.get("complete"),
+    expect(reloaded.get("complete"),
       `reloaded.complete after toggling off: ${reloaded.get("complete")} (typeof ${typeof reloaded.get("complete")})`)
-      .to.equal(false);
+      .to.be.falsy;
     expect(reloaded.toCerdiApiJson().complete,
       `serialised complete after toggling off: ${reloaded.toCerdiApiJson().complete}`)
       .to.equal(false);

--- a/walta-app/app/spec/Notes_spec.js
+++ b/walta-app/app/spec/Notes_spec.js
@@ -105,3 +105,32 @@ describe("Notes controller", function () {
     });
   });
 });
+
+describe("WB-143: Notes screen does not flip complete on note-only edit", function () {
+  let ctl;
+  beforeEach(function () {
+    Alloy.Models.instance("sample").clear();
+    Alloy.Models.instance("sample").set("complete", false);
+    Alloy.Models.sample.set("notes", "original notes");
+  });
+  afterEach(function (done) {
+    if (ctl) closeWindow(ctl.getView(), done);
+    else done();
+  });
+
+  it("(D) typing into notesTextField leaves sample.complete=false and toggle off", async function () {
+    ctl = Alloy.createController("Notes");
+    await controllerOpenTest(ctl);
+
+    expect(ctl.partialToggle.value,
+      `partialToggle on open with sample.complete=false: ${ctl.partialToggle.value}`)
+      .to.equal(false);
+
+    ctl.notesTextField.fireEvent("change", { value: "edit one character" });
+    await waitForTick(10)();
+
+    expect(!!Alloy.Models.instance("sample").get("complete"),
+      `sample.complete after note-only edit: ${Alloy.Models.instance("sample").get("complete")}`)
+      .to.equal(false);
+  });
+});

--- a/walta-app/app/spec/Sample_spec.js
+++ b/walta-app/app/spec/Sample_spec.js
@@ -7,6 +7,7 @@ var { makeSampleData } = require("spec/fixtures/SampleData_fixture");
 
 var { makeTestPhoto, removeDatabase, resetSample, clearDatabase, waitForTick  } = require("spec/util/TestUtils");
 use( require('spec/lib/chai-date-string') );
+use( require('spec/lib/chai-falsy') );
 var Sample = require('logic/Sample');
 
 describe("Taxa collection", function() {
@@ -1111,18 +1112,18 @@ describe("WB-143: complete=false survives the edit roundtrip", function() {
 
   it("(A) createTemporaryForEdit preserves complete=false in the in-memory dup", function() {
     let dup = makeUncheckedSample().createTemporaryForEdit();
-    expect(!!dup.get("complete"),
+    expect(dup.get("complete"),
       `dup.complete after createTemporaryForEdit: ${dup.get("complete")} (typeof ${typeof dup.get("complete")})`)
-      .to.equal(false);
+      .to.be.falsy;
   });
 
   it("(B) complete=false survives dup.save() + reload via loadById", function() {
     let dup = makeUncheckedSample().createTemporaryForEdit();
     let reloaded = Alloy.createModel("sample");
     reloaded.loadById(dup.get("sampleId"));
-    expect(!!reloaded.get("complete"),
+    expect(reloaded.get("complete"),
       `reloaded.complete: ${reloaded.get("complete")} (typeof ${typeof reloaded.get("complete")})`)
-      .to.equal(false);
+      .to.be.falsy;
   });
 
   it("(C) toCerdiApiJson after the roundtrip still serialises complete=false", function() {

--- a/walta-app/app/spec/Sample_spec.js
+++ b/walta-app/app/spec/Sample_spec.js
@@ -1094,3 +1094,44 @@ describe("Sample model", function() {
     });
   });
 });
+
+describe("WB-143: complete=false survives the edit roundtrip", function() {
+  beforeEach(clearDatabase);
+
+  function makeUncheckedSample() {
+    let s = makeSampleData({
+      serverSampleId: 1862,
+      complete: 0,
+      dateCompleted: moment().format(),
+      serverSyncTime: moment().valueOf()
+    });
+    s.save();
+    return s;
+  }
+
+  it("(A) createTemporaryForEdit preserves complete=false in the in-memory dup", function() {
+    let dup = makeUncheckedSample().createTemporaryForEdit();
+    expect(!!dup.get("complete"),
+      `dup.complete after createTemporaryForEdit: ${dup.get("complete")} (typeof ${typeof dup.get("complete")})`)
+      .to.equal(false);
+  });
+
+  it("(B) complete=false survives dup.save() + reload via loadById", function() {
+    let dup = makeUncheckedSample().createTemporaryForEdit();
+    let reloaded = Alloy.createModel("sample");
+    reloaded.loadById(dup.get("sampleId"));
+    expect(!!reloaded.get("complete"),
+      `reloaded.complete: ${reloaded.get("complete")} (typeof ${typeof reloaded.get("complete")})`)
+      .to.equal(false);
+  });
+
+  it("(C) toCerdiApiJson after the roundtrip still serialises complete=false", function() {
+    let dup = makeUncheckedSample().createTemporaryForEdit();
+    let reloaded = Alloy.createModel("sample");
+    reloaded.loadById(dup.get("sampleId"));
+    let json = reloaded.toCerdiApiJson();
+    expect(json.complete,
+      `serialised complete: ${json.complete} (typeof ${typeof json.complete})`)
+      .to.equal(false);
+  });
+});

--- a/walta-app/app/spec/lib/chai-falsy.js
+++ b/walta-app/app/spec/lib/chai-falsy.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = (_chai, utils) => {
+  let Assertion = _chai.Assertion;
+
+  Assertion.addProperty('falsy', function () {
+    this.assert(
+        !this._obj
+      , 'expected #{this} to be falsy'
+      , 'expected #{this} to be truthy'
+      , false
+      , this._obj
+    );
+  });
+
+  Assertion.addProperty('truthy', function () {
+    this.assert(
+        !!this._obj
+      , 'expected #{this} to be truthy'
+      , 'expected #{this} to be falsy'
+      , true
+      , this._obj
+    );
+  });
+};


### PR DESCRIPTION
## Summary
- **Root cause**: on Android, `Ti.Database` binds a JS boolean parameter to a declared-INTEGER column as TEXT — so `dup.save()` after `createTemporaryForEdit` (or `sample.set("complete", false) + sample.save()` from the Notes toggle) wrote the string `"false"` into the `complete` column. Reload returned the string, then `toCerdiApiJson` did `!!"false"` (truthy) and the next upload PUT carried `"complete":true`. iPad downloaded the flipped value and the partial-survey checkbox appeared rechecked from the user's POV.
- **Fix**: coerce `complete` to integer `0/1` at the two sites that ever put a boolean into the attribute — `fromCerdiApiJson` (covers the `createTemporaryForEdit` roundtrip) and `Notes.onPartialChange` (covers the partial-toggle user path). No wire-protocol change; `toCerdiApiJson` keeps emitting boolean.
- **Five specs** lock the regression in: A–C cover the SQLite roundtrip in `Sample_spec`, D + E cover the Notes screen in `Notes_spec` (note-only edit and partial-toggle-off). All five pass on Android emulator (`Medium_Phone_API_36.1`) **and** iOS simulator.
- One drive-by: loosened one existing `Notes_spec` assertion (`.equal(false)` → `.equal(!!… false)`) since `complete` is now consistently integer `0/1`.

First slice of [Trello WB-143](https://trello.com/c/MDQTLn9h/143-sample-flipping-the-sample-is-complete-flag) — covers the on-device bug end-to-end. Diagnosis trail (iPad + Pixel persisted logs, Bugfender PUT at `2026-06-01T01:34:36` showing `"complete":true` despite the user's "left unchecked in android" notes) is in the Trello description.

## Test plan
- [x] `npx grunt --platform=android --simulator unit-test --grep=WB-143` — 5 passing
- [x] `npx grunt --platform=android --simulator unit-test --grep=Notes` — 8 passing (no regression)
- [x] `npx grunt --platform=ios --simulator unit-test --grep=WB-143` — 5 passing (control: fix is platform-portable)
- [x] **Manual on-device probe on Pixel 6 Pro (Android 16)** — both paths confirmed:
  - `createTemporaryForEdit` path: sample 1860 edit → notes-only change → `PUT … "complete":false` ✓
  - Notes toggle path: sample 1857 edit → toggle partial OFF → `PUT … "complete":false` ✓
- [x] iOS + Android acceptance suites stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)