### PR TITLE
WB-156: Scope token-expiration fake timers to Date only

### DIFF
--- a/contract-tests/CerdiApi_spec.js
+++ b/contract-tests/CerdiApi_spec.js
@@ -249,7 +249,10 @@ describe('CerdiApi', function() {
         describe('token expiration', function() {
             let clock;
             beforeEach( function() {
-                clock = sinon.useFakeTimers( { now: 12345678 });
+                // toFake: ['Date'] — sinon 22 patches setImmediate by default, which
+                // suspends nock's async response delivery (callback never fires →
+                // 60s test timeout). We only need fake Date for the cache-age math.
+                clock = sinon.useFakeTimers( { now: 12345678, toFake: ['Date'] });
                 nock(SERVER_URL)
                     .post( '/token/create/server')
                     .reply( 200, {


### PR DESCRIPTION
## Summary

The two `#obtainAccessToken > token expiration` contract tests were timing out at 60s. Diagnosed as a sinon 22 / nock interaction: `sinon.useFakeTimers({now: 12345678})` defaults to patching `setImmediate` (since sinon 9+), and nock 14 routes its async response delivery through `setImmediate`. Under suspended timers, the proxy's request callback never fires → 60s test timeout.

Confirmed with a minimal repro: `useFakeTimers({now})` default → nock+request callback never fires (even after `clock.runAllAsync()`); `useFakeTimers({now, toFake: ['Date']})` → callback fires immediately.

The tests only need fake `Date` for the cache-age math:

```js
let tokenAge = Date.now() - cachedAppAccessToken.retrieved_at;
if (tokenAge < cachedAppAccessToken.expires_in * 1000) return cachedAppAccessToken;
```

`clock.tick(1000)` still advances Date under `toFake: ['Date']`, so the "renew after expiry" test still works.

## Result

| State | Pass | Pending | Fail | Run time |
|---|---|---|---|---|
| Before | 15 | 3 | 3 | ~2 min |
| After | **17** | 3 | **1** | **22s** |

The remaining 1 failure is [WB-157](https://trello.com/c/OUv7r8nA) (unknown-creatures count drift, unrelated). The 3 pending are the `it.skip`ped image-comparison tests pending WB-92's pixelmatch wiring.

## Diagnostic flow (for the record)

Followed the [diagnose-bug](.claude/skills/diagnose-bug/SKILL.md) discipline:

1. **Capture failure verbatim**: 60s timeout, no error stack
2. **2-3 hypotheses**: (a) nock+sinon timer interaction, (b) stale cached token from prior test, (c) request library internal timers
3. **Discriminate**: (b) ruled out — would produce assertion failure not timeout. Built a minimal repro for (a)/(c) → both point at sinon's default `toFake` set being too aggressive for nock-intercepted HTTP.
4. **Verify**: `toFake: ['Date']` repro succeeds; same change applied to the failing tests works in the actual suite.

## Test plan

- [x] `npx grunt contract-test` — 17 passing, 3 pending, 1 failing (matches WB-157 only)
- [x] Both token-expiration tests pass: `should cache the previous value`, `should renew the value after it has expired`
- [ ] CI green (this PR doesn't touch app code; CI will skip-on-paths-filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)