### PR TITLE
WB-151: Make external test group release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -491,16 +491,41 @@ jobs:
             CHANGELOG_ARG=(--changelog "Release ${VERSION}")
           fi
 
-          fastlane pilot distribute \
-            --api_key_path /tmp/asc_key.json \
-            --app_identifier net.thewaterbug.waterbug \
-            --app_platform ios \
-            --app_version "$VERSION" \
-            --build_number "$VERSION" \
-            --groups "$GROUP" \
-            --distribute_external $EXTERNAL \
-            --notify_external_testers $EXTERNAL \
-            "${CHANGELOG_ARG[@]}"
+          # altool returns as soon as the IPA hits ASC; the build then takes
+          # a few minutes to appear via the ASC API. pilot distribute does
+          # a one-shot lookup and bails with "No build to distribute!" if
+          # the ingestion isn't done yet, so poll: retry on that specific
+          # error, fail fast on anything else.
+          ATTEMPTS=30
+          SLEEP_SECS=30
+          for i in $(seq 1 $ATTEMPTS); do
+            set +e
+            fastlane pilot distribute \
+              --api_key_path /tmp/asc_key.json \
+              --app_identifier net.thewaterbug.waterbug \
+              --app_platform ios \
+              --app_version "$VERSION" \
+              --build_number "$VERSION" \
+              --groups "$GROUP" \
+              --distribute_external $EXTERNAL \
+              --notify_external_testers $EXTERNAL \
+              "${CHANGELOG_ARG[@]}" 2>&1 | tee /tmp/pilot.log
+            PILOT_EXIT=${PIPESTATUS[0]}
+            set -e
+
+            if [ "$PILOT_EXIT" -eq 0 ]; then
+              echo "Distribute succeeded on attempt $i."
+              exit 0
+            fi
+            if ! grep -q "No build to distribute" /tmp/pilot.log; then
+              echo "::error::pilot distribute failed with a non-retriable error"
+              exit 1
+            fi
+            echo "Build not yet in ASC (attempt $i/$ATTEMPTS) — waiting ${SLEEP_SECS}s..."
+            sleep "$SLEEP_SECS"
+          done
+          echo "::error::Build never appeared in ASC after $((ATTEMPTS * SLEEP_SECS))s"
+          exit 1
 
       - name: Cleanup keychain
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -438,39 +438,30 @@ jobs:
             npx grunt --platform=ios clean release
           fi
 
-      - name: Upload to TestFlight
-        run: |
-          mkdir -p ~/private_keys
-          echo "${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}" | base64 --decode \
-            > ~/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}.p8
-
-          # altool has been observed to print "ERROR: …" and exit 0 on
-          # upload rejection (e.g. CFBundleVersion violations). Capture
-          # output and fail the step if any ERROR: line appears, even
-          # when altool itself reports success.
-          ALTOOL_LOG=$(mktemp)
-          xcrun altool --upload-app --type ios \
-            --file builds/release/Waterbug.ipa \
-            --apiKey ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }} \
-            --apiIssuer ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }} \
-            2>&1 | tee "$ALTOOL_LOG"
-          if grep -qE '^[0-9].* ERROR:' "$ALTOOL_LOG"; then
-            echo "::error::altool printed ERROR: lines despite exit 0 — upload rejected"
-            exit 1
-          fi
-
-      - name: Distribute build to TestFlight group
+      - name: Upload to TestFlight and assign to test group
         env:
           ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: |
+          # pilot upload (single step): uploads the IPA via fastlane's
+          # transporter, waits for ASC processing, then assigns the
+          # build it just uploaded to the right group. Using upload rather
+          # than altool + pilot distribute avoids a version-string-match
+          # race — pilot knows the build it uploaded by internal ID, not
+          # by querying ASC for a build matching --app_version/--build_number
+          # (which was wedging with "No build to distribute!" because Apple
+          # stores/returns the version field differently than pilot queries
+          # for it).
+          #
           # The Sandbox Api Testers internal group has "Enable automatic
-          # distribution" turned OFF, so altool uploads sit unassigned
-          # until this step explicitly hands the build to a group.
+          # distribution" turned OFF in ASC, so this --groups assignment is
+          # the only thing that puts a build in front of internal testers.
           # test → Sandbox Api Testers (internal, no review).
           # production → Production Api Testers (external, submits to
           # Beta App Review and notifies testers on approval).
-          VERSION="${{ needs.prepare.outputs.version }}"
+          mkdir -p ~/private_keys
+          echo "${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}" | base64 --decode \
+            > ~/private_keys/AuthKey_${ASC_KEY_ID}.p8
 
           # fastlane wants the ASC key as a JSON wrapper around the .p8.
           KEY_CONTENT=$(cat ~/private_keys/AuthKey_${ASC_KEY_ID}.p8)
@@ -481,51 +472,26 @@ jobs:
             '{key_id: $key_id, issuer_id: $issuer_id, key: $key, in_house: false}' \
             > /tmp/asc_key.json
 
