### PR TITLE
WB-171: Bump iOS release job timeout for slow TestFlight processing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,7 +295,10 @@ jobs:
     # prepare result check.
     if: ${{ always() && needs.prepare.result == 'success' && inputs.platforms != 'android' }}
     runs-on: macos-latest
-    timeout-minutes: 45
+    # The TestFlight upload step waits on Apple's build processing before it can
+    # assign the build to the test group; processing is normally <15 min but can
+    # spike. 90 absorbs a slow day so a successful upload isn't cancelled mid-wait.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- The iOS release job's TestFlight upload step blocks on Apple's build processing before it can assign the build to the Sandbox test group (that group has automatic distribution off, so the `--groups` assignment is the only path to internal testers). On `v2.0.4.45-test` the IPA uploaded successfully but processing ran past the 45-min job cap, so GitHub cancelled the job mid-wait — the binary was already on Apple's side; only the auto-assign tail was lost.
- Bump iOS `timeout-minutes` 45 → 90. Processing is normally <15 min, so this was an unlucky outlier; 90 absorbs a slow day. Stopgap, not a determinism fix — the nondeterministic processing wait remains, just with a higher ceiling.

Closes [Trello WB-171](https://trello.com/c/td3fjVhk). The reactive ASC-webhook fix that removes the wait entirely is captured in [WB-172](https://trello.com/c/6CZnoPno) — deferred until this recurs often enough to be worth the standing infra.

## Test plan
- [x] N/A — GitHub Actions config change (timeout value); no automated test. Verified by the next `environment=test` release completing the iOS job without a timeout cancellation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)