### PR TITLE
WB-151: stop pilot submitting test builds to Beta App Review

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -475,15 +475,23 @@ jobs:
             '{key_id: $key_id, issuer_id: $issuer_id, key: $key, in_house: false}' \
             > /tmp/asc_key.json
 
+          # `submit_beta_review` defaults to true in pilot and gates on
+          # `(groups || distribute_external)` (an OR), so just specifying
+          # --groups — even with an internal group like Sandbox Api Testers —
+          # silently submits the build to Beta App Review. Pass it explicitly:
+          # false for test (internal-only, no review needed), true for
+          # production (external, Apple review is the point).
           VERSION="${{ needs.prepare.outputs.version }}"
           if [ "${{ inputs.environment }}" = "test" ]; then
             GROUP="Sandbox Api Testers"
             EXTERNAL=false
-            EXTRA_ARGS=()
+            SUBMIT_REVIEW=false
+            CHANGELOG_ARGS=()
           else
             GROUP="Production Api Testers"
             EXTERNAL=true
-            EXTRA_ARGS=(--changelog "Release ${VERSION}")
+            SUBMIT_REVIEW=true
+            CHANGELOG_ARGS=(--changelog "Release ${VERSION}")
           fi
 
           fastlane pilot upload \
@@ -494,7 +502,8 @@ jobs:
             --groups "$GROUP" \
             --distribute_external $EXTERNAL \
             --notify_external_testers $EXTERNAL \
-            "${EXTRA_ARGS[@]}"
+            --submit_beta_review $SUBMIT_REVIEW \
+            "${CHANGELOG_ARGS[@]}"
 
       - name: Cleanup keychain
         if: always()


### PR DESCRIPTION
## Summary

Follow-up to #309. While exercising the release pipeline on `environment=test` we found that builds were leaking into Apple's Beta App Review queue and blocking subsequent production submissions with "Another build is in review." Two test builds (2.0.4.38 and 2.0.4.40) ended up there before we caught it.

Root cause is in fastlane pilot v2.235's `distribute_build`:

```ruby
if options[:submit_beta_review] && (options[:groups] || options[:distribute_external])
  uploaded_build.post_beta_app_review_submission
end
```

That's an **OR** — passing any `--groups` triggers review submission, even when the group is an internal-only group like Sandbox Api Testers. `submit_beta_review` defaults to true, so unless we pass it explicitly the pipeline submits every test build to Beta Review.

Pilot's `"Successfully distributed to Internal testers 🚀"` log line prints *after* the review submission, so the surface output looked correct and hid the leak.

Fix: pass `--submit_beta_review` explicitly — `false` for `environment=test` (internal-only, no review needed), `true` for `environment=production` (external, review is the point).

## Test plan

- [ ] Trigger `release.yml` from this branch with `environment=test`, `platforms=ios`, `skip_ci_gate=true`. Confirm in ASC that the resulting build:
  - Lands in **Sandbox Api Testers** (internal).
  - Is **not** in "Waiting for Review" / "In Beta App Review" status.
  - Has "Submit for Review" available as an action (proving it wasn't submitted).
- [ ] After merge, trigger a real `environment=production` run from main. Confirm the build IS submitted to Beta Review and assigned to Production Api Testers (i.e. the production path is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)