### PR TITLE
WB-167: UPLOAD_PROGRESS id namespace mismatch — SampleHistory VM throws

### DIFF
--- a/walta-app/app/lib/logic/SampleUploader.js
+++ b/walta-app/app/lib/logic/SampleUploader.js
@@ -45,7 +45,7 @@ function uploadSitePhoto(sample,progress) {
     var sitePhotoId = sample.get("serverSitePhotoId");
     if ( !sitePhotoId ) {
         var sitePhoto = sample.getSitePhoto();
-        var sampleId = sample.get("serverSampleId");
+        var serverSampleId = sample.get("serverSampleId");
         if ( sitePhoto ) {
             let blob = loadPhoto( sitePhoto );
             if ( needsOptimising(blob) ) {
@@ -54,13 +54,13 @@ function uploadSitePhoto(sample,progress) {
             }
             log(`Uploading site photo: ${sitePhoto}`);
             return Alloy.Globals.CerdiApi.acquire()
-                    .then( () => submitSitePhoto( sampleId, sitePhoto ) )
+                    .then( () => submitSitePhoto( serverSampleId, sitePhoto ) )
                     .then( (res) => {
                         loadCorrectSampleToUpdate(sample);
                         sample.save({
                             "serverSitePhotoId": res.id
                         });
-                        Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: sampleId, message: "Uploading site photo" } );
+                        Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: sample.get("sampleId"), message: "Uploading site photo" } );
                         progress.tick();
                         return sample;
                     })
@@ -87,7 +87,7 @@ function uploadTaxaPhoto(sample,t,progress) {
     }
 
     var taxonId = t.getTaxonId();
-    var sampleId = sample.get("serverSampleId");
+    var serverSampleId = sample.get("serverSampleId");
     var taxonPhotoId = t.get("serverCreaturePhotoId");
 
     // don't upload photos for unknown bugs here
@@ -100,11 +100,11 @@ function uploadTaxaPhoto(sample,t,progress) {
                 savePhoto( optimisePhoto( blob ), photoPath );
             }
             return Alloy.Globals.CerdiApi.acquire()
