### PR TITLE
WB-166: Survey date defaults to today even if already set

### DIFF
--- a/walta-app/app/models/sample.js
+++ b/walta-app/app/models/sample.js
@@ -537,6 +537,11 @@ exports.definition = {
 
 				dup.set("originalSampleId",this.get("sampleId"));
 
+				// Carry the original survey date so editing doesn't reset it to today
+				// (WB-166). dateCompleted stays null (the editing marker); the date
+				// rides on overrideDateCompleted, which saveCurrentSample reapplies.
+				dup.set("overrideDateCompleted", this.get("dateCompleted"));
+
 				// accuracy isn't in the CERDI JSON currently
 				dup.set("accuracy", this.get("accuracy"));
 

--- a/walta-app/app/models/sample.js
+++ b/walta-app/app/models/sample.js
@@ -347,8 +347,12 @@ exports.definition = {
 
 				sampleJson.surveyType = Sample.surveyTypeToString( parseInt( sampleJson.surveyType ) );
 					
-				if ( sampleJson.dateCompleted ) {
-					sampleJson.dateCompleted = moment(sampleJson.dateCompleted).format("DD/MMM/YYYY h:mm:ss a");
+				// While editing, dateCompleted is null and the chosen survey date
+				// lives on overrideDateCompleted (WB-166); fall back to now only
+				// when neither is set.
+				let surveyDate = sampleJson.dateCompleted || sampleJson.overrideDateCompleted;
+				if ( surveyDate ) {
+					sampleJson.dateCompleted = moment(surveyDate).format("DD/MMM/YYYY h:mm:ss a");
 				} else {
 					sampleJson.dateCompleted = moment().format("DD/MMM/YYYY h:mm:ss a");
 				}

--- a/walta-app/app/spec/Sample_spec.js
+++ b/walta-app/app/spec/Sample_spec.js
@@ -1115,6 +1115,33 @@ describe("Sample model", function() {
   });
 });
 
+describe("WB-166: editing a dated survey keeps its survey date", function() {
+  beforeEach(clearDatabase);
+
+  function makeDatedSurvey(originalDate) {
+    let s = makeSampleData({
+      serverSampleId: 777,
+      dateCompleted: originalDate,
+      serverSyncTime: moment().valueOf()
+    });
+    s.save();
+    return s;
+  }
+
+  it("opens the temporary edit on the original survey date, not today", function() {
+    let originalDate = moment("2020-03-15T09:00:00").format();
+    let temp = makeDatedSurvey(originalDate).createTemporaryForEdit();
+    expect(temp.get("overrideDateCompleted")).to.equal(originalDate);
+  });
+
+  it("preserves the original date when an edited survey is resubmitted", async function() {
+    let originalDate = moment("2020-03-15T09:00:00").format();
+    let temp = makeDatedSurvey(originalDate).createTemporaryForEdit();
+    await temp.saveCurrentSample();
+    expect(temp.get("dateCompleted")).to.equal(originalDate);
+  });
+});
+
 describe("WB-143: complete=false survives the edit roundtrip", function() {
   beforeEach(clearDatabase);
 

--- a/walta-app/app/spec/Sample_spec.js
+++ b/walta-app/app/spec/Sample_spec.js
@@ -1140,6 +1140,13 @@ describe("WB-166: editing a dated survey keeps its survey date", function() {
     await temp.saveCurrentSample();
     expect(temp.get("dateCompleted")).to.equal(originalDate);
   });
+
+  it("shows the overridden date on the summary while editing, not today", function() {
+    let originalDate = moment("2020-03-15T09:00:00").format();
+    let temp = makeDatedSurvey(originalDate).createTemporaryForEdit();
+    expect(temp.transform().dateCompleted)
+      .to.equal(moment(originalDate).format("DD/MMM/YYYY h:mm:ss a"));
+  });
 });
 
 describe("WB-143: complete=false survives the edit roundtrip", function() {


### PR DESCRIPTION
## Summary
- Editing an already-timestamped survey (e.g. one synced from the server) opened the Notes date picker on **today** instead of the survey's original date. Root cause: `createTemporaryForEdit` serialises via CERDI JSON and deletes `sample_date`, so the temporary edit copy has neither `dateCompleted` nor `overrideDateCompleted` — the Notes ViewModel then falls back to `now()`.
- Worse second-order bug: because `saveCurrentSample` writes `dateCompleted = overrideDateCompleted || now()`, resubmitting *any* edited survey silently reset its date to today.
- Same root surfaced on the **Summary screen** (found during on-device verification): `{sample.dateCompleted}` binds through the model's `transform()`, which formatted `now()` whenever `dateCompleted` was null — so the edit Summary showed today.

### Fixes
- `createTemporaryForEdit`: carry the original `dateCompleted` onto the temp as `overrideDateCompleted`. `dateCompleted` stays null (the editing/unsaved marker); `saveCurrentSample` reapplies the override on submit. `updatedAt` still bumps, so sync still fires and the survey keeps its true sampling date.
- `transform()`: prefer `dateCompleted || overrideDateCompleted` before falling back to `now()` — harmless for submitted samples (where `dateCompleted` wins), fixes the edit-time Summary display.

Fixes [Trello WB-166](https://trello.com/c/kWjxDF41). Separate branch from the WB-165 picker-visibility work (#324).

## Test plan
- [x] `Sample_spec` device spec (iOS sim) — three new WB-166 tests (RED → GREEN): picker seed date, resubmit preservation, Summary `transform()` date; existing temporary-copy / `saveCurrentSample` / serialise / WB-158 / WB-143 tests still green (18 passing)
- [x] Manual check on device (iPhone 17e): edited a synced survey → Notes picker opened on original date → Summary showed original date → resubmit kept it

## Out of scope (logged separately)
- During on-device verification, resubmitting an edited synced sample with photos throws (logged, not user-visible): `UPLOAD_PROGRESS` carries serverSampleId for photo steps but local sampleId for record steps, so the SampleHistory VM's strict guard throws on the mismatch. Pre-existing, unrelated to the date fix — logged as its own Defect card (trello.com/c/Qrhp0bK4).