### PR TITLE
WB-168: Archive View/Edit row taps ignored after sync reorder

### DIFF
--- a/walta-app/app/controllers/SampleHistory.js
+++ b/walta-app/app/controllers/SampleHistory.js
@@ -38,7 +38,10 @@ var rowControllers = new Map();
 function buildAndBindRow(rowVm) {
     var ctl = Alloy.createController("SampleHistoryRow");
     var unbind = ctl.bind(rowVm);
-    rowControllers.set(rowVm.sampleId, { ctl: ctl, unbind: unbind });
+    // Per-row click by stable sampleId — Android drops table-level dispatch on reused/reordered row proxies.
+    var onClick = function() { openSampleMenu(rowVm.sampleId); };
+    ctl.getView().addEventListener("click", onClick);
+    rowControllers.set(rowVm.sampleId, { ctl: ctl, unbind: unbind, onClick: onClick });
     return ctl.getView();
 }
 
@@ -46,6 +49,7 @@ function disposeRow(sampleId) {
     var r = rowControllers.get(sampleId);
     if (!r) return;
     r.unbind();
+    r.ctl.getView().removeEventListener("click", r.onClick);
     if (r.ctl && typeof r.ctl.destroy === "function") r.ctl.destroy();
     rowControllers.delete(sampleId);
 }