+          VERSION="${{ needs.prepare.outputs.version }}"
           if [ "${{ inputs.environment }}" = "test" ]; then
             GROUP="Sandbox Api Testers"
             EXTERNAL=false
-            CHANGELOG_ARG=()
+            EXTRA_ARGS=()
           else
             GROUP="Production Api Testers"
             EXTERNAL=true
-            CHANGELOG_ARG=(--changelog "Release ${VERSION}")
+            EXTRA_ARGS=(--changelog "Release ${VERSION}")
           fi
 
-          # altool returns as soon as the IPA hits ASC; the build then takes
-          # a few minutes to appear via the ASC API. pilot distribute does
-          # a one-shot lookup and bails with "No build to distribute!" if
-          # the ingestion isn't done yet, so poll: retry on that specific
-          # error, fail fast on anything else.
-          ATTEMPTS=30
-          SLEEP_SECS=30
-          for i in $(seq 1 $ATTEMPTS); do
-            set +e
-            fastlane pilot distribute \
-              --api_key_path /tmp/asc_key.json \
-              --app_identifier net.thewaterbug.waterbug \
-              --app_platform ios \
-              --app_version "$VERSION" \
-              --build_number "$VERSION" \
-              --groups "$GROUP" \
-              --distribute_external $EXTERNAL \
-              --notify_external_testers $EXTERNAL \
-              "${CHANGELOG_ARG[@]}" 2>&1 | tee /tmp/pilot.log
-            PILOT_EXIT=${PIPESTATUS[0]}
-            set -e
-
-            if [ "$PILOT_EXIT" -eq 0 ]; then
-              echo "Distribute succeeded on attempt $i."
-              exit 0
-            fi
-            if ! grep -q "No build to distribute" /tmp/pilot.log; then
-              echo "::error::pilot distribute failed with a non-retriable error"
-              exit 1
-            fi
-            echo "Build not yet in ASC (attempt $i/$ATTEMPTS) — waiting ${SLEEP_SECS}s..."
-            sleep "$SLEEP_SECS"
-          done
-          echo "::error::Build never appeared in ASC after $((ATTEMPTS * SLEEP_SECS))s"
-          exit 1
+          fastlane pilot upload \
+            --api_key_path /tmp/asc_key.json \
+            --app_identifier net.thewaterbug.waterbug \
+            --app_platform ios \
+            --ipa builds/release/Waterbug.ipa \
+            --groups "$GROUP" \
+            --distribute_external $EXTERNAL \
+            --notify_external_testers $EXTERNAL \
+            "${EXTRA_ARGS[@]}"
 
       - name: Cleanup keychain
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -494,6 +494,7 @@ jobs:
           fastlane pilot distribute \
             --api_key_path /tmp/asc_key.json \
             --app_identifier net.thewaterbug.waterbug \
+            --app_platform ios \
             --app_version "$VERSION" \
             --build_number "$VERSION" \
             --groups "$GROUP" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,13 +263,15 @@ jobs:
             npx grunt --platform=android clean release
           fi
 
-      - name: Upload to Google Play (internal track)
+      - name: Upload to Google Play
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: net.thewaterbug.waterbug
           releaseFiles: builds/release/Waterbug.aab
-          track: internal
+          # test → internal track (sandbox testers).
+          # production → beta track (Open Testing, public opt-in link).
+          track: ${{ inputs.environment == 'production' && 'beta' || 'internal' }}
           status: completed
 
       - name: Upload build artifact
@@ -450,6 +452,48 @@ jobs:
             echo "::error::altool printed ERROR: lines despite exit 0 — upload rejected"
             exit 1
           fi
+
+      - name: Distribute build to TestFlight group
+        env:
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+        run: |
+          # The Sandbox Api Testers internal group has "Enable automatic
+          # distribution" turned OFF, so altool uploads sit unassigned
+          # until this step explicitly hands the build to a group.
+          # test → Sandbox Api Testers (internal, no review).
+          # production → Production Api Testers (external, submits to
+          # Beta App Review and notifies testers on approval).
+          VERSION="${{ needs.prepare.outputs.version }}"
+
+          # fastlane wants the ASC key as a JSON wrapper around the .p8.
+          KEY_CONTENT=$(cat ~/private_keys/AuthKey_${ASC_KEY_ID}.p8)
+          jq -n \
+            --arg key_id "$ASC_KEY_ID" \
+            --arg issuer_id "$ASC_ISSUER_ID" \
+            --arg key "$KEY_CONTENT" \
+            '{key_id: $key_id, issuer_id: $issuer_id, key: $key, in_house: false}' \
+            > /tmp/asc_key.json
+
+          if [ "${{ inputs.environment }}" = "test" ]; then
+            GROUP="Sandbox Api Testers"
+            EXTERNAL=false
+            CHANGELOG_ARG=()
+          else
+            GROUP="Production Api Testers"
+            EXTERNAL=true
+            CHANGELOG_ARG=(--changelog "Release ${VERSION}")
+          fi
+
+          fastlane pilot distribute \
+            --api_key_path /tmp/asc_key.json \
+            --app_identifier net.thewaterbug.waterbug \
+            --app_version "$VERSION" \
+            --build_number "$VERSION" \
+            --groups "$GROUP" \
+            --distribute_external $EXTERNAL \
+            --notify_external_testers $EXTERNAL \
+            "${CHANGELOG_ARG[@]}"
 
       - name: Cleanup keychain
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,8 +274,11 @@ jobs:
           packageName: net.thewaterbug.waterbug
           releaseFiles: builds/release/Waterbug.aab
           # test → internal track (sandbox testers).
