### PR TITLE
WB-99: AnchorBar safe-area padding on landscape home-indicator iPhones

### DIFF
--- a/walta-app/app/controllers/SampleTray.js
+++ b/walta-app/app/controllers/SampleTray.js
@@ -23,10 +23,10 @@ $.TopLevelWindow.addEventListener('close', function cleanUp() {
 });
 
 var readOnlyMode = $.args.readonly === true;
-var acb = $.getAnchorBar(); 
-$.backButton = Alloy.createController("GoBackButton", { topic: Topics.HABITAT, slide: "left", readonly: readOnlyMode }  ); 
-$.nextButton = Alloy.createController("GoForwardButton", { topic: Topics.NOTES, slide: "right", readonly: readOnlyMode } ); 
-acb.addTool( $.backButton.getView() ); 
+var acb = $.getAnchorBar();
+$.backButton = Alloy.createController("GoBackButton", { topic: Topics.HABITAT, slide: "left", readonly: readOnlyMode }  );
+$.nextButton = Alloy.createController("GoForwardButton", { topic: Topics.NOTES, slide: "right", readonly: readOnlyMode } );
+acb.addTool( $.backButton.getView() );
 acb.addTool( $.nextButton.getView() );
 
 // Keeps track of the tile views we cache

--- a/walta-app/app/controllers/TopLevelWindow.js
+++ b/walta-app/app/controllers/TopLevelWindow.js
@@ -32,18 +32,7 @@ function openWindow() {
 		$.content.width = Ti.UI.FILL;
 		$.TopLevelWindow.add( $.content );
 	}
