### PR TITLE
fix(build): target emulator on android --simulator despite pinned ANDROID_DEVICE_SERIAL

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,8 +58,22 @@ module.exports = function(grunt) {
       return '127.0.0.1';
     }
 
+    // The serial of a running emulator (emulator-NNNN), or undefined if none is up.
+    function resolveEmulatorSerial() {
+      const { execFileSync } = require('child_process');
+      const adbBin = process.env.ANDROID_SDK_ROOT ? `${process.env.ANDROID_SDK_ROOT}/platform-tools/adb` : 'adb';
+      try {
+        const out = execFileSync(adbBin, ['devices'], { encoding: 'utf8' });
+        const line = out.split('\n').find((l) => /^emulator-\d+\s+device\b/.test(l));
+        return line ? line.split(/\s+/)[0] : undefined;
+      } catch (e) {
+        return undefined;
+      }
+    }
+
     function createLiveViewLauncher(platform, { isSimulator = false, target, unitTest = false, buildOnly = true, noPrompt = true } = {}) {
       const args = ["serve", "-p", platform, "-d", "./walta-app", "--deploy-type", "development", "--liveview-ip", getLocalIP()];
+      const env = { ALLOY_PATH: "./node_modules/.bin/alloy" };
       if (target) {
         args.push("--target", target);
       }
@@ -70,6 +84,10 @@ module.exports = function(grunt) {
         if (SIM_UDID) args.push("-C", SIM_UDID);
       } else if (platform === "android" && isSimulator) {
         args.push("-C", "Medium_Phone_API_36.1", "--target", "emulator");
+        // A profile-level ANDROID_DEVICE_SERIAL pins adb to a physical device,
+        // overriding --target emulator. Point adb at the running emulator (or
+        // clear the pin when none is up) so the build, install and logcat land there.
+        env.ANDROID_DEVICE_SERIAL = resolveEmulatorSerial();
       } else if (platform === "android" && !isSimulator) {
         if (ANDROID_DEVICE_SERIAL) args.push("-C", ANDROID_DEVICE_SERIAL);
         args.push("--target", "device");
@@ -79,7 +97,7 @@ module.exports = function(grunt) {
       if (noPrompt) args.push("--no-prompt");
       // Dynamic import for ESM module
       return import("./build-utils/LiveViewLauncher.js").then(({ default: LiveViewLauncher }) =>
-        new LiveViewLauncher({ command: "./node_modules/.bin/titanium", args, env: { ALLOY_PATH: "./node_modules/.bin/alloy" } })
+        new LiveViewLauncher({ command: "./node_modules/.bin/titanium", args, env })
       );
     }
 

--- a/build-tests/unit/LiveViewLauncher_spec.js
+++ b/build-tests/unit/LiveViewLauncher_spec.js
@@ -82,6 +82,27 @@ describe("LiveViewLauncher", function () {
       await startPromise; // should resolve without timeout
     });
 
+    it("should drop an inherited env var when the override value is undefined", async function () {
+      const { stub } = makeSpawn("[LiveView] Server ready");
+      const prev = process.env.ANDROID_DEVICE_SERIAL;
+      process.env.ANDROID_DEVICE_SERIAL = "PIXEL123";
+      try {
+        const launcher = new LiveViewLauncher({ spawn: stub, args: [], env: { ANDROID_DEVICE_SERIAL: undefined } });
+        await launcher.start();
+        expect(stub.firstCall.args[2].env).to.not.have.property("ANDROID_DEVICE_SERIAL");
+      } finally {
+        if (prev === undefined) delete process.env.ANDROID_DEVICE_SERIAL;
+        else process.env.ANDROID_DEVICE_SERIAL = prev;
+      }
+    });
+
+    it("should pass through a defined env override", async function () {
+      const { stub } = makeSpawn("[LiveView] Server ready");
+      const launcher = new LiveViewLauncher({ spawn: stub, args: [], env: { ANDROID_DEVICE_SERIAL: "emulator-5554" } });
+      await launcher.start();
+      expect(stub.firstCall.args[2].env).to.include({ ANDROID_DEVICE_SERIAL: "emulator-5554" });
+    });
+
     it("should reject if the process exits before becoming ready", async function () {
       const { stub, proc } = makeSpawn();
       const launcher = new LiveViewLauncher({ spawn: stub, args: [] });

--- a/build-utils/LiveViewLauncher.js
+++ b/build-utils/LiveViewLauncher.js
@@ -27,6 +27,17 @@ class LiveViewLauncher {
     this._env = env;
   }
 
+  // Child env is the inherited process env with our overrides applied; an
+  // override of `undefined` unsets the inherited key (e.g. clearing a
+  // profile-level ANDROID_DEVICE_SERIAL so it can't pin adb to a device).
+  _childEnv() {
+    const env = { ...process.env, ...this._env };
+    for (const key of Object.keys(this._env)) {
+      if (this._env[key] === undefined) delete env[key];
+    }
+    return env;
+  }
+
   isRunning() {
     return new Promise((resolve) => {
       this._execFile("lsof", ["-ti", `:${this._port}`], (err, stdout) => {
@@ -40,7 +51,7 @@ class LiveViewLauncher {
       const proc = this._spawn(this._command, this._args, {
         detached: true,
         stdio: ["ignore", "pipe", "pipe"],
-        env: { ...process.env, ...this._env },
+        env: this._childEnv(),
       });
 
       proc.unref();


### PR DESCRIPTION
## Summary
- A profile-level `ANDROID_DEVICE_SERIAL` is a standard adb env var, so every adb subprocess Titanium spawns inherits it and pins install/logcat to that physical device — silently overriding `--target emulator`. LiveView `--simulator` runs then build for the emulator but deploy to the device, and the unit/acceptance result socket aborts across the mismatch ("Software caused connection abort").
- Gruntfile: for the android emulator path, resolve the running emulator's serial via `adb devices` and pass it as the child `ANDROID_DEVICE_SERIAL`, clearing the pin when no emulator is up.
- `LiveViewLauncher`: an `undefined` env override now *unsets* the inherited key (extracted `_childEnv()`), so the Gruntfile can clear the pin rather than only override it.

No Trello card — surfaced while verifying WB-158 on Android, split out per one-PR-one-responsibility. Independent of WB-158.

## Test plan
- [x] `npx grunt build-test` — 167 passing (incl. 2 new `LiveViewLauncher` env specs)
- [x] `npx grunt --platform=android --simulator --liveview unit-test` with a physical device also connected and `ANDROID_DEVICE_SERIAL` pinned to it — now lands on the emulator and passes (previously aborted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)