### PR TITLE
WB-146: SampleEditMenu action pills are badly formatted

### DIFF
--- a/walta-app/app/controllers/SampleEditMenu.js
+++ b/walta-app/app/controllers/SampleEditMenu.js
@@ -1,34 +1,28 @@
-var { menuEntry } = require('ui/MenuBuilder');
 var Topics = require('ui/Topics');
 
-$.view = menuEntry( $.content, null, null, null,
-  "View selected survey.", false, true, "45%" );
-
-$.edit = menuEntry( $.content, null, null, null,
-  "Edit selected survey.", false, true, "45%" );
-
-$.view.on("click", () => {
+function onViewClick() {
     Alloy.Models.instance("sample").loadById($.args.sampleId);
-	Alloy.Collections.instance("taxa").load($.args.sampleId);
+    Alloy.Collections.instance("taxa").load($.args.sampleId);
     Topics.fireTopicEvent( Topics.SITEDETAILS, {slide:"right",readonly:true});
-} );
+}
 
-$.edit.on("click", () => {
-  
+function onEditClick() {
     let sample = Alloy.Models.instance("sample");
     sample.loadById($.args.sampleId);
     let tempSample = sample.createTemporaryForEdit();
     Alloy.Models.sample = tempSample;
     Alloy.Collections.taxa = tempSample.loadTaxa();
     Topics.fireTopicEvent( Topics.SITEDETAILS, {slide:"right",readonly:false});
-}  );
+}
 
+$.view.addEventListener("click", onViewClick);
+$.edit.addEventListener("click", onEditClick);
 $.closeButton.on("close", () => $.trigger("close") );
 
 function cleanUp() {
+  $.view.removeEventListener("click", onViewClick);
+  $.edit.removeEventListener("click", onEditClick);
   $.destroy();
   $.off();
-  $.view.cleanUp();
-  $.edit.cleanUp();
 }
 exports.cleanUp = cleanUp;

