### PR TITLE
WB-169: Investigate completed date not persisting on server

### DIFF
--- a/contract-tests/CerdiApi_spec.js
+++ b/contract-tests/CerdiApi_spec.js
@@ -630,10 +630,31 @@ describe('CerdiApi', function() {
                             },
                             "photos": []
                         }
-                    ); 
+                    );
                 })
         });
-        
+
+        // WB-169: the sample is created then immediately updated, so it is
+        // seconds old — a failure here rules out an age-based server lock and
+        // pins the contract that updating sample_date must persist. Expected to
+        // fail against the current sandbox, which discards sample_date on PUT.
+        it("should update the sample_date on an existing sample", async function() {
+            await cerdi.loginUser('testlogin@example.com', 'tstPassw0rd!');
+
+            const sampleData = makeTestSample(moment().format());
+            const created = await cerdi.submitSample(sampleData);
+
+            const backDated = moment().subtract(30, 'days').format();
+            sampleData.sample_date = backDated;
+            await cerdi.updateSampleById(created.id, sampleData);
+
+            const result = await cerdi.retrieveSampleById(created.id);
+            expect(
+                moment(result.sample_date).isSame(moment(backDated)),
+                `expected server to persist updated sample_date ${backDated}, got ${result.sample_date}`
+            ).to.be.true;
+        });
+
         // WB-12: the patch-broken-records block at sample.js:455-476 assumes
         // the server stores habitat 0s as NULL for two-word fields, and bumps
         // `updatedAt` to force a re-upload — driving the observed upload loop.


### PR DESCRIPTION
## Summary
- Adds a contract test that creates a fresh sample, then updates its `sample_date`, and asserts the server persists the new value. The record is seconds old, so the test discriminates between "the server ignores the field on update" and the "2-week business lock" hypothesis from the card.
- The test is **currently RED**: the CERDI sandbox discards `sample_date` on `PUT /samples/{id}` while honouring it on `POST /samples`. It flips green once the server applies the field on update. (Contract suite is dev/sandbox-only, not CI, so nothing breaks in CI.)

Diagnosis for [Trello WB-169](https://trello.com/c/2h8vaEIV/169-investigate-completed-date-not-persisting-on-server).

## Findings
Root cause is **server-side**. Evidence from John's diagnostic emails (both platforms) plus the new contract test:

| Hypothesis | Verdict |
|---|---|
| Server ignores new `sample_date` on update | ✅ Confirmed — every PUT echoes back the original date |
| Server locks the field after 2 weeks | ❌ Refuted — records 7–17 min old are ignored too |
| Client sends the wrong data | ❌ Refuted — client transmits the correct/overridden date in both POST and PUT |

The create path works (back-dated `sample_date` is accepted on POST). Only the update path drops it. **Fix must come from CERDI** — the `PUT /samples/{id}` handler needs to apply `sample_date`. This test is the regression lock and a clean reproduction to hand over.

## Test plan
- [x] `npx grunt contract-test` — new test runs and fails for the expected reason (server returns creation date, not the updated date)
- [ ] Re-run to green once CERDI applies `sample_date` on PUT

🤖 Generated with [Claude Code](https://claude.com/claude-code)