### PR TITLE
WB-154: Repair ProxyCreateHTTPClient — bring back into sync with CerdiApi

### DIFF
--- a/contract-tests/CerdiApi_spec.js
+++ b/contract-tests/CerdiApi_spec.js
@@ -34,6 +34,7 @@ function ProxyCreateHTTPClient( params ) {
         onerror: params.onerror,
         timeout: (params.timeout ? params.timeout : 5000 ),
         headers: {},
+        _responseHeaders: {},
         setRequestHeader( name, value ) {
             this.headers[name] = value;
         },
@@ -41,17 +42,34 @@ function ProxyCreateHTTPClient( params ) {
             this.url = url;
             this.method = method;
         },
+        // Ti.Network.HTTPClient.getAllResponseHeaders returns one string,
+        // CRLF-joined, parsed by HttpHeaders.parse in CerdiApi.js:33.
+        getAllResponseHeaders() {
+            return Object.entries(this._responseHeaders)
+                .map(([name, value]) => `${name}: ${value}`)
+                .join("\r\n");
+        },
+        // Ti.Network.HTTPClient.getResponseHeader(name) returns the value,
+        // or null. Node lowercases header names in res.headers, so do a
+        // case-insensitive lookup.
+        getResponseHeader( name ) {
+            const lower = name.toLowerCase();
+            for (const key of Object.keys(this._responseHeaders)) {
+                if (key.toLowerCase() === lower) return this._responseHeaders[key];
+            }
+            return null;
+        },
         send( data ) {
-            //console.log(`REQUEST (${this.method}) to ${this.url}:s  data =`, data);
-            let attrs = { 
-                method: this.method, 
-                url: this.url, 
-                headers: this.headers, 
+            let attrs = {
+                method: this.method,
+                url: this.url,
+                headers: this.headers,
                 json: false
             }
             if ( typeof(data) === "object" && (this.method === "POST" || this.method === "PUT") && data.photo ) {
-                // Assume this is the image posts and set up options value 
-                // accordingly... Titanium seems to do this for us....
+                // Image posts: Ti.Network constructs multipart/form-data
+                // transparently when send() is given a {photo, count}
+                // dict; mirror that here so CerdiApi.js doesn't need to know.
                 attrs.formData = {};
                 if ( data.count ) {
                     attrs.formData.count = data.count;
@@ -62,32 +80,29 @@ function ProxyCreateHTTPClient( params ) {
                             filename: "unittest.jpg",
                             contentType: "image/jpeg"
                         }
-                }; 
+                };
             } else {
                 attrs.body = data;
             }
-            //console.log("headers= ", JSON.stringify(attrs.headers));
             let rawContentChunks = [];
             request(attrs, (err,res,body) => {
                 if ( err ) {
-                    //console.log(`ERROR ${err}`);
+                    params.onerror.call( this, err );
+                    return;
+                }
+                let rawData = Buffer.concat(rawContentChunks);
+                this.responseData = rawData;
+                this.responseText = rawData.toString("utf8");
+                this.status = res.statusCode;
+                this._responseHeaders = res.headers || {};
+                if ( isHttpError( res.statusCode ) ) {
+                    params.onerror.call( this, { status: res.statusCode } );
                 } else {
-                    //console.log(`RESPONSE ${res.statusCode}: ${prettyJson(res.body)}`);
-                    let rawData = Buffer.concat(rawContentChunks);
-                    this.responseData = rawData;
-                    this.responseText = rawData.toString("utf8");
-                    if ( err || isHttpError( res.statusCode ) ) {
-                        params.onerror.call( this, err );
-                    } else {
-                        params.onload.call( this, res );
-                    }
+                    params.onload.call( this, res );
                 }
             })
             .on('error', err => params.onerror.call({}, err ) )
-            .on('data', chunk => rawContentChunks.push(chunk) )
-            .on('socket', socket => {
-                socket.on('keylog', line => fs.appendFileSync('/tmp/secrets.log', line));
-            });
+            .on('data', chunk => rawContentChunks.push(chunk) );
         }
     }
 }
