### PR TITLE
WB-152: Bump CI to Node 24 to unlock cucumber 13 (PR #312)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Restore node_modules cache
         id: node-modules-cache
@@ -134,7 +134,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Restore node_modules cache
         id: node-modules-cache
@@ -247,7 +247,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Restore node_modules cache
         id: node-modules-cache
@@ -360,7 +360,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - uses: actions/setup-java@v4
         with:
@@ -467,7 +467,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - uses: actions/setup-java@v4
         with:
@@ -593,7 +593,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Restore node_modules cache
         id: node-modules-cache
@@ -738,7 +738,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - uses: actions/setup-java@v4
         with:
@@ -882,7 +882,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Restore node_modules cache
         id: node-modules-cache
@@ -994,7 +994,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - uses: actions/setup-java@v4
         with:
@@ -308,7 +308,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Restore node_modules cache
         id: node-modules-cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ If unrelated work surfaces while you're in the middle of a task — a build fix,
 ### Setup
 
 ```bash
-brew install node@20
+brew install node@24
 brew install ios-deploy
 brew install libimobiledevice
 npm install

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,10 +10,10 @@ Install [Homebrew](https://brew.sh) if not already present:
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
-### Node.js 20
+### Node.js 24
 ```bash
-brew install node@20
-echo 'export PATH="/opt/homebrew/opt/node@20/bin:$PATH"' >> ~/.zshrc
+brew install node@24
+echo 'export PATH="/opt/homebrew/opt/node@24/bin:$PATH"' >> ~/.zshrc
 source ~/.zshrc
 ```
 


### PR DESCRIPTION
## Summary
- Cucumber 13 (dependabot PR #312) dropped Node 20.x — both acceptance jobs exit 75 at startup. Bumping CI to Node 24 unblocks #312 and lets the rest of the dependabot group land.
- Targeting **Node 24** specifically because it's the current Active LTS (until 2026-10-20, EOL 2028-04-30). Node 22 is already in Maintenance, so it would force another bump in ~10 months; Node 26 is still on the unstable Current line. Cucumber 13 supports `22 || 24 || >=26`.
- 9 `setup-node` sites in `.github/workflows/ci.yml` + 2 in `.github/workflows/release.yml`, plus `brew install node@20` → `node@24` in `CLAUDE.md` and `docs/installation.md`.

First slice of [Trello WB-152](https://trello.com/c/L5vvBzq3/152-bump-ci-to-node-24-to-unlock-cucumber-13-pr-312) — CI-side Node version bump only. Re-verifying appium 3.5 / driver bumps and any cucumber 13 BeforeAll/AfterAll semantic changes happens after this lands and dependabot rebases #312.

## Test plan
- [x] `npx grunt unit-test-node` — 302 passing locally (Node 20.19.4)
- [ ] CI green on this branch (the only thing that actually exercises Node 24)
- [ ] After merge: dependabot rebases #312; verify cucumber 13 boots and acceptance jobs run to completion
- [ ] Sanity-check Titanium SDK 13.2.0.GA + grunt-titanium + mocha behaviour on Node 24 via the CI logs (no expected breakage, but this is the main unknown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)