### PR TITLE
WB-147: Migrate CI workflow actions from Node.js 20 to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -66,15 +66,15 @@ jobs:
     if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
 
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -87,7 +87,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -107,7 +107,7 @@ jobs:
   # iOS unit and acceptance jobs can both consume it instead of each
   # rebuilding from scratch (WB-51). Tarballed before upload to preserve
   # the .app bundle's executable bits and framework symlinks, which
-  # actions/upload-artifact@v4 strips otherwise.
+  # actions/upload-artifact@v7 strips otherwise.
   ios-build:
     name: iOS simulator build
     needs: changes
@@ -119,7 +119,7 @@ jobs:
       # ios-simulator-tests, so all three iOS jobs share the same Xcode.
       XCODE_VERSION: "26.3"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select pinned Xcode
         run: |
@@ -132,13 +132,13 @@ jobs:
           sudo xcode-select -s "$XCODE_APP/Contents/Developer"
           xcodebuild -version
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
 
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -151,7 +151,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -167,7 +167,7 @@ jobs:
 
       - name: Restore Titanium SDK cache
         id: ti-sdk-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/Library/Application Support/Titanium/mobilesdk/osx/${{ steps.ti-version.outputs.version }}
           key: titanium-sdk-${{ steps.ti-version.outputs.version }}-osx
@@ -178,7 +178,7 @@ jobs:
 
       - name: Save Titanium SDK cache
         if: steps.ti-sdk-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/Library/Application Support/Titanium/mobilesdk/osx/${{ steps.ti-version.outputs.version }}
           key: titanium-sdk-${{ steps.ti-version.outputs.version }}-osx
@@ -216,7 +216,7 @@ jobs:
         run: tar -czf /tmp/waterbug-ios-sim.tgz -C builds/test-sim Waterbug.app
 
       - name: Upload Waterbug.app artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: waterbug-ios-sim
           path: /tmp/waterbug-ios-sim.tgz
@@ -232,7 +232,7 @@ jobs:
     env:
       XCODE_VERSION: "26.3"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select pinned Xcode
         run: |
@@ -245,13 +245,13 @@ jobs:
           sudo xcode-select -s "$XCODE_APP/Contents/Developer"
           xcodebuild -version
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
 
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -264,7 +264,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -273,7 +273,7 @@ jobs:
         run: sh install.sh
 
       - name: Download Waterbug.app artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: waterbug-ios-sim
           path: /tmp
@@ -332,7 +332,7 @@ jobs:
 
       - name: Upload simulator screenshot
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: simulator-screenshot
           path: /tmp/sim-screenshot.png
@@ -356,20 +356,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -382,7 +382,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -401,7 +401,7 @@ jobs:
 
       - name: Restore Titanium SDK cache
         id: ti-sdk-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.titanium/mobilesdk/linux/${{ steps.ti-version.outputs.version }}
           key: titanium-sdk-${{ steps.ti-version.outputs.version }}-linux
@@ -412,7 +412,7 @@ jobs:
 
       - name: Save Titanium SDK cache
         if: steps.ti-sdk-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.titanium/mobilesdk/linux/${{ steps.ti-version.outputs.version }}
           key: titanium-sdk-${{ steps.ti-version.outputs.version }}-linux
@@ -429,7 +429,7 @@ jobs:
       # (where module versions are declared); restore-keys lets a stale
       # cache populate most of the deps when only one bumps.
       - name: Cache gradle dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -443,7 +443,7 @@ jobs:
         run: npx grunt exec:build:android:test-sim
 
       - name: Upload Waterbug.apk artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: waterbug-android-sim
           path: builds/test-sim/Waterbug.apk
@@ -463,20 +463,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -489,7 +489,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -498,7 +498,7 @@ jobs:
         run: sh install.sh
 
       - name: Download Waterbug.apk artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: waterbug-android-sim
           path: builds/test-sim