-          # production → beta track (Open Testing, public opt-in link).
-          track: ${{ inputs.environment == 'production' && 'beta' || 'internal' }}
+          # production → alpha track (Closed Testing, email/Google Group
+          # allowlist) — mirrors the email-managed Production Api Testers
+          # external group on TestFlight, keeps tester control symmetric
+          # across stores, and stops random URL-clickers polluting CERDI.
+          track: ${{ inputs.environment == 'production' && 'alpha' || 'internal' }}
           status: completed
 
       - name: Upload build artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,11 @@ jobs:
   release-android:
     name: Android release
     needs: prepare
-    if: inputs.platforms != 'ios'
+    # always() + explicit needs.prepare.result check so the job runs when
+    # ci-gate was skipped via skip_ci_gate=true (prepare recovers via its
+    # own always(), but downstream non-status if: conditions otherwise
+    # propagate the upstream skip).
+    if: ${{ always() && needs.prepare.result == 'success' && inputs.platforms != 'ios' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -284,7 +288,9 @@ jobs:
   release-ios:
     name: iOS release
     needs: prepare
-    if: inputs.platforms != 'android'
+    # See release-android above for why this needs always() + the explicit
+    # prepare result check.
+    if: ${{ always() && needs.prepare.result == 'success' && inputs.platforms != 'android' }}
     runs-on: macos-latest
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
## Summary

- **Android**: `Upload to Google Play` step picks `track` from the `environment` input — `internal` for test, `alpha` (Closed Testing) for production. Closed Testing keeps tester management symmetric with TestFlight's external groups and stops random URL-clickers polluting the production CERDI server.
- **iOS**: replaces `altool` upload + `pilot distribute` with a single `pilot upload` step. The combined step uploads the IPA via fastlane's transporter, waits for ASC processing in-band, then assigns the build it just uploaded — by internal build ID, not by an ASC version-string lookup that was wedging with "No build to distribute!" when Apple's API returned the version field in a form pilot couldn't match.
- iOS test environment lands in **Sandbox Api Testers** (internal, no review); production lands in **Production Api Testers** (external, triggers Beta App Review and notifies testers on approval).
- **Drive-by**: fix `skip_ci_gate=true` propagation. When the CI gate was skipped, `prepare` recovered via its own `always()`, but `release-android` and `release-ios` then auto-skipped because their non-status `if:` conditions didn't explicitly handle the upstream skip. Made the platform jobs' `if:` explicit — `always() && needs.prepare.result == 'success' && ...`. Required to validate this PR's changes from the task branch.

First slice of [Trello WB-151](https://trello.com/c/LmNxxwao/151-make-external-test-group-release) — production releases now route to external test groups on both stores while sandbox builds remain on internal tracks.

### ASC configuration change (not in code)

The **Sandbox Api Testers** internal TestFlight group must have **"Enable automatic distribution" turned off** for the split to be clean. With it on, every uploaded build (including production ones) would auto-distribute to internal testers regardless of which group the CI assigns. Configured manually in App Store Connect by recreating the group with auto-distribute disabled at creation time.

## Test plan

Five workflow runs against the task branch with `environment=test`, `skip_ci_gate=true`:

- [x] **Android path**: signed release builds, uploads to Play internal track (test) — confirmed in Play Console.
- [x] **iOS path**: pilot upload uploads IPA, waits for ASC processing, assigns build to Sandbox Api Testers — confirmed in TestFlight Builds.
- [x] `skip_ci_gate=true` correctly propagates after the fix — both platform jobs run when CI gate is skipped.
- [x] `fastlane pilot` is preinstalled on the macOS runner (no extra `gem install` needed).
- [x] Tag `v<X.Y.Z.N>-test` created on successful runs.

Production-environment validation deferred to the first real `environment=production` trigger after merge:

- [ ] Android: build lands in Play Console **Closed Testing** track (alpha).
- [ ] iOS: build lands in TestFlight assigned to **Production Api Testers** external group, status moves through "Waiting for Review" → "In Beta App Review" → available to testers.
- [ ] Clean `v<X.Y.Z.N>` tag (no `-test` suffix).
- [ ] Sandbox Api Testers does **not** see the production build (proof the auto-distribute toggle is off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)