-                    .then( () => submitCreaturePhoto(sampleId, taxonId, photoPath) )
+                    .then( () => submitCreaturePhoto(serverSampleId, taxonId, photoPath) )
                     .then( (res) => {
                         debug(`setting serverCreaturePhotoId = ${res.id}`);
                         t.save({"serverCreaturePhotoId": res.id});
-                        Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: sampleId, message: "Uploading taxon photo" } );
+                        Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: sample.get("sampleId"), message: "Uploading taxon photo" } );
                         progress.tick();
                     })
                     .catch( (err) => {
@@ -135,14 +135,14 @@ function uploadTaxaPhotos(sample,progress) {
 
 function uploadUnknownCreature(sample,t,progress) {
     var taxonId = t.getTaxonId();
-    var sampleId = sample.get("serverSampleId");
+    var serverSampleId = sample.get("serverSampleId");
     var serverCreatureId = t.get("serverCreatureId");
     var taxonPhotoId = t.get("serverCreaturePhotoId");
 
     // skip known creatures and any unknown creatures that have had
     // their serverCreaturePhotoId set.
     if ( taxonId == null ) {
-        info(`Uploading unknown creature and photo [serverSampleId=${sampleId},taxonId=${taxonId}]`);
+        info(`Uploading unknown creature and photo [serverSampleId=${serverSampleId},taxonId=${taxonId}]`);
         let photoPath = t.getPhoto();
         let count = t.getAbundance();
         if ( photoPath ) {
@@ -155,7 +155,7 @@ function uploadUnknownCreature(sample,t,progress) {
 
             if ( !serverCreatureId ) {
                 actions = Alloy.Globals.CerdiApi.acquire()
-                    .then( () => Alloy.Globals.CerdiApi.submitUnknownCreature(sampleId, count, photoPath) );
+                    .then( () => Alloy.Globals.CerdiApi.submitUnknownCreature(serverSampleId, count, photoPath) );
             } else {
                 actions = Alloy.Globals.CerdiApi.acquire()
                     .then( () => Alloy.Globals.CerdiApi.updateUnknownCreature(serverCreatureId, count, photoPath) );
@@ -165,7 +165,7 @@ function uploadUnknownCreature(sample,t,progress) {
                     "serverCreatureId": res.id,
                     "serverCreaturePhotoId": res.photos[0].id
                 });
-                Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: sampleId, message: "Uploading unknown creature" } );
+                Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: sample.get("sampleId"), message: "Uploading unknown creature" } );
                 progress.tick();
             })
             .catch( (err) => {

--- a/walta-app/app/spec/SampleSync_spec.js
+++ b/walta-app/app/spec/SampleSync_spec.js
@@ -178,6 +178,45 @@ describe("SampleSync", function () {
         expectPhotoOptimised(Alloy.Globals.CerdiApi.submitSitePhoto.lastCall.args[1]);
         expectPhotoOptimised(Alloy.Globals.CerdiApi.submitCreaturePhoto.lastCall.args[2]);
     });
+
+    // WB-167: SampleHistory resolves UPLOAD_PROGRESS by local sampleId, so every
+    // step must report the local id. The photo steps used to report serverSampleId.
+    it("reports UPLOAD_PROGRESS with the local sampleId for every step, including photos", async function () {
+        clearMockSampleData();
+
+        let samples = Alloy.Collections.instance("sample");
+        let taxa = Alloy.Collections.instance("taxa");
+
+        let sample = Alloy.createModel("sample", { sitePhotoPath: makeTestPhoto("site.jpg") });
+        sample.save();
+        let localId = sample.get("sampleId");
+
+        let taxon = Alloy.createModel("taxa", {
+            taxonId: 1, sampleId: localId,
+            taxonPhotoPath: makeTestPhoto("taxon.jpg"), abundance: "1-2", updatedAt: 0
+        });
+        taxa.add(taxon);
+        taxon.save();
+        samples.add(sample);
+
+        simple.mock(Alloy.Globals.CerdiApi, "submitSample").resolveWith({ id: 666 });
+        simple.mock(Alloy.Globals.CerdiApi, "submitSitePhoto").resolveWith({ id: 1 });
+        simple.mock(Alloy.Globals.CerdiApi, "submitCreaturePhoto").resolveWith({ id: 2 });
+
+        let progressIds = [];
+        let onProgress = (payload) => progressIds.push(payload.id);
+        Topics.subscribe(Topics.UPLOAD_PROGRESS, onProgress);
+        try {
+            await createSampleUploader().uploadNextSample(samples);
+        } finally {
+            Topics.unsubscribe(Topics.UPLOAD_PROGRESS, onProgress);
+        }
+
+        expect(progressIds.length, "some UPLOAD_PROGRESS events fired").to.be.greaterThan(0);
+        expect(progressIds.every(id => id === localId),
+            `every UPLOAD_PROGRESS id should be local sampleId ${localId}, got ${JSON.stringify(progressIds)}`)
+            .to.be.true;
+    });
     /*
         Sample Sync upload
         - polls every fifteen minutes to upload


### PR DESCRIPTION
## Summary
- `SampleUploader` fired `UPLOAD_PROGRESS` with two different id namespaces: the **record** steps used the local `sampleId`, but the **site/taxon/unknown-creature photo** steps used `serverSampleId` (the var was named `sampleId` but assigned `sample.get("serverSampleId")`).
- `SampleHistory` ViewModel resolves the event id via `loadOne(sampleId)` keyed on the **local** sampleId, so the photo-step events never matched and tripped its strict WB-119 guard, logging `UPLOAD_PROGRESS for unknown sampleId <serverSampleId>` (not user-visible — swallowed in the topic dispatch loop — but spammy, and it aborts that subscriber).

### Fix
- Fire the local `sample.get("sampleId")` in all three photo-step `UPLOAD_PROGRESS` events.
- Rename the photo-path vars from `sampleId` → `serverSampleId` (they're passed to the CERDI API, which does want the server id) so the namespace is no longer confused at the source.
- **Kept the VM's strict throw guard as-is** — it's a deliberate, tested contract (`SampleHistory_spec.js:175-191`) that correctly surfaced this bug; softening it would hide the next id-shape regression.

User-facing upside: those photo-step progress events now actually update the matching SampleHistory row (previously dropped), so upload progress is smoother during photo-heavy uploads.

Fixes [Trello WB-167](https://trello.com/c/Qrhp0bK4). Discovered during WB-166 on-device verification.

## Test plan
- [x] `SampleSync_spec` device spec (iOS sim) — new test: every `UPLOAD_PROGRESS` id during an upload (incl. photos) is the local sampleId (RED `[1268,666,666,1268]` → GREEN); `resize photos` + `continue on photo error` regressions still green