@@ -511,7 +511,7 @@ jobs:
 
       - name: Restore Android AVD cache
         id: avd-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             ~/.android/avd/*
@@ -533,7 +533,7 @@ jobs:
 
       - name: Save Android AVD cache
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             ~/.android/avd/*
@@ -578,7 +578,7 @@ jobs:
       # between versions. 26.3 is the current App Store submission target.
       XCODE_VERSION: "26.3"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select pinned Xcode
         run: |
@@ -591,13 +591,13 @@ jobs:
           sudo xcode-select -s "$XCODE_APP/Contents/Developer"
           xcodebuild -version
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
 
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -610,7 +610,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -619,7 +619,7 @@ jobs:
         run: sh install.sh
 
       - name: Download Waterbug.app artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: waterbug-ios-sim
           path: /tmp
@@ -671,7 +671,7 @@ jobs:
       # unrelated dependency bumps don't invalidate the cache.
       - name: Cache prebuilt WebDriverAgent
         id: wda-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.WDA_DERIVED_DATA_PATH }}
           key: wda-prebuilt-xcode-${{ env.XCODE_VERSION }}-${{ hashFiles('node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent/package.json') }}
@@ -686,7 +686,7 @@ jobs:
       # Keyed on package-lock.json so dependency upgrades bust the cache.
       # See WB-50.
       - name: Cache Appium driver hashes
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules/.cache/appium
           key: appium-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -720,7 +720,7 @@ jobs:
 
       - name: Upload per-scenario failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: acceptance-failures-ios
           path: /tmp/acceptance-artifacts
@@ -734,20 +734,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -760,7 +760,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -769,7 +769,7 @@ jobs:
         run: sh install.sh
 
       - name: Download Waterbug.apk artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: waterbug-android-sim
           path: builds/test-sim
@@ -782,7 +782,7 @@ jobs:
 
       - name: Restore Android AVD cache
         id: avd-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             ~/.android/avd/*
@@ -804,7 +804,7 @@ jobs:
 
       - name: Save Android AVD cache
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             ~/.android/avd/*
@@ -818,7 +818,7 @@ jobs:
       # Keyed on package-lock.json so dependency upgrades bust the cache.
       # See WB-50.
       - name: Cache Appium driver hashes
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules/.cache/appium
           key: appium-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -845,7 +845,7 @@ jobs:
 
       - name: Upload per-scenario failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: acceptance-failures-android
           path: /tmp/acceptance-artifacts
@@ -867,7 +867,7 @@ jobs:
       WDA_DERIVED_DATA_PATH: ${{ github.workspace }}/.wda-derived
       XCODE_VERSION: "26.3"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select pinned Xcode
         run: |
@@ -880,13 +880,13 @@ jobs:
           sudo xcode-select -s "$XCODE_APP/Contents/Developer"
           xcodebuild -version
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
 
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -899,7 +899,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -908,7 +908,7 @@ jobs:
         run: sh install.sh
 
       - name: Download Waterbug.app artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: waterbug-ios-sim
           path: /tmp
@@ -948,7 +948,7 @@ jobs:
 
       - name: Cache prebuilt WebDriverAgent
         id: wda-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.WDA_DERIVED_DATA_PATH }}
           key: wda-prebuilt-xcode-${{ env.XCODE_VERSION }}-${{ hashFiles('node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent/package.json') }}
@@ -958,7 +958,7 @@ jobs:
         run: bash build-utils/prebuild-wda.sh
 
       - name: Cache Appium driver hashes
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules/.cache/appium
           key: appium-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -976,7 +976,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-failures-ios
           path: /tmp/acceptance-artifacts
@@ -990,20 +990,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -1016,7 +1016,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -1025,7 +1025,7 @@ jobs:
         run: sh install.sh
 
       - name: Download Waterbug.apk artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: waterbug-android-sim
           path: builds/test-sim
@@ -1038,7 +1038,7 @@ jobs:
 
       - name: Restore Android AVD cache
         id: avd-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             ~/.android/avd/*
@@ -1060,7 +1060,7 @@ jobs:
 
       - name: Save Android AVD cache
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             ~/.android/avd/*
@@ -1069,7 +1069,7 @@ jobs:
           key: avd-30-google_apis-x86
 
       - name: Cache Appium driver hashes
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules/.cache/appium
           key: appium-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -1091,7 +1091,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-failures-android
           path: /tmp/acceptance-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
     if: ${{ !inputs.skip_ci_gate }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Verify latest CI on release SHA succeeded
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -94,7 +94,7 @@ jobs:
       version_code: ${{ steps.version.outputs.version_code }}
       tag_name: ${{ steps.version.outputs.tag_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # need full history for tags
 
@@ -160,20 +160,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -186,7 +186,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -230,7 +230,7 @@ jobs:
 
       - name: Restore Titanium SDK cache
         id: ti-sdk-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.titanium/mobilesdk/linux/${{ steps.ti-version.outputs.version }}
           key: titanium-sdk-${{ steps.ti-version.outputs.version }}-linux
@@ -241,7 +241,7 @@ jobs:
 
       - name: Save Titanium SDK cache
         if: steps.ti-sdk-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.titanium/mobilesdk/linux/${{ steps.ti-version.outputs.version }}
           key: titanium-sdk-${{ steps.ti-version.outputs.version }}-linux
@@ -282,7 +282,7 @@ jobs:
           status: completed
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-release-${{ needs.prepare.outputs.display_version }}
           path: builds/release/Waterbug.*
@@ -297,7 +297,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select latest Xcode
         run: |
@@ -306,13 +306,13 @@ jobs:
           sudo xcode-select -s "/Applications/$LATEST_XCODE/Contents/Developer"
           xcodebuild -version
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
 
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -325,7 +325,7 @@ jobs:
 
       - name: Save node_modules cache
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -376,7 +376,7 @@ jobs:
 
       - name: Restore Titanium SDK cache
         id: ti-sdk-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/Library/Application Support/Titanium/mobilesdk/osx/${{ steps.ti-version.outputs.version }}
           key: titanium-sdk-${{ steps.ti-version.outputs.version }}-osx
@@ -387,7 +387,7 @@ jobs:
 
       - name: Save Titanium SDK cache
         if: steps.ti-sdk-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/Library/Application Support/Titanium/mobilesdk/osx/${{ steps.ti-version.outputs.version }}
           key: titanium-sdk-${{ steps.ti-version.outputs.version }}-osx
@@ -510,7 +510,7 @@ jobs:
         run: security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-release-${{ needs.prepare.outputs.display_version }}
           path: builds/release/Waterbug.ipa
@@ -525,7 +525,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create and push tag
         run: |


### PR DESCRIPTION
## Summary

- Bump all 9 distinct action pins in `ci.yml` + `release.yml` to their current Node-24-compatible majors so they survive GitHub's **2026-06-16 Node 20 default-switch** (one week out) and the **2026-09-16 Node 20 runtime removal**.
- `actions/checkout v4→v6`, `setup-node v4→v6`, `setup-java v4→v5`, `cache v4→v5` (incl. `cache/restore` + `cache/save`), `upload-artifact v4→v7`, `download-artifact v4→v8`, `dorny/paths-filter v3→v4`.
- Pre-checked the riskier upgrades against release notes: `download-artifact@v5` only changed the layout for downloads *by ID* (we use by name); `download-artifact@v8` errors on hash mismatch by default (security improvement, no normal-path impact); `setup-node@v5+` auto-caches when `package.json` has a `packageManager` field — we don't have one, so no collision with our manual `actions/cache/restore`+`save` pattern.
- Drive-by: one stale comment in `ci.yml` ("`actions/upload-artifact@v4` strips otherwise") refreshed to match the new pin.

First (and only) slice of [Trello WB-147](https://trello.com/c/RUSm2XSI/147-migrate-ci-workflow-actions-from-nodejs-20-to-nodejs-24) — pure version-pin bumps, no behavioural change to the workflows.

Note: PR #311 (commit 75d29431) earlier today bumped the `node-version:` *input* to setup-node from 20→24 to unblock cucumber 13. That was the *app runtime* — explicitly out of scope of WB-147, which is about the *action runtime*. This PR finishes that other half.

## Test plan

- [ ] CI run on this PR is green — no Node-20 deprecation warnings in any job log
- [ ] Eyeball each action's CI behaviour against the previous main run (cache hit/miss accounting, artifact upload/download paths)
- [ ] Spot-check one acceptance failure-artifact upload still includes the per-scenario logs/screenshots the way it does on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)