### PR TITLE
WB-165: Survey date picker on iOS is mostly invisible

### DIFF
--- a/walta-app/app/spec/IosSurveyDatePicker_spec.js
+++ b/walta-app/app/spec/IosSurveyDatePicker_spec.js
@@ -22,6 +22,12 @@ describe("IosSurveyDatePicker controller", function () {
     }
   });
 
+  // The app has no dark palette; on a dark-mode device the system picker draws
+  // white-on-white and the cells vanish, so pin the picker to light mode.
+  it("forces the picker to light mode", function () {
+    expect(ctl.datePicker.overrideUserInterfaceStyle).to.equal(Ti.UI.USER_INTERFACE_STYLE_LIGHT);
+  });
+
   it("triggers 'selected' with the chosen date when Done is tapped", function (done) {
     ctl.on("selected", function (e) {
       expect(e.value).to.be.a("date");

--- a/walta-app/app/styles/IosSurveyDatePicker.tss
+++ b/walta-app/app/styles/IosSurveyDatePicker.tss
@@ -14,6 +14,7 @@
 }
 "#datePicker[platform=ios]": {
     datePickerStyle: Ti.UI.DATE_PICKER_STYLE_INLINE,
+    overrideUserInterfaceStyle: Ti.UI.USER_INTERFACE_STYLE_LIGHT,
     width: Ti.UI.FILL,
     height: Ti.UI.SIZE,
     left: "8dp",


### PR DESCRIPTION
## Summary
- On a dark-mode iOS device the inline `UIDatePicker` drew its weekday headers and date cells in white on the white modal card, so almost every cell was invisible (only the blue-tinted selected/today cells survived). The app has no dark palette, so pin the picker to light mode via `overrideUserInterfaceStyle` on `#datePicker[platform=ios]`.
- The simulator runs in light mode by default, which is why this never reproduced there.

Fixes [Trello WB-165](https://trello.com/c/b4xSD8rD) — scoped to the iOS survey date picker visibility only. Separate from the WB-158 override-date work already merged.

## Test plan
- [x] `IosSurveyDatePicker_spec` device spec (iOS sim) — new assertion that the picker forces light mode; full describe green
- [x] Visual check on the dark-mode iPhone 17e that originally reported the bug — calendar now fully legible