--- a/walta-app/app/spec/Main_spec.js
+++ b/walta-app/app/spec/Main_spec.js
@@ -62,7 +62,7 @@ describe("Main controller", function() {
     currentController().sampleTable.fireEvent("click", { index: 0 });
 
     await waitForTick(10)();
-    await actionFiresTopicTest( currentController().sampleMenu.edit.getView(), "click", Topics.PAGE_OPENED );
+    await actionFiresTopicTest( currentController().sampleMenu.edit, "click", Topics.PAGE_OPENED );
     currentController().waterbodyNameField.value = "changed by test edit";
     currentController().waterbodyNameField.fireEvent("change"); // simulate user entering text
 
@@ -94,9 +94,9 @@ describe("Main controller", function() {
    
     await actionFiresTopicTest( currentController().history, "click", Topics.PAGE_OPENED);
     currentController().sampleTable.fireEvent("click", { index: 0 });
-    await actionFiresTopicTest( currentController().sampleMenu.edit.getView(), "click", Topics.PAGE_OPENED );
+    await actionFiresTopicTest( currentController().sampleMenu.edit, "click", Topics.PAGE_OPENED );
 
-    // At this point the global sample SHOULD NOT be the original record but 
+    // At this point the global sample SHOULD NOT be the original record but
     // a temporary copy instead. This a new sample with the DateSubmitted field blank.
     expect( Alloy.Models.instance("sample").get("serverSampleId")).to.equal(666);
     expect( Alloy.Models.instance("sample").get("dateCompleted")).to.be.undefined;
@@ -123,7 +123,7 @@ describe("Main controller", function() {
     currentController().sampleTable.fireEvent("click", { index: 0 });
 
     
-    await actionFiresTopicTest( currentController().sampleMenu.view.getView(), "click", Topics.PAGE_OPENED );
+    await actionFiresTopicTest( currentController().sampleMenu.view, "click", Topics.PAGE_OPENED );
 
     // verify change has been persisted
     expect( currentController().waterbodyNameField.value ).to.equal("changed by test edit");

--- a/walta-app/app/spec/SampleEditMenu_spec.js
+++ b/walta-app/app/spec/SampleEditMenu_spec.js
@@ -1,0 +1,38 @@
+require("spec/lib/ti-mocha");
+var { expect } = require('spec/lib/chai');
+var { wrapViewInWindow, closeWindow, windowOpenTest } = require('spec/util/TestUtils');
+var Topics = require('ui/Topics');
+
+describe('SampleEditMenu', function() {
+	var mnu, win;
+	before( function(done) {
+		this.timeout(3000);
+		mnu = Alloy.createController("SampleEditMenu", { sampleId: 1 });
+		win = wrapViewInWindow( mnu.getView() );
+		windowOpenTest( win, done );
+	});
+
+	after( function(done) {
+		closeWindow( win, done );
+	});
+
+	it('fires SITEDETAILS readonly=true when View is tapped', function(done) {
+		function handler(e) {
+			Topics.unsubscribe( Topics.SITEDETAILS, handler );
+			expect( e.readonly ).to.equal( true );
+			done();
+		}
+		Topics.subscribe( Topics.SITEDETAILS, handler );
+		mnu.view.fireEvent("click");
+	});
+
+	it('fires SITEDETAILS readonly=false when Edit is tapped', function(done) {
+		function handler(e) {
+			Topics.unsubscribe( Topics.SITEDETAILS, handler );
+			expect( e.readonly ).to.equal( false );
+			done();
+		}
+		Topics.subscribe( Topics.SITEDETAILS, handler );
+		mnu.edit.fireEvent("click");
+	});
+});

--- a/walta-app/app/spec/SampleHistory_spec.js
+++ b/walta-app/app/spec/SampleHistory_spec.js
@@ -30,19 +30,19 @@ describe("SampleHistory controller", function() {
   it('selecting row should open menu', async function() {
     await controllerOpenTest( ctl );
     ctl.sampleTable.fireEvent("click", { index: 0 } );
-    expect( ctl.sampleMenu.view.description.text ).to.include("View");
+    expect( ctl.sampleMenu.view.accessibilityLabel ).to.include("View");
   });
   it('selecting view should raise view event', async function() {
     await controllerOpenTest( ctl );
     ctl.sampleTable.fireEvent("click", { index: 0 } );
-    let result = await actionFiresTopicTest( ctl.sampleMenu.view.getView(), "click", Topics.SITEDETAILS );
+    let result = await actionFiresTopicTest( ctl.sampleMenu.view, "click", Topics.SITEDETAILS );
     expect( result.readonly ).to.be.true;
 
   });
   it('selecting edit should raise edit event', async function() {
     await controllerOpenTest( ctl );
     ctl.sampleTable.fireEvent("click", { index: 0 } );
-    let result = await actionFiresTopicTest( ctl.sampleMenu.edit.getView(), "click", Topics.SITEDETAILS );
+    let result = await actionFiresTopicTest( ctl.sampleMenu.edit, "click", Topics.SITEDETAILS );
     expect( result.readonly ).to.be.false;
   });
   it('places a Sync button on the anchor bar toolbar', async function() {

--- a/walta-app/app/spec/index.js
+++ b/walta-app/app/spec/index.js
@@ -65,6 +65,7 @@ var SPEC_FILES = [
   "SampleSync",
   "SyncFeedback",
   "UploadBadge",
+  "SampleEditMenu",
   "SampleHistory",
   "Gallery",
   "PhotoSelect",

--- a/walta-app/app/styles/SampleEditMenu.tss
+++ b/walta-app/app/styles/SampleEditMenu.tss
@@ -1,15 +1,31 @@
 ".window": {
   width: "50%",
-  height: "46%"
+  height: Ti.UI.SIZE
 }
 
-".title": {
+"#content": {
+  width: Ti.UI.FILL,
+  height: Ti.UI.SIZE,
+  bottom: "8dp"
+}
+
+".actionRow": {
+  width: "94%",
+  height: "64dp",
   top: "8dp",
-  left: "24dp",
-  font: {
-    fontFamily: "sans-serif",
-    fontSize: "16dp"
-  }
+  borderRadius: "15dp",
+  backgroundColor: "#cfdbf3"
 }
 
-
+".actionRowText": {
+  width: Ti.UI.FILL,
+  height: Ti.UI.FILL,
+  textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER,
+  verticalAlign: Ti.UI.TEXT_VERTICAL_ALIGNMENT_CENTER,
+  font: {
+    fontFamily: "Tahoma",
+    fontWeight: "bold",
+    fontSize: "15dp"
+  },
+  color: Alloy.CFG.colors.primary
+}

--- a/walta-app/app/views/SampleEditMenu.xml
+++ b/walta-app/app/views/SampleEditMenu.xml
@@ -6,7 +6,12 @@
 					<Require id="closeButton" src="CloseButton"/>
 				</View>
 				<View id="content" layout="vertical">
-
+					<View id="view" class="actionRow" accessibilityLabel="View selected survey.">
+						<Label class="actionRowText">View selected survey.</Label>
+					</View>
+					<View id="edit" class="actionRow" accessibilityLabel="Edit selected survey.">
+						<Label class="actionRowText">Edit selected survey.</Label>
+					</View>
 				</View>
 			</View>
 	</View>


### PR DESCRIPTION
## Summary
- Drop `MenuButton` from `SampleEditMenu` and render the two action rows directly as styled `View` + `Label`. `MenuButton` is shaped for icon + title + description menu cards (MethodSelect); reusing it for SampleEditMenu's text-only rows produced oversized pills, an invisible 12% icon spacer pushing text right of centre, and a top-aligned description (so text wasn't vertically centred on Android either).
- Switch `.window` to `Ti.UI.SIZE` so the dialog auto-fits its contents instead of hard-coding `46%` height (which produced ~21%-of-screen pills and a band of dead space above the first button).
- Add a `SampleEditMenu_spec` that fires the View / Edit clicks and asserts `Topics.SITEDETAILS` is dispatched with the right `readonly` flag.

Closes [Trello WB-146](https://trello.com/c/twjhCXEl/146-sampleeditmenu-action-pills-are-badly-formatted) — verified visually on iOS simulator and Pixel 6 Pro device (matches MethodSelect-style proportions on both platforms; X close button intentionally left as the generous-touch-target it already was, per card scope).

## Test plan
- [x] `npx grunt unit-test-node` — 267 passing
- [x] `npx grunt --platform=ios --simulator --liveview --reuse-server --grep=SampleEditMenu unit-test` — spec passes
- [x] `npx grunt --platform=android --simulator --liveview --reuse-server --grep=SampleEditMenu unit-test` — spec passes
- [x] Visual check on iOS simulator (`--manual`) — text centred both axes; dialog auto-fits
- [x] Visual check on Pixel 6 Pro device — same; bug reported device
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)