@@ -76,11 +80,7 @@ $.syncButton.on("click", syncNowClicked);
 acb.addTool($.syncButton.getView());
 
 $.TopLevelWindow.addEventListener('close', function cleanUp() {
-    rowControllers.forEach(function(r) {
-        r.unbind();
-        if (r.ctl && typeof r.ctl.destroy === "function") r.ctl.destroy();
-    });
-    rowControllers.clear();
+    Array.from(rowControllers.keys()).forEach(disposeRow);
     $.vm.dispose();
     if ($.sampleMenu) $.sampleMenu.cleanUp();
     closeSyncFeedback();
@@ -105,10 +105,7 @@ function closeSyncFeedback() {
     $.syncFeedback = null;
 }
 
-function rowSelected(e) {
-    var rowVm = $.vm.rows[e.index];
-    if (!rowVm) return;
-    var sampleId = rowVm.sampleId;
+function openSampleMenu(sampleId) {
     function closeSelectMethod() {
         $.TopLevelWindow.remove($.sampleMenu.getView());
         $.sampleMenu.cleanUp();

--- a/walta-app/app/spec/Main_spec.js
+++ b/walta-app/app/spec/Main_spec.js
@@ -59,7 +59,7 @@ describe("Main controller", function() {
     app = Alloy.createController("Main", services);
     await app.startApp();
     await actionFiresTopicTest( currentController().history, "click", Topics.PAGE_OPENED );
-    currentController().sampleTable.fireEvent("click", { index: 0 });
+    currentController().sampleTable.data[0].rows[0].fireEvent("click");
 
     await waitForTick(10)();
     await actionFiresTopicTest( currentController().sampleMenu.edit, "click", Topics.PAGE_OPENED );
@@ -93,7 +93,7 @@ describe("Main controller", function() {
     await app.startApp();
    
     await actionFiresTopicTest( currentController().history, "click", Topics.PAGE_OPENED);
-    currentController().sampleTable.fireEvent("click", { index: 0 });
+    currentController().sampleTable.data[0].rows[0].fireEvent("click");
     await actionFiresTopicTest( currentController().sampleMenu.edit, "click", Topics.PAGE_OPENED );
 
     // At this point the global sample SHOULD NOT be the original record but
@@ -120,7 +120,7 @@ describe("Main controller", function() {
     
     expect( currentController().sampleTable.data[0].rows.length, "there should only be one row" ).to.equal(1);
 
-    currentController().sampleTable.fireEvent("click", { index: 0 });
+    currentController().sampleTable.data[0].rows[0].fireEvent("click");
 
     
     await actionFiresTopicTest( currentController().sampleMenu.view, "click", Topics.PAGE_OPENED );

--- a/walta-app/app/spec/SampleHistory_spec.js
+++ b/walta-app/app/spec/SampleHistory_spec.js
@@ -29,19 +29,19 @@ describe("SampleHistory controller", function() {
   });
   it('selecting row should open menu', async function() {
     await controllerOpenTest( ctl );
-    ctl.sampleTable.fireEvent("click", { index: 0 } );
+    ctl.sampleTable.data[0].rows[0].fireEvent("click");
     expect( ctl.sampleMenu.view.accessibilityLabel ).to.include("View");
   });
   it('selecting view should raise view event', async function() {
     await controllerOpenTest( ctl );
-    ctl.sampleTable.fireEvent("click", { index: 0 } );
+    ctl.sampleTable.data[0].rows[0].fireEvent("click");
     let result = await actionFiresTopicTest( ctl.sampleMenu.view, "click", Topics.SITEDETAILS );
     expect( result.readonly ).to.be.true;
 
   });
   it('selecting edit should raise edit event', async function() {
     await controllerOpenTest( ctl );
-    ctl.sampleTable.fireEvent("click", { index: 0 } );
+    ctl.sampleTable.data[0].rows[0].fireEvent("click");
     let result = await actionFiresTopicTest( ctl.sampleMenu.edit, "click", Topics.SITEDETAILS );
     expect( result.readonly ).to.be.false;
   });
@@ -65,6 +65,22 @@ describe("SampleHistory controller", function() {
     var sampleId = rowBefore.sampleId;
     Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: sampleId } );
     expect( ctl.vm.rows[0] ).to.equal( rowBefore );
+  });
+
+  it('a reused row still opens its menu after the list reorders during sync', async function() {
+    await controllerOpenTest( ctl );
+
+    // A new sample arrives mid-sync and is prepended, reordering the
+    // already-rendered (reused) rows — the WB-168 trigger.
+    var newSample = makeSampleData({ serverSampleId: 669, dateCompleted: moment("2021-06-22T09:00").format() });
+    newSample.save();
+    Topics.fireTopicEvent( Topics.UPLOAD_PROGRESS, { id: newSample.get("sampleId") } );
+
+    // Tapping a reused, shifted row must still open the View/Edit menu.
+    var rows = ctl.sampleTable.data[0].rows;
+    rows[rows.length - 1].fireEvent("click");
+    expect( ctl.sampleMenu, "menu should open for the tapped row" ).to.exist;
+    expect( ctl.sampleMenu.view.accessibilityLabel ).to.include("View");
   });
 
 });

--- a/walta-app/app/views/SampleHistory.xml
+++ b/walta-app/app/views/SampleHistory.xml
@@ -6,6 +6,6 @@
 			<Label class="waterbodyName column" text="Waterbody Name"/>
 			<Label class="boolColumn column" text="Sync"/>
 		</View>
-		<TableView id="sampleTable" onClick="rowSelected"/>
+		<TableView id="sampleTable"/>
 	</View>
 </Alloy>


### PR DESCRIPTION
## Summary
- **Root cause:** when a sync adds rows, `renderRows` reuses the existing row-view proxies and reorders them via `setData`. On Android this drops native **table-level click dispatch** on the moved rows — every second row stops opening the View/Edit menu (the row still greys on touch, but the `click` never reaches the handler), and stays broken until the screen is rebuilt (the Home→Archive recovery).
- **Fix:** bind each row's tap to its own stable `sampleId` in `buildAndBindRow`, and drop the `TableView` `onClick`/`e.index` routing. Taps no longer depend on the table's reorder-fragile index bookkeeping. Confirmed on-device: row-level click fires for the previously-dead rows where the table-level one was silent or reported a stale index.
- **Not the same as WB-167.** An already-synced account adds no rows, so the list never reorders and the bug can't surface — which is why it first looked like the WB-167 `sampleId` fix had resolved it. The real trigger is rows arriving during a fresh/long sync.

Resolves [Trello WB-168](https://trello.com/c/yxco89fI). The card's "after closing the Sync screen" framing was a red herring — the trigger is the reorder during an active sync, not closing the popup.

## Test plan
- [x] `npx grunt unit-test-node` — passes (314)
- [x] iOS simulator device spec (`SampleHistory controller`) — 8 passing, incl. new reorder test
- [x] Android device (Pixel 6 Pro) — manual `--reset` + long-sync repro: previously-dead rows now open menus
- [x] iOS device — `--reset` + long-sync confirmation: all rows open menus

🤖 Generated with [Claude Code](https://claude.com/claude-code)