@@ -459,22 +474,13 @@ describe('CerdiApi', function() {
         });
 
         context("image comparision tests", function() {
-            /* FIXME: need to build images and related modules on Mac OS Arm 64 for the following
-               to work. For now just disabled them. */
-            /*
-                const { assertLooksSame, diffImages } = require('../features/support/image-test');
-                const images = require('images');
-                
-            */
+            // Skipped: image-diff helpers (assertLooksSame, rescaleImage) were
+            // removed when WB-92 replaced the macOS-arm64-hanging `looks-same`
+            // and `images` packages. Re-enable when WB-92 follow-up wires up
+            // pixelmatch-based assertions for contract tests.
             function assertLooksSame() { throw Error("assertLooksSame unimplemented") }
-            function rescaleImage(filePath,width) {
-                let img = fs.readFileSync(filePath);
-                /*if ( img === undefined ) 
-                        throw new Error(`Unable to read file ${filePath}`);
-                return images(img).size(width).encode("png");*/
-                return img;
-            }
-            it("should retrieve unknown creature photo", function() {
+            function rescaleImage(filePath,width) { return fs.readFileSync(filePath); }
+            it.skip("should retrieve unknown creature photo", function() {
                 let serverSampleId, unknownCreaturePhotoId;
                 return cerdi
                     .loginUser( 'testlogin@example.com', 'tstPassw0rd!' )
@@ -485,7 +491,7 @@ describe('CerdiApi', function() {
                     .then( () => cerdi.retrievePhoto(unknownCreaturePhotoId,"testsitephoto.jpg"))
                     .then( () => assertLooksSame(creaturePhotoPath,`/tmp/waterbugtest/applicationData/testsitephoto.jpg`));
             });
-            it("should retrieve site photo", function() {
+            it.skip("should retrieve site photo", function() {
                 let serverSampleId,sitePhotoId;
                 
                 let siteImageRescaled = rescaleImage(sitePhotoPath,1280);
@@ -498,7 +504,7 @@ describe('CerdiApi', function() {
                     .then( () => cerdi.retrieveSitePhoto(serverSampleId,"testsitephoto.jpg"))
                     .then( () => assertLooksSame(siteImageRescaled,`/tmp/waterbugtest/applicationData/testsitephoto.jpg`));
             });
-            it("should retrieve creature photo", function() {
+            it.skip("should retrieve creature photo", function() {
                 let serverSampleId,sitePhotoId,creaturePhotoId;
                 return cerdi
                     .loginUser( 'testlogin@example.com', 'tstPassw0rd!' )

--- a/contract-tests/README.md
+++ b/contract-tests/README.md
@@ -1,0 +1,42 @@
+# Contract tests
+
+`contract-tests/CerdiApi_spec.js` exercises `walta-app/app/lib/logic/CerdiApi.js` against the **real** CERDI sandbox API at `api-sandbox.waterbugblitz.org.au/v1`. The aim is to verify that our client code agrees with the live API — not to mock it.
+
+Distinct from the other test layers:
+
+| Layer | Mock or real? | Runs in CI? |
+|---|---|---|
+| `test/` (Node unit) | Mocked dependencies | Yes |
+| `walta-app/app/spec/` (device unit) | Mocked `Ti.*` | Yes |
+| `features/` (Cucumber acceptance) | Real Appium, mock CERDI server | Yes |
+| `end-to-end-testing/` (Appium integration) | Real Appium, mock CERDI server, dormant | No (revival = WB-104) |
+| **`contract-tests/` (this directory)** | **Real CERDI sandbox API** | **No** |
+
+## How it works
+
+The spec mocks `Ti.Network.createHTTPClient` with `ProxyCreateHTTPClient`, which preserves Titanium's `client.{open, setRequestHeader, send, getAllResponseHeaders, getResponseHeader}` shape but forwards each call through the `request` npm package to the real sandbox. The production `CerdiApi.js` runs unchanged — only its HTTP transport is swapped at the boundary.
+
+When `CerdiApi.js` adds a new `Ti.Network` method call, the proxy needs the matching method added too. See WB-154 (2026-06-09) for the history of letting that drift.
+
+## Running
+
+```bash
+npx grunt contract-test
+```
+
+Requires network access to `api-sandbox.waterbugblitz.org.au` and a test account on the sandbox (`testlogin@example.com` / `tstPassw0rd!` is what the existing tests use). Run time is around 2 minutes against a healthy sandbox.
+
+## Expected output (as of 2026-06-09, post-WB-154)
+
+- 15 passing
+- 3 pending (`it.skip`ped image-comparison tests — see WB-92 for the missing pixelmatch wiring)
+- 3 failing — known pre-existing issues each tracked separately:
+  - WB-156 — `#obtainAccessToken` token-expiration tests time out under `sinon.useFakeTimers` + `nock`
+  - WB-157 — `should update unknown creatures` count drift (15 expected, 6 returned)
+
+Run to investigate the sandbox; not part of regular CI because the suite would hammer CERDI's sandbox on every push.
+
+## Out of scope
+
+- Migrating off `request` (deprecated). Tracked separately under WB-153 follow-up — only safe to do once this suite is reliably green so the refactor has a baseline to compare against.
+- Adding to CI. The point of contract tests is to surface assumption mismatches against the live API; running on every push would be slow + noisy.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -47,11 +47,8 @@ npx grunt --platform=android end-to-end-test
 # Acceptance tests
 npx grunt --platform=android acceptance-test
 
-# Contract tests (API contract verification)
+# Contract tests (API contract verification — see contract-tests/README.md)
 npx grunt contract-test
-
-# Visual regression tests
-npx grunt --platform=android visual-regression-test
 ```
 
 ## Shared Appium orchestration


### PR DESCRIPTION
## Summary

`contract-tests/CerdiApi_spec.js` failed 21/21 against the CERDI sandbox with `client.getAllResponseHeaders is not a function`. The `ProxyCreateHTTPClient` mock had drifted from the `Ti.Network.HTTPClient` shape that production `CerdiApi.js` calls. Audit found **three** drift points, not just the one [WB-154](https://trello.com/c/6hvUxmcQ/154-repair-contract-tests-cerdiapispecjs-proxy-tinetwork-shape-has-drifted-from-cerdiapi) flagged:

| Required by CerdiApi.js | Present in proxy before? |
|---|---|
| `client.getAllResponseHeaders()` | ✗ |
| `client.getResponseHeader(name)` | ✗ |
| `this.status` (set from `res.statusCode`) | ✗ |

All three added; the success / error paths now populate `responseData` / `responseText` / `status` consistently, and the err branch actually calls `params.onerror` (the original silently swallowed network errors). The `/tmp/secrets.log` TLS keylog hook was dropped — debug aid, not load-bearing.

## Result against the sandbox

| State | Pass | Pending | Fail |
|---|---|---|---|
| Before | 0 | 0 | 21 |
| After this PR | **15** | **3** | **3** |

- **15 passing** — every test that actually exercises CerdiApi against the sandbox now runs to completion.
- **3 pending** — converted the existing `assertLooksSame unimplemented` stubs to `it.skip`. These were left as failure-throwing functions when WB-92 replaced the macOS-arm64-hanging `looks-same` package; running them was masked by the proxy bug. They'll be `it()` again when WB-92's pixelmatch wiring lands for the contract suite.
- **3 failing** — pre-existing, surfaced by this PR, **tracked separately**:
  - [WB-156](https://trello.com/c/wsO4P5fe) — `#obtainAccessToken` token-expiration tests time out at 60s (sinon.useFakeTimers + nock interaction)
  - [WB-157](https://trello.com/c/OUv7r8nA) — `should update unknown creatures` count update doesn't persist (15 expected, 6 returned)

## Drive-by

`docs/testing.md` still referenced the `visual-regression-test` grunt task — removed by WB-153 PR #318 (Kobiton cleanup). Removed the stale instruction and added a pointer to the new `contract-tests/README.md`.

## Out of scope

- **Migrating `request` → `node:fetch` / undici.** Originally proposed as PR B of WB-153 but pulled out because there was no green baseline to verify a refactor against. Now we have one; tracked as a WB-153 follow-up.
- **Fixing WB-156 / WB-157.** Each is its own diagnostic surface; not in this PR per "one PR = one responsibility".

## Test plan

- [x] `npx grunt contract-test` runs to completion: 15 passing, 3 pending, 3 failing
- [x] All 3 remaining failures match the cards filed above
- [ ] CI green (unit-test-node, build-test, iOS+Android unit/acceptance/e2e — contract-test is dev-only and not in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)