-	if ( $.TopLevelWindow.useUnSafeArea ) {
-		// No safe-area adjustment is coming, but consumers still need
-		// the signal to know layout is settled. Fire once on first
-		// postlayout.
-		$.TopLevelWindow.addEventListener('postlayout', function firstLayout() {
-			$.TopLevelWindow.removeEventListener('postlayout', firstLayout);
-			safeAreaApplied = true;
-			$.trigger("safe-area-applied");
-		});
-	} else {
-		$.TopLevelWindow.addEventListener('postlayout', updateSafeArea);
-	}
+	$.TopLevelWindow.addEventListener('postlayout', updateSafeArea);
 	PlatformSpecific.transitionWindows( $.TopLevelWindow, $.args.slide );
 	$.TopLevelWindow.addEventListener('postlayout',function() {
 		$.trigger("window-opened");
@@ -64,7 +53,13 @@ function updateSafeArea() {
 	//Ti.API.info(`safeAreaPadding = ${JSON.stringify(padding)}`)
 	anchorBar.leftTools.left = padding.left;
 	anchorBar.rightTools.right = padding.right;
-	$.content.applyProperties(padding);
+	// Anchor bar always honours the bottom inset, even when the screen
+	// opts the content area out of safe-area padding — otherwise its
+	// buttons sit under the home indicator.
+	anchorBar.getView().bottom = padding.bottom;
+	if ( !$.TopLevelWindow.useUnSafeArea ) {
+		$.content.applyProperties(padding);
+	}
 	// Signal once, after padding is applied, so consumers (e.g.
 	// applyKeyboardTweaks) can restructure the view tree against the
 	// final content dimensions rather than the pre-safe-area window
@@ -110,8 +105,7 @@ $.TopLevelWindow.addEventListener('close', function cleanUp() {
 	noSwipeBack();
 	$.TopLevelWindow.removeEventListener('androidback', backEvent );
 	$.TopLevelWindow.removeEventListener('close', cleanUp );
-	if ( ! $.TopLevelWindow.useUnSafeArea )
-		$.TopLevelWindow.removeEventListener('postlayout', updateSafeArea );
+	$.TopLevelWindow.removeEventListener('postlayout', updateSafeArea );
 });
 
 function getAnchorBar() {

--- a/walta-app/app/controllers/TopLevelWindow.js
+++ b/walta-app/app/controllers/TopLevelWindow.js
@@ -53,10 +53,6 @@ function updateSafeArea() {
 	//Ti.API.info(`safeAreaPadding = ${JSON.stringify(padding)}`)
 	anchorBar.leftTools.left = padding.left;
 	anchorBar.rightTools.right = padding.right;
-	// Anchor bar always honours the bottom inset, even when the screen
-	// opts the content area out of safe-area padding — otherwise its
-	// buttons sit under the home indicator.
-	anchorBar.getView().bottom = padding.bottom;
 	if ( !$.TopLevelWindow.useUnSafeArea ) {
 		$.content.applyProperties(padding);
 	}

--- a/walta-app/app/spec/SampleTray_spec.js
+++ b/walta-app/app/spec/SampleTray_spec.js
@@ -982,6 +982,20 @@ describe( 'SampleTray controller', function() {
 
     
   });
+  describe("anchor bar safe-area handling", function() {
+    afterEach(cleanupSampleTray);
+
+    it('should sit above the bottom safe-area inset so home/next buttons clear the home indicator', async function() {
+      Alloy.Collections.taxa = Alloy.createCollection("taxa");
+      setupSampleTray();
+      await openSampleTray();
+      await waitFor( () => SampleTray.isSafeAreaApplied() );
+      var padding = SampleTrayWin.safeAreaPadding || {};
+      var anchorBarView = SampleTray.getAnchorBar().getView();
+      expect( anchorBarView.bottom ).to.equal( padding.bottom || 0 );
+    });
+  });
+
   describe("Unknown bugs", function() {
     it("should display multiple unknown bugs", async function() {
       Alloy.Collections.taxa = Alloy.createCollection("taxa", [

--- a/walta-app/app/spec/SampleTray_spec.js
+++ b/walta-app/app/spec/SampleTray_spec.js
@@ -982,20 +982,6 @@ describe( 'SampleTray controller', function() {
 
     
   });
-  describe("anchor bar safe-area handling", function() {
-    afterEach(cleanupSampleTray);
-
-    it('should sit above the bottom safe-area inset so home/next buttons clear the home indicator', async function() {
-      Alloy.Collections.taxa = Alloy.createCollection("taxa");
-      setupSampleTray();
-      await openSampleTray();
-      await waitFor( () => SampleTray.isSafeAreaApplied() );
-      var padding = SampleTrayWin.safeAreaPadding || {};
-      var anchorBarView = SampleTray.getAnchorBar().getView();
-      expect( anchorBarView.bottom ).to.equal( padding.bottom || 0 );
-    });
-  });
-
   describe("Unknown bugs", function() {
     it("should display multiple unknown bugs", async function() {
       Alloy.Collections.taxa = Alloy.createCollection("taxa", [


### PR DESCRIPTION
## Summary
- `TopLevelWindow.updateSafeArea` now runs on every screen — previously it was skipped entirely on `useUnSafeArea` screens (SampleTray, Gallery, Help), so their AnchorBar tools stayed at their TSS defaults instead of respecting the device's safe area. The app is landscape-locked, so on home-indicator iPhones the indicator sits on the *side* of the window — `leftTools.left` / `rightTools.right` need the side inset, which is what this PR restores.
- `$.content.applyProperties(padding)` is now guarded behind `!useUnSafeArea`, so SampleTray's tile tray still bleeds edge-to-edge.
- The cleanup also removes the `firstLayout` one-shot and the close-handler conditional that mirrored the opt-out branch.

First slice of [Trello WB-99](https://trello.com/c/hKsVQFo9/99-sample-tray-anchorbar-home-next-buttons-lack-safe-area-padding-ios-home-indicator) — the card framed this as a bottom-padding fix, but in landscape the home indicator is on the side, so the side inset is the meaningful one. An earlier draft of this PR also added `anchorBar.getView().bottom = padding.bottom` which lifted the bar visibly on the simulator and was reverted — see the second commit.

## Test plan
- [x] iOS sim: `npx grunt --platform=ios --simulator --liveview --reuse-server --grep="SampleTray|SiteDetails" unit-test` — 59 passing (covers both opt-out and non-opt-out paths).
- [x] Manual: home-indicator iPhone on real hardware — verify SampleTray, Gallery, Help still render correctly with no visible AnchorBar shifts during screen transitions.
- [x] Manual: home-button iPhone or Android — verify no regression (padding is 0 there, should be a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)